### PR TITLE
Makefile: pin controller-gen and kustomize tool versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,9 @@ certs:
 ifeq (,$(findstring -notls,$(AUTHORINO_DEPLOYMENT)))
 ifeq (,$(TLS_CERT_SECRET_CHECK))
 ifneq (, $(CERT_MANAGER_CHECK))
-	cd deploy/base/certmanager && $(KUSTOMIZE) edit set namespace $(AUTHORINO_NAMESPACE)
+	cd deploy/base/certmanager && ../../../$(KUSTOMIZE) edit set namespace $(AUTHORINO_NAMESPACE)
 	$(KUSTOMIZE) build deploy/base/certmanager | kubectl -n $(AUTHORINO_NAMESPACE) apply -f -
-	cd deploy/base/certmanager && $(KUSTOMIZE) edit set namespace authorino
+	cd deploy/base/certmanager && ../../../$(KUSTOMIZE) edit set namespace authorino
 else
 	echo "cert-manager not installed."
 endif
@@ -96,12 +96,12 @@ endif
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests $(KUSTOMIZE)
 	$(MAKE) certs AUTHORINO_NAMESPACE=$(AUTHORINO_NAMESPACE) AUTHORINO_DEPLOYMENT=$(AUTHORINO_DEPLOYMENT)
-	cd deploy/base && $(KUSTOMIZE) edit set image authorino=$(AUTHORINO_IMAGE) && $(KUSTOMIZE) edit set namespace $(AUTHORINO_NAMESPACE) && $(KUSTOMIZE) edit set replicas authorino-controller-manager=$(AUTHORINO_REPLICAS)
-	cd deploy/overlays/$(AUTHORINO_DEPLOYMENT) && $(KUSTOMIZE) edit set namespace $(AUTHORINO_NAMESPACE)
+	cd deploy/base && ../../$(KUSTOMIZE) edit set image authorino=$(AUTHORINO_IMAGE) && ../../$(KUSTOMIZE) edit set namespace $(AUTHORINO_NAMESPACE) && ../../$(KUSTOMIZE) edit set replicas authorino-controller-manager=$(AUTHORINO_REPLICAS)
+	cd deploy/overlays/$(AUTHORINO_DEPLOYMENT) && ../../../$(KUSTOMIZE) edit set namespace $(AUTHORINO_NAMESPACE)
 	$(KUSTOMIZE) build deploy/overlays/$(AUTHORINO_DEPLOYMENT) | kubectl -n $(AUTHORINO_NAMESPACE) apply -f -
 # rollback kustomize edit
-	cd deploy/base && $(KUSTOMIZE) edit set image authorino=$(DEFAULT_AUTHORINO_IMAGE) && $(KUSTOMIZE) edit set namespace authorino && $(KUSTOMIZE) edit set replicas authorino-controller-manager=1
-	cd deploy/overlays/$(AUTHORINO_DEPLOYMENT) && $(KUSTOMIZE) edit set namespace authorino
+	cd deploy/base && ../../$(KUSTOMIZE) edit set image authorino=$(DEFAULT_AUTHORINO_IMAGE) && ../../$(KUSTOMIZE) edit set namespace authorino && ../../$(KUSTOMIZE) edit set replicas authorino-controller-manager=1
+	cd deploy/overlays/$(AUTHORINO_DEPLOYMENT) && ../../../$(KUSTOMIZE) edit set namespace authorino
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: $(CONTROLLER_GEN)

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,31 @@ AUTHORINO_REPLICAS ?= 1
 
 all: manager
 
+CONTROLLER_GEN=bin/controller-gen
+bin/controller-gen:
+	@{ \
+	set -e ;\
+	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
+	cd $$CONTROLLER_GEN_TMP_DIR ;\
+	go mod init tmp ;\
+	GOBIN=$(PROJECT_DIR)/bin go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.1 ;\
+	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
+	}
+
+controller-gen: $(CONTROLLER_GEN)
+
+KUSTOMIZE=bin/kustomize
+bin/kustomize:
+	@{ \
+	set -e ;\
+	KUSTOMIZE_GEN_TMP_DIR=$$(mktemp -d) ;\
+	cd $$KUSTOMIZE_GEN_TMP_DIR ;\
+	go mod init tmp ;\
+	GOBIN=$(PROJECT_DIR)/bin go get sigs.k8s.io/kustomize/kustomize/v3@v3.5.4 ;\
+	rm -rf $$KUSTOMIZE_GEN_TMP_DIR ;\
+	}
+
+kustomize: $(KUSTOMIZE)
 
 test: generate fmt vet manifests setup-envtest
 	KUBEBUILDER_ASSETS='$(strip $(shell $(SETUP_ENVTEST) use -p path 1.21.2))'  go test ./... -coverprofile cover.out
@@ -67,34 +92,6 @@ else
 	echo "tls disabled."
 endif
 
-CONTROLLER_GEN=$(PROJECT_DIR)/bin/controller-gen
-# find or download controller-gen
-# download controller-gen if necessary
-$(CONTROLLER_GEN):
-	@{ \
-	set -e ;\
-	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$CONTROLLER_GEN_TMP_DIR ;\
-	go mod init tmp ;\
-	GOBIN=$(PROJECT_DIR)/bin go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.1 ;\
-	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
-	}
-
-controller-gen: $(CONTROLLER_GEN)
-
-KUSTOMIZE = $(PROJECT_DIR)/bin/kustomize
-# Download kustomize locally if necessary
-$(KUSTOMIZE):
-	@{ \
-	set -e ;\
-	KUSTOMIZE_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$KUSTOMIZE_GEN_TMP_DIR ;\
-	go mod init tmp ;\
-	GOBIN=$(PROJECT_DIR)/bin go get sigs.k8s.io/kustomize/kustomize/v3@v3.5.4 ;\
-	rm -rf $$KUSTOMIZE_GEN_TMP_DIR ;\
-	}
-
-kustomize: $(KUSTOMIZE)
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests $(KUSTOMIZE)


### PR DESCRIPTION
Enforce repeatable builds by pinning `kustomize` and `controller-gen` tools to specific version.

The tools will be installed and used from `${PROJECT_DIR}/bin` directory. Note that if version is updated, then installed binary should be manually removed. Then the make target will install the new version.

Signed-off-by: Eguzki Astiz Lezaun <eastizle@redhat.com>