### PR TITLE
doc/examples/readme: Update documented HTTP return code for APIKey example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -99,7 +99,7 @@ kubectl -n authorino apply -f ./examples/simple-api-key.yaml
 
 ```sh
 curl -H 'Host: talker-api' -H 'Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx' http://localhost:8000/hello # 200
-curl -H 'Host: talker-api' -H 'Authorization: APIKEY nonono' http://localhost:8000/hello # 403
+curl -H 'Host: talker-api' -H 'Authorization: APIKEY nonono' http://localhost:8000/hello # 401
 ```
 
 ----


### PR DESCRIPTION
When an invalid APIKey is provided an HTTP return code 401 is returned.

Execution example:

```
msoriano@localhost:~/go/src/github.com/Kuadrant/authorino (update-returned-code-doc-in-apikey-example)$ curl -H "Host: talker-api" -H "Authorization: APIKEY nono" 127.0.0.1:8000/api/test -v
*   Trying 127.0.0.1:8000...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
> GET /api/test HTTP/1.1
> Host: talker-api
> User-Agent: curl/7.65.3
> Accept: */*
Handling connection for 8000
> Authorization: APIKEY nono
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 401 Unauthorized
< www-authenticate: APIKEY realm="friends"
< x-ext-auth-reason: the API Key provided is invalid
< date: Thu, 03 Jun 2021 09:30:57 GMT
< server: envoy
< content-length: 0
< 
* Connection #0 to host 127.0.0.1 left intact
```

Authorino has been deployed with:
```
make local-setup
```