### PR TITLE
[examples/talker-api] Better logging for the Talker API

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -693,7 +693,7 @@ kubectl -n authorino apply -f ./examples/wristband.yaml
 Obtain a wristband by successfully authenticating via API key:
 
 ```sh
-export WRISTBAND=$(curl -H 'Host: talker-api' -H 'Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx' http://localhost:8000/auth | jq -r '.headers.HTTP_X_EXT_AUTH_WRISTBAND')
+export WRISTBAND=$(curl -H 'Host: talker-api' -H 'Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx' http://localhost:8000/auth | jq -r '.headers["X-Ext-Auth-Wristband"]')
 ```
 
 The payload of the wristband (decoded) shall look like the following:

--- a/examples/talker-api/config.ru
+++ b/examples/talker-api/config.ru
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'securerandom'
+require 'net/http/status'
 
 class RackApp
   def call(env)
@@ -10,22 +11,55 @@ class RackApp
     request_path = request.path
     request_query_string = request.query_string
     request_query_string = nil if request_query_string.empty?
-    request_headers = env.select { |header, _| header.start_with?('HTTP_') || header == 'CONTENT_LENGTH' || header == 'CONTENT_TYPE' }
-    response_status = request_headers['HTTP_X_ECHO_STATUS']&.to_i || 200
-    response_message = request_headers['HTTP_X_ECHO_MESSAGE']
-    response_content_type = response_message ? 'text/plain' : 'application/json'
-    response_message ||= JSON.pretty_generate(
+    request_status_line = "#{request_method} #{[request_path, request_query_string].compact.join('?')}"
+    request_headers = env.select { |header, _| header.start_with?('HTTP_') || header == 'CONTENT_LENGTH' || header == 'CONTENT_TYPE' }.transform_keys { |header| header.sub(/^HTTP_/, '').split('_').map(&:capitalize).join('-') }
+    request_version = request_headers['Version']
+    request_body = request.body.read
+
+    response_status = request_headers['X-Echo-Status']&.to_i || 200
+    response_message = Net::HTTP::STATUS_CODES[response_status]
+    response_body = request_headers['X-Echo-Message']
+    response_content_type = response_body ? 'text/plain' : 'application/json'
+    response_headers = { 'Content-Type' => response_content_type }
+    response_body ||= JSON.pretty_generate(
       method: request_method,
       path: request_path,
       query_string: request_query_string,
-      body: request.body.read,
+      body: request_body,
       headers: request_headers,
       uuid: SecureRandom.uuid
     )
 
-    puts "[#{Time.now}] #{request_method} #{[request_path, request_query_string].compact.join('?')} => #{response_status}"
+    log_details = if ENV['LOG_LEVEL'].to_s.downcase == 'debug'
+      [
+        '',
+        '[Request]',
+        "#{request_status_line} #{request_version}",
+        request_headers.map{ |k,v| [k, v].join(': ') },
+        '(…request headers omitted)',
+        '',
+        request_body,
+        '',
+        '[Response]',
+        "#{request_version} #{response_status} #{response_message}",
+        response_headers.map{ |k,v| [k, v].join(': ') },
+        '(…response headers omitted)',
+        '',
+        response_body,
+      ].flatten.map(&method(:indent)).join("\n")
+    else
+      "=> #{response_status}"
+    end
 
-    [response_status, { 'Content-Type' => response_content_type }, [response_message]]
+    puts "[#{Time.now}] #{request_status_line} #{log_details}"
+
+    [response_status, response_headers, [response_body]]
+  end
+
+  protected
+
+  def indent(str)
+    ['  ', str].join
   end
 end
 

--- a/examples/talker-api/talker-api-deploy.yaml
+++ b/examples/talker-api/talker-api-deploy.yaml
@@ -16,11 +16,13 @@ spec:
       containers:
       - name: talker-api
         image: quay.io/3scale/authorino:talker-api
+        imagePullPolicy: Always
         env:
         - name: PORT
           value: "3000"
         ports:
         - containerPort: 3000
+        tty: true
   replicas: 1
 ---
 apiVersion: v1


### PR DESCRIPTION
- [x] Support for `LOG_LEVEL=debug` env var
- [x] Response message with HTTP header names echoed back in their original form – e.g. `HTTP_X_EXT_AUTH_WRISTBAND` becomes `X-Ext-Auth-Wristband`