### PR TITLE
`valueFrom.authJSON` with mixed static string and variable placeholders

### DIFF
--- a/api/v1beta1/auth_config_types.go
+++ b/api/v1beta1/auth_config_types.go
@@ -374,7 +374,11 @@ type SigningKeyRef struct {
 }
 
 type ValueFromAuthJSON struct {
-	// Selector to fill the value of claim from the authorization JSON
+	// Selector to fill the value from the authorization JSON.
+	// Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+	// The value can be just the pattern with the path to fetch from the authorization JSON (e.g. 'context.request.http.host')
+	// or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+	// The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower.
 	AuthJSON string `json:"authJSON,omitempty"`
 }
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -767,7 +767,7 @@ Notice that the response returned by the API includes the HTTP header added by A
   "body": "",
   "headers": {
     …
-    "HTTP_X_EXT_AUTH_DATA": "{\"authorized\":\"true\",\"request-time\":\"1628097734\"}",
+    "X-Ext-Auth-Data": "{\"authorized\":\"true\",\"geeting-message\":\"Hello, John Doe!\",\"request-time\":\"1628097734\"}",
   },
   …
 }

--- a/examples/dynamic-response.yaml
+++ b/examples/dynamic-response.yaml
@@ -32,7 +32,7 @@ spec:
             value: internal
           - name: username
             valueFrom:
-              authJSON: auth.identity.metadata.annotations.authorino\.3scale\.net/username
+              authJSON: auth.identity.metadata.annotations.authorino\.3scale\.net/username|@case:lower
           - name: roles
             value: ["consumer"]
           - name: born
@@ -50,6 +50,9 @@ spec:
           - name: request-time
             valueFrom:
               authJSON: context.request.time.seconds
+          - name: geeting-message
+            valueFrom:
+              authJSON: Hello, {auth.identity.metadata.annotations.authorino\.3scale\.net/name}!
 ---
 apiVersion: v1
 kind: Secret
@@ -59,6 +62,7 @@ metadata:
     authorino.3scale.net/managed-by: authorino
   annotations:
     authorino.3scale.net/username: consumer-1
+    authorino.3scale.net/name: John Doe
 stringData:
   api_key: ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx
 type: Opaque
@@ -70,7 +74,8 @@ metadata:
   labels:
     authorino.3scale.net/managed-by: authorino
   annotations:
-    authorino.3scale.net/username: consumer-2
+    authorino.3scale.net/username: Consumer-2
+    authorino.3scale.net/name: Jane Smith
 stringData:
   api_key: orVKflEHd5Udtu8iFzmvQQTqN7Em7tRu
 type: Opaque

--- a/install/crd/authorino.3scale.net_authconfigs.yaml
+++ b/install/crd/authorino.3scale.net_authconfigs.yaml
@@ -214,8 +214,17 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: Selector to fill the value of claim
-                                        from the authorization JSON
+                                      description: 'Selector to fill the value from
+                                        the authorization JSON. Any patterns supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The value can be just the pattern
+                                        with the path to fetch from the authorization
+                                        JSON (e.g. ''context.request.http.host'')
+                                        or a string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                        The following string modifiers are available:
+                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower.'
                                       type: string
                                   type: object
                               type: object
@@ -226,8 +235,17 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: Selector to fill the value of claim
-                                        from the authorization JSON
+                                      description: 'Selector to fill the value from
+                                        the authorization JSON. Any patterns supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The value can be just the pattern
+                                        with the path to fetch from the authorization
+                                        JSON (e.g. ''context.request.http.host'')
+                                        or a string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                        The following string modifiers are available:
+                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower.'
                                       type: string
                                   type: object
                               type: object
@@ -238,8 +256,17 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: Selector to fill the value of claim
-                                        from the authorization JSON
+                                      description: 'Selector to fill the value from
+                                        the authorization JSON. Any patterns supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The value can be just the pattern
+                                        with the path to fetch from the authorization
+                                        JSON (e.g. ''context.request.http.host'')
+                                        or a string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                        The following string modifiers are available:
+                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower.'
                                       type: string
                                   type: object
                               type: object
@@ -250,8 +277,17 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: Selector to fill the value of claim
-                                        from the authorization JSON
+                                      description: 'Selector to fill the value from
+                                        the authorization JSON. Any patterns supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The value can be just the pattern
+                                        with the path to fetch from the authorization
+                                        JSON (e.g. ''context.request.http.host'')
+                                        or a string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                        The following string modifiers are available:
+                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower.'
                                       type: string
                                   type: object
                               type: object
@@ -262,8 +298,17 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: Selector to fill the value of claim
-                                        from the authorization JSON
+                                      description: 'Selector to fill the value from
+                                        the authorization JSON. Any patterns supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The value can be just the pattern
+                                        with the path to fetch from the authorization
+                                        JSON (e.g. ''context.request.http.host'')
+                                        or a string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                        The following string modifiers are available:
+                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower.'
                                       type: string
                                   type: object
                               type: object
