### PR TITLE
Add 'use' claim to wristband signing keys

### DIFF
--- a/pkg/config/wristband.go
+++ b/pkg/config/wristband.go
@@ -22,6 +22,7 @@ func NewSigningKey(name string, algorithm string, singingKey []byte) (*jose.JSON
 	signingKey := &jose.JSONWebKey{
 		KeyID:     name,
 		Algorithm: algorithm,
+		Use:       "sig",
 	}
 
 	keyPEM, _ := pem.Decode(singingKey)

--- a/pkg/config/wristband_test.go
+++ b/pkg/config/wristband_test.go
@@ -121,11 +121,15 @@ invalid
 	key, err = NewSigningKey("my-signing-key", "ES256", []byte(ellipticCurveSigningKey))
 	assert.NilError(t, err)
 	assert.Equal(t, key.KeyID, "my-signing-key")
+	assert.Equal(t, key.Algorithm, "ES256")
+	assert.Equal(t, key.Use, "sig")
 	assert.Check(t, key.Valid())
 
 	key, err = NewSigningKey("my-signing-key", "RS256", []byte(rsaSigningKey))
 	assert.NilError(t, err)
 	assert.Equal(t, key.KeyID, "my-signing-key")
+	assert.Equal(t, key.Algorithm, "RS256")
+	assert.Equal(t, key.Use, "sig")
 	assert.Check(t, key.Valid())
 }
 


### PR DESCRIPTION
Some clients require the `"use": "sig"` claim to be present, to accept the key as a valid JWT signing key.