### PR TITLE
[do-not-merge] Option to setup from config files alternatively to CRDs

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -25,6 +25,7 @@ type SecretReconciler struct {
 	Scheme            *runtime.Scheme
 	SecretLabel       string
 	ServiceReconciler reconcile.Reconciler
+	ServiceReader     client.Reader
 }
 
 func (r *SecretReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
@@ -91,7 +92,7 @@ func (r *SecretReconciler) getServicesUsingAPIKey(ctx context.Context, namespace
 	var existingServices = &configv1beta1.ServiceList{}
 	selectedServices := make([]configv1beta1.Service, 0)
 
-	if err := r.List(ctx, existingServices, &client.ListOptions{
+	if err := r.ServiceReader.List(ctx, existingServices, &client.ListOptions{
 		Namespace: namespace,
 	}); err != nil {
 		return nil, err

--- a/controllers/secret_controller_test.go
+++ b/controllers/secret_controller_test.go
@@ -96,6 +96,7 @@ func newSecretReconcilerTest(secretLabels map[string]string) secretReconcilerTes
 		Scheme:            nil,
 		SecretLabel:       "authorino.3scale.net/managed-by",
 		ServiceReconciler: serviceReconciler,
+		ServiceReader:     client,
 	}
 
 	t := secretReconcilerTest{

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -44,9 +44,11 @@ import (
 // ServiceReconciler reconciles a Service object
 type ServiceReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
-	Cache  cache.Cache
+	ServiceReader client.Reader
+	ServiceWriter client.Writer
+	Log           logr.Logger
+	Scheme        *runtime.Scheme
+	Cache         cache.Cache
 }
 
 // +kubebuilder:rbac:groups=config.authorino.3scale.net,resources=services,verbs=get;list;watch;create;update;patch;delete
@@ -58,7 +60,7 @@ func (r *ServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("service", req.NamespacedName)
 
 	service := configv1beta1.Service{}
-	err := r.Get(ctx, req.NamespacedName, &service)
+	err := r.ServiceReader.Get(ctx, req.NamespacedName, &service)
 	if err != nil && errors.IsNotFound(err) {
 
 		// As we can't get the object, that means it was deleted.
@@ -75,22 +77,21 @@ func (r *ServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	// The object exists so we need to either create it or update
-	serviceConfigByHost, err := r.translateService(ctx, &service)
-	if err != nil {
+	if serviceConfigByHost, err := r.translateService(ctx, &service); err != nil {
 		return ctrl.Result{}, err
-	}
-
-	for serviceHost, apiConfig := range serviceConfigByHost {
-		// Check for host collision with another namespace
-		if cachedKey, found := r.Cache.FindId(serviceHost); found {
-			if cachedKeyParts := strings.Split(cachedKey, string(types.Separator)); cachedKeyParts[0] != req.Namespace {
-				log.Info("host already taken in another namespace", "host", serviceHost)
-				return ctrl.Result{}, nil
+	} else {
+		for serviceHost, apiConfig := range serviceConfigByHost {
+			// Check for host collision with another namespace
+			if cachedKey, found := r.Cache.FindId(serviceHost); found {
+				if cachedKeyParts := strings.Split(cachedKey, string(types.Separator)); cachedKeyParts[0] != req.Namespace {
+					log.Info("host already taken in another namespace", "host", serviceHost)
+					return ctrl.Result{}, nil
+				}
 			}
-		}
 
-		if err := r.Cache.Set(req.String(), serviceHost, apiConfig, true); err != nil {
-			return ctrl.Result{}, err
+			if err := r.Cache.Set(req.String(), serviceHost, apiConfig, true); err != nil {
+				return ctrl.Result{}, err
+			}
 		}
 	}
 

--- a/controllers/service_controller_test.go
+++ b/controllers/service_controller_test.go
@@ -149,10 +149,12 @@ func setupEnvironment(t *testing.T, c cache.Cache) ServiceReconciler {
 	client := fake.NewFakeClientWithScheme(scheme, &service, &secret)
 
 	return ServiceReconciler{
-		Client: client,
-		Log:    ctrl.Log.WithName("reconcilerTest"),
-		Scheme: nil,
-		Cache:  c,
+		Client:        client,
+		Log:           ctrl.Log.WithName("reconcilerTest"),
+		Scheme:        nil,
+		Cache:         c,
+		ServiceReader: client,
+		ServiceWriter: client,
 	}
 }
 

--- a/deploy/overlays/setup-from-files/kustomization.yaml
+++ b/deploy/overlays/setup-from-files/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+- manage_role_binding.yaml
+
+# Adds namespace to all resources.
+namespace: authorino
+
+patchesStrategicMerge:
+- patches/setup_from_files_patch.yaml

--- a/deploy/overlays/setup-from-files/manage_role_binding.yaml
+++ b/deploy/overlays/setup-from-files/manage_role_binding.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system
+

--- a/deploy/overlays/setup-from-files/patches/setup_from_files_patch.yaml
+++ b/deploy/overlays/setup-from-files/patches/setup_from_files_patch.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - "--metrics-addr=0"
+        - "--enable-leader-election"
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: SETUP_FROM_FILES_DIR
+          value: /configs

--- a/examples/setup-from-files.yaml
+++ b/examples/setup-from-files.yaml
@@ -1,0 +1,81 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: api-protections
+  # make sure to replace here and in the wristband endpoints
+  namespace: ${AUTHORINO_NAMESPACE}
+data:
+  talker-api-protection.json: |
+    {
+      "hosts": [
+        "talker-api"
+      ],
+      "identity": [
+        {
+            "name": "friends",
+            "apiKey": {
+              "labelSelectors": {
+                  "authorino.3scale.net/managed-by": "authorino",
+                  "group": "friends"
+              }
+            },
+            "credentials": {
+              "in": "authorization_header",
+              "keySelector": "APIKEY"
+            }
+        },
+        {
+          "name": "wristband",
+          "oidc": {
+            "endpoint": "http://authorino-wristband:8003/${AUTHORINO_NAMESPACE}/talker-api-protection"
+          },
+            "credentials": {
+              "in": "authorization_header",
+              "keySelector": "Wristband"
+            }
+        }
+      ],
+      "authorization": [
+        {
+          "name": "5min-grace-period",
+          "opa": {
+            "inlineRego": "allow { id = object.get(input.auth.identity, \"metadata\", input.auth.identity); born = time.parse_rfc3339_ns(object.get(id, \"creationTimestamp\", object.get(id, \"born\", \"\"))); age := time.now_ns() - born; age_in_minutes := (age/1000000000/60); age_in_minutes >= 5 }"
+          }
+        }
+      ],
+      "wristband": {
+        "issuer": "http://authorino-wristband:8003/${AUTHORINO_NAMESPACE}/talker-api-protection",
+        "customClaims": [
+          {
+            "name": "aud",
+            "value": "internal"
+          },
+          {
+            "name": "born",
+            "valueFrom": {
+              "authJSON": "auth.identity.metadata.creationTimestamp"
+            }
+          }
+        ],
+        "tokenDuration": 60,
+        "signingKeyRefs": [
+          {
+            "name": "wristband-signing-key",
+            "algorithm": "ES256"
+          }
+        ]
+      }
+    }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wristband-signing-key
+stringData:
+  key.pem: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDHvuf81gVlWGo0hmXGTAnA/HVxGuH8vOc7/8jewcVvqoAoGCCqGSM49
+    AwEHoUQDQgAETJf5NLVKplSYp95TOfhVPqvxvEibRyjrUZwwtpDuQZxJKDysoGwn
+    cnUvHIu23SgW+Ee9lxSmZGhO4eTdQeKxMA==
+    -----END EC PRIVATE KEY-----
+type: Opaque

--- a/pkg/service/service_from_file_loader.go
+++ b/pkg/service/service_from_file_loader.go
@@ -1,0 +1,158 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"time"
+
+	configv1beta1 "github.com/kuadrant/authorino/api/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const SERVICE_FILE_EXTENSION = ".json"
+
+type ServiceFromFileLoader struct {
+	client.Reader
+	client.Writer
+	BaseDir   string
+	Namespace string
+}
+
+func NewServiceFromFileLoader(localDir string, namespace string) *ServiceFromFileLoader {
+	dir := localDir
+	if !strings.HasSuffix(dir, "/") {
+		dir = dir + "/"
+	}
+	return &ServiceFromFileLoader{
+		BaseDir:   dir,
+		Namespace: namespace,
+	}
+}
+
+// Get sets a `configv1beta1.Service` into `obj`, reading from file in the filesystem whose name is `key`
+func (c *ServiceFromFileLoader) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	service := &configv1beta1.Service{}
+	if err := c.readServiceFromFile(key.Name+SERVICE_FILE_EXTENSION, service); err != nil {
+		return err
+	} else {
+		service.DeepCopyInto(obj.(*configv1beta1.Service))
+		return nil
+	}
+}
+
+// List sets a `configv1beta1.ServiceList{}` into `list`, reading from files in the filesystem
+func (c *ServiceFromFileLoader) List(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+	if files, err := c.serviceFileNames(); err != nil {
+		return err
+	} else {
+		services := make([]configv1beta1.Service, 0)
+		for _, file := range files {
+			service := &configv1beta1.Service{}
+			if err := c.readServiceFromFile(file, service); err != nil {
+				return err
+			} else {
+				services = append(services, *service)
+			}
+		}
+		list.(*configv1beta1.ServiceList).Items = services
+		return nil
+	}
+}
+
+func (c *ServiceFromFileLoader) Load(mgr manager.Manager, reconciler reconcile.Reconciler) error {
+	ctx := context.Background()
+
+	// wait for the cache to be ready
+	mgrCacheSyncCtx, mgrCacheSyncCtxCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer mgrCacheSyncCtxCancel()
+	if synced := mgr.GetCache().WaitForCacheSync(mgrCacheSyncCtx.Done()); !synced {
+		return fmt.Errorf("cache sync timeout")
+	}
+
+	// "reconcile" all
+	var services = &configv1beta1.ServiceList{}
+
+	if err := c.List(ctx, services); err != nil {
+		return err
+	} else {
+		for _, service := range services.Items {
+			serviceName := service.Name
+			serviceNamespace := c.Namespace
+			request := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: serviceNamespace,
+					Name:      serviceName,
+				},
+			}
+			if _, err = reconciler.Reconcile(request); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// ServiceFromFileLoader implements client.Writer but it's a no-op
+
+func (c *ServiceFromFileLoader) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+	return nil
+}
+
+func (c *ServiceFromFileLoader) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+	return nil
+}
+
+func (c *ServiceFromFileLoader) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	return nil
+}
+
+func (c *ServiceFromFileLoader) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return nil
+}
+
+func (c *ServiceFromFileLoader) DeleteAllOf(ctx context.Context, obj runtime.Object, opts ...client.DeleteAllOfOption) error {
+	return nil
+}
+
+func (c *ServiceFromFileLoader) serviceFileNames() ([]string, error) {
+	glob := fmt.Sprintf("%v*%v", c.BaseDir, SERVICE_FILE_EXTENSION)
+	if files, err := filepath.Glob(glob); err != nil {
+		return nil, err
+	} else {
+		fileNames := make([]string, 0)
+		for _, fileName := range files {
+			fileNames = append(fileNames, fileName[len(c.BaseDir):])
+		}
+		return fileNames, nil
+	}
+}
+
+func (c *ServiceFromFileLoader) readServiceFromFile(fileName string, service *configv1beta1.Service) error {
+	if fileContent, err := ioutil.ReadFile(c.BaseDir + fileName); err != nil {
+		return err
+	} else {
+		var serviceSpec configv1beta1.ServiceSpec
+		if err := json.Unmarshal(fileContent, &serviceSpec); err != nil {
+			return err
+		} else {
+			serviceName := fileName[:len(fileName)-len(SERVICE_FILE_EXTENSION)] // remove extension of the file
+			service.ObjectMeta = metav1.ObjectMeta{
+				Namespace: c.Namespace,
+				Name:      serviceName,
+			}
+			service.Spec = serviceSpec
+			return nil
+		}
+	}
+}


### PR DESCRIPTION
For the cases when the user does not have enough privileges to create CRDs in the Kubernetes server and wants to try Authorino in the user space.

The deployment works similarly to Authorino's `namespaced` deployment mode, with the following additional environment variable set in the manager containers:
- `SETUP_FROM_FILES_DIR`: the directory in the filesystem where service config specs will be mounted, as json files, usually from a `ConfigMap`

## Try this PR with a provided example

The following resources will be created in the Kubernetes server:
- `Namespace`
- Talker API (`Deployment` and `Service` of an example upstream API to be protected)
- Envoy proxy (`ConfigMap`, `Deployment`, `Service`)
- `Ingress` or OpenShift `Route` (depending on the the deployment option chosen below)
- Authorino (`Deployment`, `Service`s, required `Role`s and `RoleBinding`s)
- API protection (`ConfigMap` and `Secret`)

The API protection config declares authentication by API key and by wristband token.
For every successful request with API key, Authorino will issue a wristband token with duration of 1 minute.
An authorization policy enforces that API keys will only be enabled 5 minutes after created.

### OPTION A - On a local cluster started with Kind

```sh
export AUTHORINO_NAMESPACE=myapp

make local-cluster-up
make namespace
make example-apps

AUTHORINO_DEPLOYMENT=setup-from-files AUTHORINO_IMAGE=authorino:setup-from-files make local-deploy
sed -e "s/\${AUTHORINO_NAMESPACE}/$AUTHORINO_NAMESPACE/g" examples/setup-from-files.yaml | kubectl -n ${AUTHORINO_NAMESPACE} apply -f -
kubectl -n ${AUTHORINO_NAMESPACE} patch deployment authorino-controller-manager -p '{"spec": {"template": {"spec":{"containers":[{"name": "manager", "volumeMounts":[{"name": "configs", "mountPath": "/configs"}]}], "volumes":[{"name": "configs", "configMap": {"name": "api-protections", "items": [{"key": "talker-api-protection.json", "path": "talker-api-protection.json"}]}}]}}}}'
```

Create the tunnel to the Envoy proxy pod inside the cluster:

```sh
kubectl -n ${AUTHORINO_NAMESPACE} port-forward deployment/envoy 8000:8000 &
```

Then, create an API key and wait 5 minutes:

```sh
kubectl -n ${AUTHORINO_NAMESPACE} create -f -<<EOF
apiVersion: v1
kind: Secret
metadata:
  name: friend-1-api-key-1
  labels:
    authorino.3scale.net/managed-by: authorino
    group: friends
stringData:
  api_key: ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx
type: Opaque
EOF
```

Consume the service with the API key:

```sh
curl -H 'Host: talker-api' -H "Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx" http://localhost:8000/hello
```

```sh
curl -H 'Host: talker-api' -H "Authorization: Wristband <wirstband-token-from-previous-response>" http://localhost:8000/hello
```

### OPTION B - On an OpenShift cluster in the cloud

```sh
oc login --token=... --server=https://api.my-openshift-cluster:6443

export AUTHORINO_NAMESPACE=authorino-from-cm \
       AUTHORINO_IMAGE=quay.io/3scale/authorino:setup-from-files \
       TALKER_API_HOST=talker-api.apps.my-openshift-cluster

make namespace

kubectl -n ${AUTHORINO_NAMESPACE} apply -f examples/talker-api/talker-api-deploy.yaml
yq r -d0 -j examples/envoy/envoy-deploy.yaml | kubectl -n ${AUTHORINO_NAMESPACE} apply -f -
yq r -d1 -j examples/envoy/envoy-deploy.yaml | kubectl -n ${AUTHORINO_NAMESPACE} apply -f -
yq r -d3 -j examples/envoy/envoy-deploy.yaml | kubectl -n ${AUTHORINO_NAMESPACE} apply -f -
kubectl -n ${AUTHORINO_NAMESPACE} create -f -<<EOF
apiVersion: route.openshift.io/v1
kind: Route
metadata:
  name: talker-api
spec:
  host: ${TALKER_API_HOST}
  port:
    targetPort: web
  tls:
    insecureEdgeTerminationPolicy: Allow
    termination: edge
  to:
    kind: Service
    name: envoy
    weight: null
status:
  ingress: null
EOF

AUTHORINO_DEPLOYMENT=setup-from-files make deploy
sed -e "s/\${AUTHORINO_NAMESPACE}/$AUTHORINO_NAMESPACE/g;s/\"talker-api\"/\"$TALKER_API_HOST\"/g" examples/setup-from-files.yaml | kubectl -n ${AUTHORINO_NAMESPACE} apply -f -
kubectl -n ${AUTHORINO_NAMESPACE} patch deployment authorino-controller-manager -p '{"spec": {"template": {"spec":{"containers":[{"name": "manager", "volumeMounts":[{"name": "configs", "mountPath": "/configs"}]}], "volumes":[{"name": "configs", "configMap": {"name": "api-protections", "items": [{"key": "talker-api-protection.json", "path": "talker-api-protection.json"}]}}]}}}}'
```

Then, create an API key and wait 5 minutes:

```sh
kubectl -n ${AUTHORINO_NAMESPACE} create -f -<<EOF
apiVersion: v1
kind: Secret
metadata:
  name: friend-1-api-key-1
  labels:
    authorino.3scale.net/managed-by: authorino
    group: friends
stringData:
  api_key: ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx
type: Opaque
EOF
```

Consume the service with the API key:

```sh
curl -H "Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx" http://$TALKER_API_HOST/hello
```

```sh
curl -H "Authorization: Wristband <wirstband-token-from-previous-response>" http://$TALKER_API_HOST/hello
```