@@ -274,8 +319,17 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: Selector to fill the value of claim
-                                        from the authorization JSON
+                                      description: 'Selector to fill the value from
+                                        the authorization JSON. Any patterns supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The value can be just the pattern
+                                        with the path to fetch from the authorization
+                                        JSON (e.g. ''context.request.http.host'')
+                                        or a string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                        The following string modifiers are available:
+                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower.'
                                       type: string
                                   type: object
                               type: object
@@ -290,8 +344,17 @@ spec:
                             valueFrom:
                               properties:
                                 authJSON:
-                                  description: Selector to fill the value of claim
-                                    from the authorization JSON
+                                  description: 'Selector to fill the value from the
+                                    authorization JSON. Any patterns supported by
+                                    https://pkg.go.dev/github.com/tidwall/gjson can
+                                    be used. The value can be just the pattern with
+                                    the path to fetch from the authorization JSON
+                                    (e.g. ''context.request.http.host'') or a string
+                                    template with variable placeholders that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!")
+                                    The following string modifiers are available:
+                                    @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower.'
                                   type: string
                               type: object
                           type: object
@@ -456,8 +519,15 @@ spec:
                             description: Dynamic value of the claim
                             properties:
                               authJSON:
-                                description: Selector to fill the value of claim from
-                                  the authorization JSON
+                                description: 'Selector to fill the value from the
+                                  authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The value can be just the pattern with
+                                  the path to fetch from the authorization JSON (e.g.
+                                  ''context.request.http.host'') or a string template
+                                  with variable placeholders that resolve to patterns
+                                  (e.g. "Hello, {auth.identity.name}!") The following
+                                  string modifiers are available: @extract:{sep:"
+                                  ",pos:0}, @replace{old:"",new:""}, @case:upper|lower.'
                                 type: string
                             type: object
                         required:
@@ -553,8 +623,17 @@ spec:
                                 description: Dynamic value of the claim
                                 properties:
                                   authJSON:
-                                    description: Selector to fill the value of claim
-                                      from the authorization JSON
+                                    description: 'Selector to fill the value from
+                                      the authorization JSON. Any patterns supported
+                                      by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The value can be just the pattern
+                                      with the path to fetch from the authorization
+                                      JSON (e.g. ''context.request.http.host'') or
+                                      a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                      The following string modifiers are available:
+                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      @case:upper|lower.'
                                     type: string
                                 type: object
                             required:
@@ -702,8 +781,17 @@ spec:
                                 description: Dynamic value of the claim
                                 properties:
                                   authJSON:
-                                    description: Selector to fill the value of claim
-                                      from the authorization JSON
+                                    description: 'Selector to fill the value from
+                                      the authorization JSON. Any patterns supported
+                                      by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The value can be just the pattern
+                                      with the path to fetch from the authorization
+                                      JSON (e.g. ''context.request.http.host'') or
+                                      a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                      The following string modifiers are available:
+                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      @case:upper|lower.'
                                     type: string
                                 type: object
                             required:
@@ -748,8 +836,17 @@ spec:
                                 description: Dynamic value of the claim
                                 properties:
                                   authJSON:
-                                    description: Selector to fill the value of claim
-                                      from the authorization JSON
+                                    description: 'Selector to fill the value from
+                                      the authorization JSON. Any patterns supported
+                                      by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The value can be just the pattern
+                                      with the path to fetch from the authorization
+                                      JSON (e.g. ''context.request.http.host'') or
+                                      a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                      The following string modifiers are available:
+                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      @case:upper|lower.'
                                     type: string
                                 type: object
                             required:


### PR DESCRIPTION
Modifies `valueFrom.authJSON` so values can be
a) any [gjson](https://pkg.go.dev/github.com/tidwall/gjson) pattern (as today), with the pattern representing a path to be fetched from the authorization JSON (e.g. `context.request.http.host`)
b) a string template with variable placeholders that resolve to patterns (e.g. `Hello, {auth.identity.name}!`)

Patterns (whether or not inside of variable placeholders) keep supporting the following custom modifiers as introduced in #154:
- `@extract:{sep:" ",pos:0}`
- `@replace{old:"",new:""}`
- `@case:upper|lower`

Examples:

```yaml
- name: ts
  valueFrom:
    authJSON: context.request.time.seconds
- name: username
  valueFrom:
    authJSON: auth.identity.metadata.annotations.authorino\.3scale\.net/username|@case:lower
- name: geeting-message
   valueFrom:
     authJSON: Hello, {auth.identity.metadata.annotations.authorino\.3scale\.net/name}!
```

Inspired by https://github.com/Kuadrant/authorino/pull/159#issuecomment-936601468