### PR TITLE
`GenerationChangedPredicate` filter for the `AuthConfig`s controller

### DIFF
--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 // AuthConfigReconciler reconciles an AuthConfig object
@@ -459,6 +460,7 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 func (r *AuthConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&configv1beta1.AuthConfig{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }
 


### PR DESCRIPTION
It saves an extra (unnecessary) reconciliation of the resource following the status update.

**Applying an `AuthConfig` and an API key (`Secret`) to the cluster:**

Before:
```jsonc
{"level":"info","ts":1635335802.708245,"logger":"authorino.controller-runtime.manager.controller.authconfig.statusupdater","msg":"resource status updated","authconfig/status":"authorino/talker-api-protection"}
{"level":"info","ts":1635335802.7825952,"logger":"authorino.controller-runtime.manager.controller.secret","msg":"resource reconciled","secret":"authorino/friend-1-api-key-1"}
{"level":"info","ts":1635335802.7184775,"logger":"authorino.controller-runtime.manager.controller.authconfig","msg":"resource reconciled","authconfig":"authorino/talker-api-protection"}
{"level":"info","ts":1635335802.791392,"logger":"authorino.controller-runtime.manager.controller.authconfig","msg":"resource reconciled","authconfig":"authorino/talker-api-protection"}
{"level":"info","ts":1635335802.8048506,"logger":"authorino.controller-runtime.manager.controller.authconfig","msg":"resource reconciled","authconfig":"authorino/talker-api-protection"}
{"level":"info","ts":1635335802.8815923,"logger":"authorino.controller-runtime.manager.controller.authconfig.statusupdater","msg":"resource status updated","authconfig/status":"authorino/talker-api-protection"}
```

After:
```jsonc
{"level":"info","ts":1635336399.663593,"logger":"authorino.controller-runtime.manager.controller.authconfig.statusupdater","msg":"resource status updated","authconfig/status":"authorino/talker-api-protection"}
{"level":"info","ts":1635336399.6663103,"logger":"authorino.controller-runtime.manager.controller.authconfig","msg":"resource reconciled","authconfig":"authorino/talker-api-protection"}
{"level":"info","ts":1635336399.7019,"logger":"authorino.controller-runtime.manager.controller.authconfig.statusupdater","msg":"resource status updated","authconfig/status":"authorino/talker-api-protection"}
{"level":"info","ts":1635336399.7130542,"logger":"authorino.controller-runtime.manager.controller.secret","msg":"resource reconciled","secret":"authorino/friend-1-api-key-1"}
{"level":"info","ts":1635336399.7160325,"logger":"authorino.controller-runtime.manager.controller.authconfig","msg":"resource reconciled","authconfig":"authorino/talker-api-protection"}
```
