### PR TITLE
Replace `OIDC_CA_PATH` env var with more explicit ones `OIDC_TLS_CERT` and `OIDC_TLS_CERT_KEY`

### DIFF
--- a/deploy/overlays/cluster-wide/patches/oidc_server_cert_patch.yaml
+++ b/deploy/overlays/cluster-wide/patches/oidc_server_cert_patch.yaml
@@ -8,14 +8,19 @@ spec:
     spec:
       containers:
       - name: manager
+        env:
+        - name: OIDC_TLS_CERT
+          value: /etc/ssl/certs/oidc.crt
+        - name: OIDC_TLS_CERT_KEY
+          value: /etc/ssl/private/oidc.key
         volumeMounts:
         - name: oidc-cert
-          mountPath: /etc/ssl/certs/tls.crt
           subPath: tls.crt
+          mountPath: /etc/ssl/certs/oidc.crt
           readOnly: true
         - name: oidc-cert
-          mountPath: /etc/ssl/private/tls.key
           subPath: tls.key
+          mountPath: /etc/ssl/private/oidc.key
           readOnly: true
       volumes:
       - name: oidc-cert

--- a/deploy/overlays/namespaced/patches/oidc_server_cert_patch.yaml
+++ b/deploy/overlays/namespaced/patches/oidc_server_cert_patch.yaml
@@ -8,14 +8,19 @@ spec:
     spec:
       containers:
       - name: manager
+        env:
+        - name: OIDC_TLS_CERT
+          value: /etc/ssl/certs/oidc.crt
+        - name: OIDC_TLS_CERT_KEY
+          value: /etc/ssl/private/oidc.key
         volumeMounts:
         - name: oidc-cert
-          mountPath: /etc/ssl/certs/tls.crt
           subPath: tls.crt
+          mountPath: /etc/ssl/certs/oidc.crt
           readOnly: true
         - name: oidc-cert
-          mountPath: /etc/ssl/private/tls.key
           subPath: tls.key
+          mountPath: /etc/ssl/private/oidc.key
           readOnly: true
       volumes:
       - name: oidc-cert


### PR DESCRIPTION
The presence/absence of these environment variables will also be used as flag to enable/disable TLS on Authorino's built-in OIDC endpoints (instead of checking for the existence of the files). If the value set for either of the env vars points to a file in the file system that cannot be read (not found, permission issue, invalid format, etc), Authorino will fail on starting up the OIDC built-in server, instead of the old behaviour of falling back to plain HTTP. To disable TLS, make sure to NOT set these env vars (or set them to the empty string alternatively).

The `OIDC_` prefix was kept in the name of env vars to distinguish them from `TLS_CERT` and `TLS_CERT_KEY` envs, yet to be implemented for the main authorization service.

Suggested in https://github.com/Kuadrant/authorino/pull/135/files#r672932280.