### PR TITLE
Change default authorino image to quay.io/3scale/authorino:latest

### DIFF
--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -32,7 +32,7 @@ patchesStrategicMerge:
 
 images:
 - name: authorino
-  newName: authorino
+  newName: quay.io/3scale/authorino
   newTag: latest
 
 replicas:

--- a/deploy/base/manager.yaml
+++ b/deploy/base/manager.yaml
@@ -35,7 +35,7 @@ spec:
         - /manager
         args:
         - --enable-leader-election
-        image: authorino:latest
+        image: quay.io/3scale/authorino:latest
         name: manager
         resources:
           limits:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -64,7 +64,13 @@ To start the local Kubernetes cluster, build and deploy Authorino, run:
 make local-setup
 ```
 
-You will then need to forward local requests to port 8000 to Envoy, by running:
+You can skip the local build of the image, and work with the default `quay.io/3scale/authorino:latest`, by using the `SKIP_LOCAL_BUILD` flag:
+
+```sh
+make local-setup SKIP_LOCAL_BUILD=1
+```
+
+After all deployments are ready and in case you want to consume protected services running inside the cluster from your local host, you can forward the requests on port 8000 to the Envoy service by running:
 
 ```sh
 kubectl -n authorino port-forward deployment/envoy 8000:8000 &
@@ -97,7 +103,7 @@ The bundle comes preloaded with the following sample configs:<br/>
   - peter/p (member, email not verified)
 
 ```sh
-DEPLOY_KEYCLOAK=1 make local-setup
+make local-setup DEPLOY_KEYCLOAK=1
 ```
 
 Forward local requests to the services running in the cluster, by running:
