### PR TITLE
Custom headers option for HTTP external metadata requests

### DIFF
--- a/api/v1beta1/auth_config_types.go
+++ b/api/v1beta1/auth_config_types.go
@@ -217,6 +217,9 @@ type Metadata_GenericHTTP struct {
 	// Use it with method=POST; for GET requests, specify parameters using placeholders in the endpoint.
 	Parameters []JsonProperty `json:"bodyParameters,omitempty"`
 
+	// Custom headers in the HTTP request.
+	Headers []JsonProperty `json:"headers,omitempty"`
+
 	// Content-Type of the request body.
 	// +kubebuilder:default:=application/x-www-form-urlencoded
 	ContentType Metadata_GenericHTTP_ContentType `json:"contentType,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -582,6 +582,13 @@ func (in *Metadata_GenericHTTP) DeepCopyInto(out *Metadata_GenericHTTP) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Headers != nil {
+		in, out := &in.Headers, &out.Headers
+		*out = make([]JsonProperty, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.SharedSecret != nil {
 		in, out := &in.SharedSecret, &out.SharedSecret
 		*out = new(SecretKeyReference)

--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -234,10 +234,22 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 				})
 			}
 
+			headers := make([]common.JSONProperty, 0, len(genericHttp.Headers))
+			for _, header := range genericHttp.Headers {
+				headers = append(headers, common.JSONProperty{
+					Name: header.Name,
+					Value: common.JSONValue{
+						Static:  header.Value,
+						Pattern: header.ValueFrom.AuthJSON,
+					},
+				})
+			}
+
 			translatedMetadata.GenericHTTP = &authorinoMetadata.GenericHttp{
 				Endpoint:        genericHttp.Endpoint,
 				Method:          string(genericHttp.Method),
 				Parameters:      params,
+				Headers:         headers,
 				ContentType:     string(genericHttp.ContentType),
 				SharedSecret:    sharedSecret,
 				AuthCredentials: auth_credentials.NewAuthCredential(creds.KeySelector, string(creds.In)),

--- a/install/crd/authorino.3scale.net_authconfigs.yaml
+++ b/install/crd/authorino.3scale.net_authconfigs.yaml
@@ -782,6 +782,37 @@ spec:
                             where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
                             and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
                           type: string
+                        headers:
+                          description: Custom headers in the HTTP request.
+                          items:
+                            properties:
+                              name:
+                                description: The name of the claim
+                                type: string
+                              value:
+                                description: Static value of the claim
+                                x-kubernetes-preserve-unknown-fields: true
+                              valueFrom:
+                                description: Dynamic value of the claim
+                                properties:
+                                  authJSON:
+                                    description: 'Selector to fill the value from
+                                      the authorization JSON. Any patterns supported
+                                      by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The value can be just the pattern
+                                      with the path to fetch from the authorization
+                                      JSON (e.g. ''context.request.http.host'') or
+                                      a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                      The following string modifiers are available:
+                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      @case:upper|lower, and @base64:encode|decode.'
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
                         method:
                           description: 'HTTP verb used in the request to the service.
                             Accepted values: GET (default), POST. When the request

--- a/pkg/config/metadata/generic_http.go
+++ b/pkg/config/metadata/generic_http.go
@@ -18,6 +18,7 @@ type GenericHttp struct {
 	Endpoint     string
 	Method       string
 	Parameters   []common.JSONProperty
+	Headers      []common.JSONProperty
 	ContentType  string
 	SharedSecret string
 	auth_credentials.AuthCredentials
@@ -53,6 +54,10 @@ func (h *GenericHttp) Call(pipeline common.AuthPipeline, ctx context.Context) (i
 	req, err := h.BuildRequestWithCredentials(ctx, endpoint, method, h.SharedSecret, requestBody)
 	if err != nil {
 		return nil, err
+	}
+
+	for _, header := range h.Headers {
+		req.Header.Set(header.Name, fmt.Sprintf("%s", header.Value.ResolveFor(string(authData))))
 	}
 
 	req.Header.Set("Content-Type", contentType)


### PR DESCRIPTION
Extends the `AuthConfig` API with option to customize the headers of the HTTP request to external sources of metadata (Generic HTTP external metadata feature).

E.g.

```yaml
spec:
  metadata:
    - name: external-metadata
      http:
        endpoint: http://external-source.io/metadata
        headers:
          - name: X-Requested-By
            value: authorino
          - name: Authorization # overwritten if used in combination with `sharedSecretRef` and `credentials.in=authorization_header`
            valueFrom:
              authJSON: context.request.http.headers.authorization # reuses the same authn token to authenticate with the external metadata service
```

Closes #183