### PR TITLE
Generic HTTP metadata can be downloaded without any authentication

### DIFF
--- a/api/v1beta1/service_types.go
+++ b/api/v1beta1/service_types.go
@@ -203,7 +203,7 @@ type Metadata_GenericHTTP struct {
 
 	// Reference to a Secret key whose value will be passed by Authorino in the request.
 	// The HTTP service can use the shared secret to authenticate the origin of the request.
-	SharedSecret *SecretKeyReference `json:"sharedSecretRef"`
+	SharedSecret *SecretKeyReference `json:"sharedSecretRef,omitempty"`
 
 	// Defines where client credentials will be passed in the request to the service.
 	// If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -195,18 +195,22 @@ func (r *ServiceReconciler) translateService(ctx context.Context, service *confi
 			sharedSecretRef := genericHttp.SharedSecret
 			creds := genericHttp.Credentials
 
+			var sharedSecret string
 			secret := &v1.Secret{}
-			if err := r.Client.Get(ctx, types.NamespacedName{
-				Namespace: service.Namespace,
-				Name:      sharedSecretRef.Name},
-				secret); err != nil {
-				return nil, err // TODO: Review this error, perhaps we don't need to return an error, just reenqueue.
+			if sharedSecretRef != nil {
+				if err := r.Client.Get(ctx, types.NamespacedName{
+					Namespace: service.Namespace,
+					Name:      sharedSecretRef.Name},
+					secret); err != nil {
+					return nil, err // TODO: Review this error, perhaps we don't need to return an error, just reenqueue.
+				}
+				sharedSecret = string(secret.Data[sharedSecretRef.Key])
 			}
 
 			translatedMetadata.GenericHTTP = &authorinoMetadata.GenericHttp{
 				Endpoint:        genericHttp.Endpoint,
 				Method:          string(genericHttp.Method),
-				SharedSecret:    string(secret.Data[sharedSecretRef.Key]),
+				SharedSecret:    sharedSecret,
 				AuthCredentials: auth_credentials.NewAuthCredential(creds.KeySelector, string(creds.In)),
 			}
 

--- a/install/crd/config.authorino.3scale.net_services.yaml
+++ b/install/crd/config.authorino.3scale.net_services.yaml
@@ -372,7 +372,6 @@ spec:
                           type: object
                       required:
                       - endpoint
-                      - sharedSecretRef
                       type: object
                     name:
                       description: The name of the metadata source. Policies of te

--- a/pkg/common/auth_credentials/auth_credentials.go
+++ b/pkg/common/auth_credentials/auth_credentials.go
@@ -89,8 +89,8 @@ func (c *AuthCredential) GetCredentialsIn() string {
 func (c *AuthCredential) BuildRequestWithCredentials(ctx context.Context, endpoint string, method string, credentialValue string, body io.Reader) (*http.Request, error) {
 	url := endpoint
 
-	// build url with creds
-	if c.In == inQuery {
+	// build url with creds (if credentialValue is not empty)
+	if c.In == inQuery && credentialValue != "" {
 		var separator string
 		if strings.Contains(url, "?") {
 			separator = "&"
@@ -104,6 +104,11 @@ func (c *AuthCredential) BuildRequestWithCredentials(ctx context.Context, endpoi
 	if req, err := http.NewRequestWithContext(ctx, method, url, body); err != nil {
 		return nil, err
 	} else {
+		// don't add creds if credentialValue is empty
+		if credentialValue == "" {
+			return req, nil
+		}
+
 		// add creds to request
 		switch c.In {
 		case inAuthHeader:

--- a/pkg/common/auth_credentials/auth_credentials_test.go
+++ b/pkg/common/auth_credentials/auth_credentials_test.go
@@ -1,6 +1,7 @@
 package auth_credentials
 
 import (
+	"context"
 	"testing"
 
 	envoyServiceAuthV3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
@@ -181,4 +182,21 @@ func TestGetCredentialsFromQueryFail(t *testing.T) {
 	_, err := authCredentials.GetCredentialsFromReq(&httpReq)
 
 	assert.Error(t, err, "credential not found")
+}
+
+func TestBuildRequestWithCredentials(t *testing.T) {
+	creds := NewAuthCredential("", "")
+	req, err := creds.BuildRequestWithCredentials(context.TODO(), "http://example.com", "GET", "123", nil)
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(req.Header.Values("Authorization")), 1)
+	assert.Equal(t, req.Header.Get("Authorization"), creds.KeySelector+" 123")
+}
+
+func TestBuildRequestWithCredentialsEmpty(t *testing.T) {
+	creds := NewAuthCredential("", "")
+	req, err := creds.BuildRequestWithCredentials(context.TODO(), "http://example.com", "GET", "", nil)
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(req.Header.Values("Authorization")), 0)
 }


### PR DESCRIPTION
This PR removes the necessity of authentication to the external metadata server. It enables to define CRD with following metadata:
```yaml
metadata:
  - name: echo-api
    http:
      endpoint: http://example.com/metadata
```