### PR TITLE
doc: Get K8S API from structured output

### DIFF
--- a/docs/tutorials/showcase/README.md
+++ b/docs/tutorials/showcase/README.md
@@ -152,7 +152,9 @@ Request an access token for the API consumer Service Account, with the same audi
 > **NOTE:** The token issued will be immediately valid and will expire after 10 minutes.
 
 ```sh
-$ export KUBERNETES_API=$(kubectl cluster-info | head -n 1 | awk '{print $7}' | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g")
+$ CURRENT_K8S_CONTEXT=$(kubectl config view -o json | jq -r '."current-context"')
+$ CURRENT_K8S_CLUSTER=$(kubectl config view -o json | jq -r --arg K8S_CONTEXT "${CURRENT_K8S_CONTEXT}"  '.contexts[] | select(.name == $K8S_CONTEXT) | .context.cluster')
+$ export KUBERNETES_API=$(kubectl config view -o json | jq -r --arg K8S_CLUSTER "${CURRENT_K8S_CLUSTER}" '.clusters[] | select(.name == $K8S_CLUSTER) | .cluster.server')
 $ export TOKEN_ISSUER_TOKEN=$(kubectl -n authorino get secret/$(kubectl -n authorino get sa/sa-token-issuer -o json | jq -r '.secrets[0].name') -o json | jq -r '.data.token' | base64 -d)
 
 $ export ACCESS_TOKEN=$(curl -k -X "POST" "$KUBERNETES_API/api/v1/namespaces/authorino/serviceaccounts/api-consumer/token" \


### PR DESCRIPTION
When trying the `Kubernetes authentication` example in `doc/examples.MD` the following line:
```
export KUBERNETES_API=$(kubectl cluster-info | head -n 1 | awk '{print $7}' | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g")
```

returned an empty output in my case:

```
msoriano@localhost:~$ export KUBERNETES_API=$(kubectl cluster-info | head -n 1 | awk '{print $7}' | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g")
msoriano@localhost:~$ echo ${KUBERNETES_API}

msoriano@localhost:~$ kubectl cluster-info | head -n 1 | awk '{print $7}' | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g"

msoriano@localhost:~$ kubectl cluster-info | head -n 1 | awk '{print $7}'

msoriano@localhost:~$ kubectl cluster-info | head -n 1
Kubernetes master is running at https://127.0.0.1:38567
```

My kubectl command version information:
```
msoriano@localhost:~$ kubectl version
Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.9", GitCommit:"94f372e501c973a7fa9eb40ec9ebd2fe7ca69848", GitTreeState:"clean", BuildDate:"2020-09-16T13:56:40Z", GoVersion:"go1.13.15", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"19", GitVersion:"v1.19.1", GitCommit:"206bcadf021e76c27513500ca24182692aabd17e", GitTreeState:"clean", BuildDate:"2020-09-14T07:30:52Z", GoVersion:"go1.15", Compiler:"gc", Platform:"linux/amd64"}
```

It seems that depending on the environment and/or kubectl version the length of the output differs.

This PR changes the way the K8S API Server URL is retrieved getting it from structured output content from the set current-context of the user.