### PR TITLE
Adjust memory resource request and limit

### DIFF
--- a/deploy/base/manager.yaml
+++ b/deploy/base/manager.yaml
@@ -40,8 +40,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 500Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 80Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
This will prevent `OOMKilled` pod failure in environments with OOM killer enabled, for the current memory resources required by Authorino.

In the future, enhancements related to issues such as #23 and #24 (if followed by extracting the wristband OIDC server out of the Authorino manager pod) will allow decreasing again the request and limit for memory.