### PR TITLE
Fix detection of authorino-managed secrets

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 	"reflect"
-	"strconv"
 
 	"github.com/kuadrant/authorino/api/v1beta1"
 	configv1beta1 "github.com/kuadrant/authorino/api/v1beta1"
@@ -91,11 +90,8 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 func filterByLabels(secretLabel string) predicate.Funcs {
 	filter := func(object client.Object) bool {
-		if val, ok := object.GetLabels()[secretLabel]; ok {
-			enabled, _ := strconv.ParseBool(val)
-			return enabled
-		}
-		return false
+		_, ok := object.GetLabels()[secretLabel]
+		return ok
 	}
 
 	return predicate.Funcs{
@@ -106,8 +102,7 @@ func filterByLabels(secretLabel string) predicate.Funcs {
 			return filter(e.ObjectNew)
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			_, ok := e.Object.GetLabels()[secretLabel]
-			return ok
+			return filter(e.Object)
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
 			return filter(e.Object)


### PR DESCRIPTION
After [upgrading controller-manager](https://github.com/Kuadrant/authorino/commit/e0e2b7f87c5c1be5ca382c7360214989fc8b54dc), Secrets stopped being reconciled. The issue has nothing to do with the version of controller-manager or the use of filtering predicates though, but with the implementation of the filter function that was trying to cast the value of the label to a `bool`, a solution poorly ported from [this example](https://github.com/Kuadrant/authorino/issues/116#issuecomment-875506866) without taking into account Authorino's convention of labeling secrets with `authorino.3scale.net/managed-by: authorino`, which does not translate to a truthy boolean in Golang.

In the future, we may want to change the convention and prefer a label such as `authorino.3scale.net/managed: true` instead.