### PR TITLE
common.StringifyJSON

### DIFF
--- a/pkg/common/json.go
+++ b/pkg/common/json.go
@@ -133,6 +133,14 @@ func ReplaceJSONPlaceholders(source string, jsonData string) string {
 	return replaced
 }
 
+func StringifyJSON(data interface{}) (string, error) {
+	if dataAsJSON, err := json.Marshal(data); err != nil {
+		return "", err
+	} else {
+		return gjson.ParseBytes(dataAsJSON).String(), nil
+	}
+}
+
 var extractJSONStr = func(json, arg string) string {
 	var sep string = " "
 	var pos int64 = 0

--- a/pkg/common/json_test.go
+++ b/pkg/common/json_test.go
@@ -82,3 +82,88 @@ func TestCaseJSONStr(t *testing.T) {
 	assert.Equal(t, gjson.Get(jsonData, `auth.identity.fullname.@case:upper`).String(), "JOHN DOE")
 	assert.Equal(t, gjson.Get(jsonData, `auth.identity.fullname.@case:lower`).String(), "john doe")
 }
+
+func TestStringifyJSON(t *testing.T) {
+	var source interface{}
+	var str string
+	var err error
+
+	_ = json.Unmarshal([]byte(`"this is a json string"`), &source)
+	str, err = StringifyJSON(source)
+	assert.Equal(t, str, "this is a json string")
+	assert.NilError(t, err)
+
+	_ = json.Unmarshal([]byte("123"), &source)
+	str, err = StringifyJSON(source)
+	assert.Equal(t, str, "123")
+	assert.NilError(t, err)
+
+	_ = json.Unmarshal([]byte("true"), &source)
+	str, err = StringifyJSON(source)
+	assert.Equal(t, str, "true")
+	assert.NilError(t, err)
+
+	_ = json.Unmarshal([]byte("false"), &source)
+	str, err = StringifyJSON(source)
+	assert.Equal(t, str, "false")
+	assert.NilError(t, err)
+
+	_ = json.Unmarshal([]byte("null"), &source)
+	str, err = StringifyJSON(source)
+	assert.Equal(t, str, "")
+	assert.NilError(t, err)
+
+	_ = json.Unmarshal([]byte(`{"a_prop":"a_value"}`), &source)
+	str, err = StringifyJSON(source)
+	assert.Equal(t, str, `{"a_prop":"a_value"}`)
+	assert.NilError(t, err)
+
+	_ = json.Unmarshal([]byte(`["a","b","c"]`), &source)
+	str, err = StringifyJSON(source)
+	assert.Equal(t, str, `["a","b","c"]`)
+	assert.NilError(t, err)
+
+	_ = json.Unmarshal([]byte(`{"prop_str":"str","prop_num":123,"prop_bool":false,"prop_null":null,"prop_obj":{"a_prop":"a_value"},"prop_arr":["a","b","c"]}`), &source)
+	str, err = StringifyJSON(source)
+	assert.Equal(t, str, `{"prop_arr":["a","b","c"],"prop_bool":false,"prop_null":null,"prop_num":123,"prop_obj":{"a_prop":"a_value"},"prop_str":"str"}`)
+	assert.NilError(t, err)
+
+	str, err = StringifyJSON(true)
+	assert.Equal(t, str, "true")
+	assert.NilError(t, err)
+
+	str, err = StringifyJSON(false)
+	assert.Equal(t, str, "false")
+	assert.NilError(t, err)
+
+	str, err = StringifyJSON(nil)
+	assert.Equal(t, str, "")
+	assert.NilError(t, err)
+
+	str, err = StringifyJSON([]string{"a", "b", "c"})
+	assert.Equal(t, str, `["a","b","c"]`)
+	assert.NilError(t, err)
+
+	type inner struct {
+		AProp string `json:"a_prop"`
+	}
+	type outer struct {
+		Str  string      `json:"prop_str"`
+		Num  int64       `json:"prop_num"`
+		Bool bool        `json:"prop_bool"`
+		Null interface{} `json:"prop_null"`
+		Arr  []string    `json:"prop_arr"`
+		Obj  inner       `json:"prop_obj"`
+	}
+
+	str, err = StringifyJSON(outer{
+		Str:  "str",
+		Num:  123,
+		Bool: false,
+		Null: nil,
+		Arr:  []string{"a", "b", "c"},
+		Obj:  inner{AProp: "a_value"},
+	})
+	assert.Equal(t, str, `{"prop_str":"str","prop_num":123,"prop_bool":false,"prop_null":null,"prop_arr":["a","b","c"],"prop_obj":{"a_prop":"a_value"}}`)
+	assert.NilError(t, err)
+}

--- a/pkg/config/response.go
+++ b/pkg/config/response.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/kuadrant/authorino/pkg/common"
@@ -98,8 +97,7 @@ func WrapResponses(responses map[*ResponseConfig]interface{}) (responseHeaders m
 	for responseConfig, authObj := range responses {
 		switch responseConfig.Wrapper {
 		case HTTP_HEADER_WRAPPER:
-			jsonObj, _ := json.Marshal(authObj)
-			responseHeaders[responseConfig.WrapperKey] = string(jsonObj)
+			responseHeaders[responseConfig.WrapperKey], _ = common.StringifyJSON(authObj)
 		case ENVOY_DYNAMIC_METADATA_WRAPPER:
 			responseMetadata[responseConfig.WrapperKey] = authObj
 		}


### PR DESCRIPTION
Ensures directly stringified values for dynamic responses wrapped in HTTP headers, instead of using always a quoted JSON type value.

The previous use of `json.Marshal`, followed by `string(bytes)`, was causing all values responded in added HTTP headers to be wrapped between string quotes. With this change, the value of the header will be the plain stringified object – e.g. `"a string"` instead of `"\"a string\""`; `"{\"a_prop\":\"a value\"}"` instead of `"\"{\"a_prop\":\"a value\"}\""`.