### PR TITLE
fixup: @base64 oas description for denyWith fields

### DIFF
--- a/install/crd/authorino.3scale.net_authconfigs.yaml
+++ b/install/crd/authorino.3scale.net_authconfigs.yaml
@@ -480,7 +480,7 @@ spec:
                                     to patterns (e.g. "Hello, {auth.identity.name}!")
                                     The following string modifiers are available:
                                     @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower.'
+                                    @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           required:
@@ -526,7 +526,7 @@ spec:
                                     to patterns (e.g. "Hello, {auth.identity.name}!")
                                     The following string modifiers are available:
                                     @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower.'
+                                    @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           required:


### PR DESCRIPTION
These two OAS property descriptions were missing on #159, due to non-conflicting yet affecting changes from #167 merged first.