### PR TITLE
[hotfix] Configurable authorino image

### DIFF
--- a/deploy/base/manager.yaml
+++ b/deploy/base/manager.yaml
@@ -35,7 +35,7 @@ spec:
         - /manager
         args:
         - --enable-leader-election
-        image: quay.io/3scale/authorino:latest
+        image: authorino:latest
         name: manager
         resources:
           limits:


### PR DESCRIPTION
By setting `image: quay.io/3scale/authorino:latest` inside of the `Deployment` definition, we actually removed the optional customize the image.