@@ -116,7 +122,7 @@ The [Dex](https://dexidp.io) bundle included is a simple OIDC identity provider 
   - marta@localhost/password
 
 ```sh
-DEPLOY_DEX=1 make local-setup
+make local-setup DEPLOY_DEX=1
 ```
 
 Forward local requests to the services running in the cluster, by running:
@@ -129,7 +135,7 @@ kubectl -n authorino port-forward deployment/dex 5556:5556 &
 #### Deploy with Keycloak and Dex
 
 ```sh
-DEPLOY_IDPS=1 make local-setup
+make local-setup DEPLOY_IDPS=1
 ```
 
 ```sh
@@ -190,30 +196,20 @@ The command above will create the Authorino definitions in the cluster based on 
 
 Chose or build an image of Authorino that is compatible with the version of the CRD installed in the previous step.
 
-You can check out [quay.io/3scale/authorino](https://quay.io/3scale/authorino) for a list of pre-built image tags available. If you choose any of the publicly available pre-built images of Authorino, you can go to the next step.
+By default, `quay.io/3scale/authorino:latest` will be used. You can check out [quay.io/3scale/authorino](https://quay.io/3scale/authorino) for a list of pre-built image tags available.
 
-Alternatively, you can build an image of Authorino from code. To build you own local image of Authorino, based on the fetched version of the repo, run:
+If you choose to continue with the default Authorino image or any other publicly available pre-built image, you can go to the next step.
 
-```sh
-make docker-build
-```
-
-The default tag of the image, in this case, will be `authorino:latest`. You can use the parameter `AUTHORINO_IMAGE` to control the name of the tag. E.g.:
+To build you own local image of Authorino from code, run:
 
 ```sh
-AUTHORINO_IMAGE=authorino:my-local-image make docker-build
+make docker-build AUTHORINO_IMAGE=authorino:my-local-image
 ```
 
 To push the image to a local Kubernetes cluster started with Kind, run:
 
 ```sh
-make local-push
-```
-
-or, specifying an image tag other than `authorino-latest` that you might have chosen before:
-
-```sh
-AUTHORINO_IMAGE=authorino:my-local-image make local-push
+make local-push AUTHORINO_IMAGE=authorino:my-local-image
 ```
 
 In case you are not working with a local Kubernetes server started with `local-cluster-up`, but yet has built your own local image of Authorino, use normal `docker push` command to push the image to a registry of your preference.
@@ -252,13 +248,13 @@ make deploy
 To deploy cluster-wide Authorino instances (`Deployment`, `Service` and `ClusterRoleBinding`s), run:
 
 ```sh
-AUTHORINO_DEPLOYMENT=cluster-wide make deploy
+make deploy AUTHORINO_DEPLOYMENT=cluster-wide
 ```
 
-By default, the commands above assume `authorino:latest` to be the tag of the Authorino image to deploy. You can change that by setting the `AUTHORINO_IMAGE` parameter.
+By default, the commands above assume `quay.io/3scale/authorino:latest` to be the Authorino image tag to deploy. You can change that by setting the `AUTHORINO_IMAGE` parameter.
 
 ```sh
-AUTHORINO_IMAGE=authorino:my-custom-image make deploy
+make deploy AUTHORINO_IMAGE=authorino:my-custom-image
 ```
 
 > **NOTE:** In case you are working with a local Kubernetes cluster started with Kind, have built and pushed a local image to the server registry, remind of Kubernetes default pull policy, which establishes that the image tag `:latest` causes the policy `Always` to be enforced. In such case, you may want to change the policy to `IfNotPresent`. See [Kubernetes `imagePullPolicy`](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for more information.
@@ -266,7 +262,7 @@ AUTHORINO_IMAGE=authorino:my-custom-image make deploy
 You can tweak with the number of replicas of the Authorino `Deployment`, by setting the `AUTHORINO_REPLICAS` parameter. E.g.:
 
 ```sh
-AUTHORINO_REPLICAS=4 AUTHORINO_DEPLOYMENT=cluster-wide AUTHORINO_IMAGE=quay.io/3scale/authorino:latest make deploy
+make deploy AUTHORINO_REPLICAS=4 AUTHORINO_DEPLOYMENT=namespaced AUTHORINO_IMAGE=quay.io/3scale/authorino:latest
 ```
 
 #### Next steps

--- a/docs/tutorials/showcase/README.md
+++ b/docs/tutorials/showcase/README.md
@@ -78,10 +78,10 @@ $ git clone git@github.com:kuadrant/authorino.git && cd authorino
 
 ## Setup the trial local environment
 
-Launch the Kubernetes cluster on a Docker with [Kind](https://kind.sigs.k8s.io), build the latest Authorino image from source and deploy the main applications of the stack. This step may take up to a few minutes for the cluster and all the deployments to be ready.
+Launch the Kubernetes cluster on a Docker with [Kind](https://kind.sigs.k8s.io) and deploy the main applications of the stack. This step may take up to a few minutes for the cluster and all the deployments to be ready.
 
 ```sh
-$ DEPLOY_IDPS=1 make local-setup
+$ make local-setup SKIP_LOCAL_BUILD=1 DEPLOY_IDPS=1
 ```
 
 Forward requests from the local host machine to pods running inside the cluster (API, Keycloak server, and Dex server):
@@ -422,7 +422,7 @@ Click again on the menu buttons to consume resources of the API. Verify that now
 Delete the Kubernetes cluster:
 
 ```sh
-$ make local-cluster-down
+$ make local-cleanup
 ```
 
 Remove the entry added to your `/etc/hosts` file to resolve the `keycloak` host name locally.

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ The simplest way to try the examples in this page is by launching a local test K
 Run from the root directory of the Authorino repo:
 
 ```sh
-make local-setup
+make local-setup SKIP_LOCAL_BUILD=1
 ```
 
 The above will setup the local environment, install and deploy Authorino, Envoy and the sample API to be protected called **Talker API**.
@@ -19,7 +19,7 @@ The above will setup the local environment, install and deploy Authorino, Envoy 
 Some of the examples involve having an external identity provider (IdP), such as [Keycloak](https://www.keycloak.org) and/or [Dex](https://dexidp.io), to support authentication. To launch the local test environment including as well both these IdPs deployed to the cluster, run instead:
 
 ```sh
-DEPLOY_IDPS=1 make local-setup
+make local-setup SKIP_LOCAL_BUILD=1 DEPLOY_IDPS=1
 ```
 
 > **NOTE:** You can replace `DEPLOY_IDPS` above with `DEPLOY_KEYCLOAK` or `DEPLOY_DEX`, in case you only want one of these auth servers deployed.
@@ -37,7 +37,7 @@ kubectl -n authorino port-forward deployment/dex 5556:5556 &      # (if using De
 <br/>To cleanup, run:
 
 ```sh
-make local-cluster-down
+make local-cleanup
 ```
 
 For more information on the deployment options and resources included in the local test Kubernetes environment included in Authorino examples, see [Deploying Authorino](/docs/deploy.md).


### PR DESCRIPTION
For the general case, `quay.io/3scale/authorino:latest` is now the default image that is deployed.

For the make targets `local-setup` and `local-rollout`, it will continue to build the image and push it to the local Kubernetes cluster started with Kind – now with the locally built image tagged as `authorino:local`.

This step of building an image locally can now be skept by supplying the `SKIP_LOCAL_BUILD=1` argument to the make `local-*` commands. In this case, the deployment defaults again to `AUTHORINO_IMAGE=quay.io/3scale/authorino:latest` and, just like with the more generic `make deploy`, Kubernetes will fetch the image from quay.

As usual, the `AUTHORINO_IMAGE` argument can still be used to set a different image, but it has no effect on the `local-*` make commands when `SKIP_LOCAL_BUILD=0` or unset (the default).

Closes #121