### PR TITLE
Priorities for the evaluator configs

### DIFF
--- a/api/v1beta1/auth_config_types.go
+++ b/api/v1beta1/auth_config_types.go
@@ -96,8 +96,13 @@ type Credentials struct {
 type Identity struct {
 	// The name of this identity source/authentication mode.
 	// It usually identifies a source of identities or group of users/clients of the protected service.
-	// It may as well be used for this identity config to be referred in some metadata configs.
+	// It can be used to refer to the resolved identity object in other configs.
 	Name string `json:"name"`
+
+	// Priority group of the config.
+	// All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+	// +kubebuilder:default:=0
+	Priority int `json:"priority,omitempty"`
 
 	// Defines where client credentials are required to be passed in the request for this identity source/authentication mode.
 	// If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the credentials value (token, API key, etc).
@@ -160,8 +165,13 @@ type Identity_KubernetesAuth struct {
 // Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "userInfo" or "uma".
 type Metadata struct {
 	// The name of the metadata source.
-	// Policies of te authorization phase can refer to this metadata by this value.
+	// It can be used to refer to the resolved identity object in other configs.
 	Name string `json:"name"`
+
+	// Priority group of the config.
+	// All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+	// +kubebuilder:default:=0
+	Priority int `json:"priority,omitempty"`
 
 	UserInfo    *Metadata_UserInfo    `json:"userInfo,omitempty"`
 	UMA         *Metadata_UMA         `json:"uma,omitempty"`
@@ -237,7 +247,13 @@ type Metadata_GenericHTTP struct {
 // Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "opa", "json" or "kubernetes".
 type Authorization struct {
 	// Name of the authorization policy.
+	// It can be used to refer to the resolved identity object in other configs.
 	Name string `json:"name"`
+
+	// Priority group of the config.
+	// All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+	// +kubebuilder:default:=0
+	Priority int `json:"priority,omitempty"`
 
 	OPA             *Authorization_OPA                 `json:"opa,omitempty"`
 	JSON            *Authorization_JSONPatternMatching `json:"json,omitempty"`
@@ -345,7 +361,14 @@ type Response_Wrapper string
 // Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "wristband" or "json".
 type Response struct {
 	// Name of the custom response.
+	// It can be used to refer to the resolved identity object in other configs.
 	Name string `json:"name"`
+
+	// Priority group of the config.
+	// All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+	// +kubebuilder:default:=0
+	Priority int `json:"priority,omitempty"`
+
 	// How Authorino wraps the response.
 	// Use "httpHeader" (default) to wrap the response in an HTTP header; or "envoyDynamicMetadata" to wrap the response as Envoy Dynamic Metadata
 	// +kubebuilder:default:=httpHeader

--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -119,6 +119,7 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 
 		translatedIdentity := &config.IdentityConfig{
 			Name:               identity.Name,
+			Priority:           identity.Priority,
 			ExtendedProperties: extendedProperties,
 		}
 
@@ -173,7 +174,8 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 
 	for _, metadata := range authConfig.Spec.Metadata {
 		translatedMetadata := &config.MetadataConfig{
-			Name: metadata.Name,
+			Name:     metadata.Name,
+			Priority: metadata.Priority,
 		}
 
 		switch metadata.GetType() {
@@ -269,7 +271,8 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 
 	for index, authorization := range authConfig.Spec.Authorization {
 		translatedAuthorization := &config.AuthorizationConfig{
-			Name: authorization.Name,
+			Name:     authorization.Name,
+			Priority: authorization.Priority,
 		}
 
 		switch authorization.GetType() {
@@ -373,7 +376,7 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 	interfacedResponseConfigs := make([]common.AuthConfigEvaluator, 0)
 
 	for _, response := range authConfig.Spec.Response {
-		translatedResponse := config.NewResponseConfig(response.Name, string(response.Wrapper), response.WrapperKey)
+		translatedResponse := config.NewResponseConfig(response.Name, response.Priority, string(response.Wrapper), response.WrapperKey)
 
 		switch response.GetType() {
 		// wristband

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,6 +98,7 @@ spec:
             value: GET
 
     - name: my-opa-policy
+      priority: 1 # optional - causes this policy to be evaluated after other policies of higher priority, where 0 is the highest and the default; can be used in configs of any phase (identity, metadata, authorization, response) to set priority of execution within the phase
       opa:
         inlineRego: |
           allow { true }
@@ -140,7 +141,7 @@ In each request to the protected API, Authorino triggers the so-called "Auth Pip
 - **(iii) Authorization phase:** all unskipped policies must evaluate to a positive result ("authorized"), or Authorino will otherwise reject the request as unauthorized (403 HTTP response code).
 - **(iv) Response phase** – Authorino builds all user-defined response items (dynamic JSON objects and/or _Festival Wristband_ OIDC tokens), which are supplied back to the external authorization client within added HTTP headers or as Envoy Dynamic Metadata
 
-Each phase is sequential to the other, from (i) to (iv), while the evaluators within each phase are triggered concurrently. The **Identity** phase (i) is the only one required to list at least one evaluator (i.e. one identity source or more); **Metadata**, **Authorization** and **Response** phases can have any number of evaluators (including zero, and even be omitted in this case).
+Each phase is sequential to the other, from (i) to (iv), while the evaluators within each phase are triggered concurrently or as prioritized. The **Identity** phase (i) is the only one required to list at least one evaluator (i.e. one identity source or more); **Metadata**, **Authorization** and **Response** phases can have any number of evaluators (including zero, and even be omitted in this case).
 
 ### The Authorization JSON
 

--- a/examples/priorities.yaml
+++ b/examples/priorities.yaml
@@ -1,0 +1,107 @@
+apiVersion: authorino.3scale.net/v1beta1
+kind: AuthConfig
+metadata:
+  name: talker-api-protection
+spec:
+  hosts:
+    - talker-api
+  identity:
+    - name: tier-1
+      priority: 0
+      apiKey:
+        labelSelectors:
+          tier: "1"
+    - name: tier-2
+      priority: 1
+      apiKey:
+        labelSelectors:
+          tier: "2"
+    - name: tier-3
+      priority: 1
+      apiKey:
+        labelSelectors:
+          tier: "3"
+  metadata:
+    - name: first
+      http:
+        endpoint: http://talker-api:3000
+        method: GET
+    - name: second
+      priority: 1
+      http:
+        endpoint: http://talker-api:3000/first_uuid={auth.metadata.first.uuid}
+        method: GET
+  authorization:
+    - name: allowed-endpoints
+      json:
+        conditions:
+          - selector: context.request.http.path
+            operator: neq
+            value: /hi
+          - selector: context.request.http.path
+            operator: neq
+            value: /hello
+          - selector: context.request.http.path
+            operator: neq
+            value: /aloha
+          - selector: context.request.http.path
+            operator: neq
+            value: /ciao
+        rules:
+          - selector: deny
+            operator: eq
+            value: "true"
+    - name: more-expensive-policy # no point in evaluating this one if it's not an allowed endpoint
+      priority: 1
+      opa:
+        inlineRego: |
+          allow { true }
+  response:
+    - name: x-auth-data
+      json:
+        properties:
+          - name: tier
+            valueFrom:
+              authJSON: auth.identity.metadata.labels.tier
+          - name: first-uuid
+            valueFrom:
+              authJSON: auth.metadata.first.uuid
+          - name: second-uuid
+            valueFrom:
+              authJSON: auth.metadata.second.uuid
+          - name: second-path
+            valueFrom:
+              authJSON: auth.metadata.second.path
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-key-1
+  labels:
+    authorino.3scale.net/managed-by: authorino
+    tier: "1"
+stringData:
+  api_key: ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-key-2
+  labels:
+    authorino.3scale.net/managed-by: authorino
+    tier: "2"
+stringData:
+  api_key: K10Z4oi9kjziUYfh4Ed8f5cFRnRa7Iqg
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-key-3
+  labels:
+    authorino.3scale.net/managed-by: authorino
+    tier: "3"
+stringData:
+  api_key: iu9ISOCMdOpDKov4eKNGSkhuZIuZC9Jj
+type: Opaque

--- a/examples/wristband.yaml
+++ b/examples/wristband.yaml
@@ -41,6 +41,7 @@ spec:
 
   authorization:
     - name: requires-pre-auth
+      priority: 0
       json:
         conditions:
           - selector: auth.identity.aud
@@ -51,16 +52,16 @@ spec:
             operator: eq
             value: /auth
     - name: rbac
+      priority: 1
       opa:
         inlineRego: |
-          identity := input.auth.identity
-          internal := identity.aud == "internal"
-          roles := object.get(identity, "roles", [])
+          path := input.context.request.http.path
+          pre_auth { path == "/auth" }
+          admin { input.auth.identity.roles[_] == "admin" }
 
-          admin { roles[_] == "admin" }
-          allow { not internal }
-          allow { internal; not admin; input.context.request.http.path != "/bye" }
-          allow { internal; admin }
+          allow { pre_auth }
+          allow { not pre_auth; admin }
+          allow { not pre_auth; not admin; path != "/bye" }
 
   response:
     - name: wristband

--- a/install/crd/authorino.3scale.net_authconfigs.yaml
+++ b/install/crd/authorino.3scale.net_authconfigs.yaml
@@ -362,7 +362,8 @@ spec:
                       - user
                       type: object
                     name:
-                      description: Name of the authorization policy.
+                      description: Name of the authorization policy. It can be used
+                        to refer to the resolved identity object in other configs.
                       type: string
                     opa:
                       description: Open Policy Agent (OPA) authorization policy.
@@ -437,6 +438,12 @@ spec:
                             NOT include the "package" declaration in line 1.
                           type: string
                       type: object
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
+                      type: integer
                   required:
                   - name
                   type: object
@@ -647,9 +654,8 @@ spec:
                     name:
                       description: The name of this identity source/authentication
                         mode. It usually identifies a source of identities or group
-                        of users/clients of the protected service. It may as well
-                        be used for this identity config to be referred in some metadata
-                        configs.
+                        of users/clients of the protected service. It can be used
+                        to refer to the resolved identity object in other configs.
                       type: string
                     oauth2:
                       properties:
@@ -689,6 +695,12 @@ spec:
                       required:
                       - endpoint
                       type: object
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
+                      type: integer
                   required:
                   - name
                   type: object
@@ -844,9 +856,15 @@ spec:
                       - endpoint
                       type: object
                     name:
-                      description: The name of the metadata source. Policies of te
-                        authorization phase can refer to this metadata by this value.
+                      description: The name of the metadata source. It can be used
+                        to refer to the resolved identity object in other configs.
                       type: string
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
+                      type: integer
                     uma:
                       description: User-Managed Access (UMA) source of resource data.
                       properties:
@@ -931,8 +949,15 @@ spec:
                       - properties
                       type: object
                     name:
-                      description: Name of the custom response.
+                      description: Name of the custom response. It can be used to
+                        refer to the resolved identity object in other configs.
                       type: string
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
+                      type: integer
                     wrapper:
                       default: httpHeader
                       description: How Authorino wraps the response. Use "httpHeader"

--- a/pkg/common/auth.go
+++ b/pkg/common/auth.go
@@ -32,6 +32,10 @@ type NamedConfigEvaluator interface {
 	GetName() string
 }
 
+type Prioritizable interface {
+	GetPriority() int
+}
+
 type IdentityConfigEvaluator interface {
 	GetAuthCredentials() auth_credentials.AuthCredentials
 	GetOIDC() interface{}

--- a/pkg/common/auth.go
+++ b/pkg/common/auth.go
@@ -18,9 +18,7 @@ type AuthPipeline interface {
 	GetHttp() *envoy_auth.AttributeContext_HttpRequest
 	GetAPI() interface{}
 	GetResolvedIdentity() (interface{}, interface{})
-	GetResolvedMetadata() map[interface{}]interface{}
-	GetDataForAuthorization() interface{}
-	GetPostAuthorizationData() interface{}
+	GetAuthorizationJSON() string
 }
 
 // AuthConfigEvaluator interface represents the configuration pieces of Identity, Metadata and Authorization

--- a/pkg/common/mocks/mock_common.go
+++ b/pkg/common/mocks/mock_common.go
@@ -67,18 +67,18 @@ func (mr *MockAuthPipelineMockRecorder) GetAPI() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPI", reflect.TypeOf((*MockAuthPipeline)(nil).GetAPI))
 }
 
-// GetDataForAuthorization mocks base method.
-func (m *MockAuthPipeline) GetDataForAuthorization() interface{} {
+// GetAuthorizationJSON mocks base method.
+func (m *MockAuthPipeline) GetAuthorizationJSON() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDataForAuthorization")
-	ret0, _ := ret[0].(interface{})
+	ret := m.ctrl.Call(m, "GetAuthorizationJSON")
+	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-// GetDataForAuthorization indicates an expected call of GetDataForAuthorization.
-func (mr *MockAuthPipelineMockRecorder) GetDataForAuthorization() *gomock.Call {
+// GetAuthorizationJSON indicates an expected call of GetAuthorizationJSON.
+func (mr *MockAuthPipelineMockRecorder) GetAuthorizationJSON() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataForAuthorization", reflect.TypeOf((*MockAuthPipeline)(nil).GetDataForAuthorization))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthorizationJSON", reflect.TypeOf((*MockAuthPipeline)(nil).GetAuthorizationJSON))
 }
 
 // GetHttp mocks base method.
@@ -93,20 +93,6 @@ func (m *MockAuthPipeline) GetHttp() *envoy_service_auth_v3.AttributeContext_Htt
 func (mr *MockAuthPipelineMockRecorder) GetHttp() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHttp", reflect.TypeOf((*MockAuthPipeline)(nil).GetHttp))
-}
-
-// GetPostAuthorizationData mocks base method.
-func (m *MockAuthPipeline) GetPostAuthorizationData() interface{} {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPostAuthorizationData")
-	ret0, _ := ret[0].(interface{})
-	return ret0
-}
-
-// GetPostAuthorizationData indicates an expected call of GetPostAuthorizationData.
-func (mr *MockAuthPipelineMockRecorder) GetPostAuthorizationData() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPostAuthorizationData", reflect.TypeOf((*MockAuthPipeline)(nil).GetPostAuthorizationData))
 }
 
 // GetRequest mocks base method.
@@ -136,20 +122,6 @@ func (m *MockAuthPipeline) GetResolvedIdentity() (interface{}, interface{}) {
 func (mr *MockAuthPipelineMockRecorder) GetResolvedIdentity() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResolvedIdentity", reflect.TypeOf((*MockAuthPipeline)(nil).GetResolvedIdentity))
-}
-
-// GetResolvedMetadata mocks base method.
-func (m *MockAuthPipeline) GetResolvedMetadata() map[interface{}]interface{} {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetResolvedMetadata")
-	ret0, _ := ret[0].(map[interface{}]interface{})
-	return ret0
-}
-
-// GetResolvedMetadata indicates an expected call of GetResolvedMetadata.
-func (mr *MockAuthPipelineMockRecorder) GetResolvedMetadata() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResolvedMetadata", reflect.TypeOf((*MockAuthPipeline)(nil).GetResolvedMetadata))
 }
 
 // MockAuthConfigEvaluator is a mock of AuthConfigEvaluator interface.

--- a/pkg/common/mocks/mock_common.go
+++ b/pkg/common/mocks/mock_common.go
@@ -227,6 +227,43 @@ func (mr *MockNamedConfigEvaluatorMockRecorder) GetName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockNamedConfigEvaluator)(nil).GetName))
 }
 
+// MockPrioritizable is a mock of Prioritizable interface.
+type MockPrioritizable struct {
+	ctrl     *gomock.Controller
+	recorder *MockPrioritizableMockRecorder
+}
+
+// MockPrioritizableMockRecorder is the mock recorder for MockPrioritizable.
+type MockPrioritizableMockRecorder struct {
+	mock *MockPrioritizable
+}
+
+// NewMockPrioritizable creates a new mock instance.
+func NewMockPrioritizable(ctrl *gomock.Controller) *MockPrioritizable {
+	mock := &MockPrioritizable{ctrl: ctrl}
+	mock.recorder = &MockPrioritizableMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockPrioritizable) EXPECT() *MockPrioritizableMockRecorder {
+	return m.recorder
+}
+
+// GetPriority mocks base method.
+func (m *MockPrioritizable) GetPriority() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPriority")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetPriority indicates an expected call of GetPriority.
+func (mr *MockPrioritizableMockRecorder) GetPriority() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPriority", reflect.TypeOf((*MockPrioritizable)(nil).GetPriority))
+}
+
 // MockIdentityConfigEvaluator is a mock of IdentityConfigEvaluator interface.
 type MockIdentityConfigEvaluator struct {
 	ctrl     *gomock.Controller

--- a/pkg/config/authorization.go
+++ b/pkg/config/authorization.go
@@ -11,6 +11,7 @@ import (
 
 type AuthorizationConfig struct {
 	Name            string                             `yaml:"name"`
+	Priority        int                                `yaml:"priority"`
 	OPA             *authorization.OPA                 `yaml:"opa,omitempty"`
 	JSON            *authorization.JSONPatternMatching `yaml:"json,omitempty"`
 	KubernetesAuthz *authorization.KubernetesAuthz     `yaml:"kubernetes,omitempty"`
@@ -32,4 +33,10 @@ func (config *AuthorizationConfig) Call(pipeline common.AuthPipeline, parentCtx 
 	default:
 		return false, fmt.Errorf("invalid authorization config")
 	}
+}
+
+// impl:Prioritizable
+
+func (config *AuthorizationConfig) GetPriority() int {
+	return config.Priority
 }

--- a/pkg/config/authorization/json.go
+++ b/pkg/config/authorization/json.go
@@ -2,7 +2,6 @@ package authorization
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/kuadrant/authorino/pkg/common"
@@ -14,12 +13,10 @@ type JSONPatternMatching struct {
 }
 
 func (jsonAuth *JSONPatternMatching) Call(pipeline common.AuthPipeline, ctx context.Context) (bool, error) {
-	data := pipeline.GetDataForAuthorization()
-	dataJSON, _ := json.Marshal(data)
-	dataStr := string(dataJSON)
+	authJSON := pipeline.GetAuthorizationJSON()
 
 	for _, condition := range jsonAuth.Conditions {
-		if match, err := condition.EvaluateFor(dataStr); err != nil {
+		if match, err := condition.EvaluateFor(authJSON); err != nil {
 			return false, err
 		} else if !match { // skip the policy if any of the conditions does not match
 			return true, nil
@@ -27,7 +24,7 @@ func (jsonAuth *JSONPatternMatching) Call(pipeline common.AuthPipeline, ctx cont
 	}
 
 	for _, rule := range jsonAuth.Rules {
-		if authorized, err := rule.EvaluateFor(dataStr); err != nil {
+		if authorized, err := rule.EvaluateFor(authJSON); err != nil {
 			return false, err
 		} else if !authorized {
 			return false, fmt.Errorf(unauthorizedErrorMsg)

--- a/pkg/config/authorization/json_test.go
+++ b/pkg/config/authorization/json_test.go
@@ -1,6 +1,7 @@
 package authorization
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/kuadrant/authorino/pkg/common"
@@ -15,11 +16,12 @@ func TestCall(t *testing.T) {
 	ctrl := NewController(t)
 	defer ctrl.Finish()
 
-	type authorizationData struct {
+	type authorizationJSON struct {
 		Context  *envoy_auth.AttributeContext `json:"context"`
 		AuthData map[string]interface{}       `json:"auth"`
 	}
-	dataForAuthorization := &authorizationData{
+
+	authJSON, _ := json.Marshal(&authorizationJSON{
 		Context: &envoy_auth.AttributeContext{
 			Request: &envoy_auth.AttributeContext_Request{
 				Http: &envoy_auth.AttributeContext_HttpRequest{
@@ -36,10 +38,10 @@ func TestCall(t *testing.T) {
 				"letters": {"a", "b", "c"},
 			},
 		},
-	}
+	})
 
 	pipelineMock := mock_common.NewMockAuthPipeline(ctrl)
-	pipelineMock.EXPECT().GetDataForAuthorization().Return(dataForAuthorization).AnyTimes()
+	pipelineMock.EXPECT().GetAuthorizationJSON().Return(string(authJSON)).AnyTimes()
 
 	var (
 		jsonAuth   *JSONPatternMatching

--- a/pkg/config/authorization/kubernetes_authz_test.go
+++ b/pkg/config/authorization/kubernetes_authz_test.go
@@ -2,7 +2,6 @@ package authorization
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/kuadrant/authorino/pkg/common"
@@ -76,10 +75,7 @@ func TestKubernetesAuthzNonResource_Allowed(t *testing.T) {
 	defer ctrl.Finish()
 
 	pipelineMock := mock_common.NewMockAuthPipeline(ctrl)
-
-	var authData interface{}
-	_ = json.Unmarshal([]byte(`{"context":{"request":{"http":{"method":"GET","path":"/hello"}}},"auth":{"identity":{"username":"john"}}}`), &authData)
-	pipelineMock.EXPECT().GetDataForAuthorization().Return(authData)
+	pipelineMock.EXPECT().GetAuthorizationJSON().Return(`{"context":{"request":{"http":{"method":"GET","path":"/hello"}}},"auth":{"identity":{"username":"john"}}}`)
 
 	request := &envoy_auth.AttributeContext_HttpRequest{Method: "GET", Path: "/hello"}
 	pipelineMock.EXPECT().GetHttp().Return(request)
@@ -108,10 +104,7 @@ func TestKubernetesAuthzNonResource_Denied(t *testing.T) {
 	defer ctrl.Finish()
 
 	pipelineMock := mock_common.NewMockAuthPipeline(ctrl)
-
-	var authData interface{}
-	_ = json.Unmarshal([]byte(`{"context":{"request":{"http":{"method":"GET","path":"/hello"}}},"auth":{"identity":{"username":"john"}}}`), &authData)
-	pipelineMock.EXPECT().GetDataForAuthorization().Return(authData)
+	pipelineMock.EXPECT().GetAuthorizationJSON().Return(`{"context":{"request":{"http":{"method":"GET","path":"/hello"}}},"auth":{"identity":{"username":"john"}}}`)
 
 	request := &envoy_auth.AttributeContext_HttpRequest{Method: "GET", Path: "/hello"}
 	pipelineMock.EXPECT().GetHttp().Return(request)
@@ -140,10 +133,7 @@ func TestKubernetesAuthzResource_Allowed(t *testing.T) {
 	defer ctrl.Finish()
 
 	pipelineMock := mock_common.NewMockAuthPipeline(ctrl)
-
-	var authData interface{}
-	_ = json.Unmarshal([]byte(`{"context":{"request":{"http":{"method":"GET","path":"/hello"}}},"auth":{"identity":{"username":"john"}}}`), &authData)
-	pipelineMock.EXPECT().GetDataForAuthorization().Return(authData)
+	pipelineMock.EXPECT().GetAuthorizationJSON().Return(`{"context":{"request":{"http":{"method":"GET","path":"/hello"}}},"auth":{"identity":{"username":"john"}}}`)
 
 	kubernetesAuth := newKubernetesAuthz(
 		[]common.JSONPatternMatchingRule{},
@@ -168,10 +158,7 @@ func TestKubernetesAuthzResource_Denied(t *testing.T) {
 	defer ctrl.Finish()
 
 	pipelineMock := mock_common.NewMockAuthPipeline(ctrl)
-
-	var authData interface{}
-	_ = json.Unmarshal([]byte(`{"context":{"request":{"http":{"method":"GET","path":"/hello"}}},"auth":{"identity":{"username":"john"}}}`), &authData)
-	pipelineMock.EXPECT().GetDataForAuthorization().Return(authData)
+	pipelineMock.EXPECT().GetAuthorizationJSON().Return(`{"context":{"request":{"http":{"method":"GET","path":"/hello"}}},"auth":{"identity":{"username":"john"}}}`)
 
 	kubernetesAuth := newKubernetesAuthz(
 		[]common.JSONPatternMatchingRule{},
@@ -196,10 +183,7 @@ func TestKubernetesAuthzWithConditions(t *testing.T) {
 	defer ctrl.Finish()
 
 	pipelineMock := mock_common.NewMockAuthPipeline(ctrl)
-
-	var authData interface{}
-	_ = json.Unmarshal([]byte(`{"context":{"request":{"http":{"method":"GET","path":"/hello"}}},"auth":{"identity":{"username":"john"}}}`), &authData)
-	pipelineMock.EXPECT().GetDataForAuthorization().Return(authData)
+	pipelineMock.EXPECT().GetAuthorizationJSON().Return(`{"context":{"request":{"http":{"method":"GET","path":"/hello"}}},"auth":{"identity":{"username":"john"}}}`)
 
 	kubernetesAuth := newKubernetesAuthz(
 		[]common.JSONPatternMatchingRule{

--- a/pkg/config/identity.go
+++ b/pkg/config/identity.go
@@ -90,11 +90,10 @@ func (config *IdentityConfig) ResolveExtendedProperties(pipeline common.AuthPipe
 		return nil, err
 	}
 
-	authDataObj := pipeline.GetDataForAuthorization()
-	authJSON, _ := json.Marshal(authDataObj)
+	authJSON := pipeline.GetAuthorizationJSON()
 
 	for _, extendedProperty := range config.ExtendedProperties {
-		extendedIdentityObject[extendedProperty.Name] = extendedProperty.Value.ResolveFor(string(authJSON))
+		extendedIdentityObject[extendedProperty.Name] = extendedProperty.Value.ResolveFor(authJSON)
 	}
 
 	return extendedIdentityObject, nil

--- a/pkg/config/identity.go
+++ b/pkg/config/identity.go
@@ -16,6 +16,7 @@ import (
 
 type IdentityConfig struct {
 	Name               string                `yaml:"name"`
+	Priority           int                   `yaml:"priority"`
 	ExtendedProperties []common.JSONProperty `yaml:"extendedProperties"`
 
 	OAuth2         *identity.OAuth2         `yaml:"oauth2,omitempty"`
@@ -54,6 +55,12 @@ func (config *IdentityConfig) Call(pipeline common.AuthPipeline, ctx context.Con
 	} else {
 		return nil, fmt.Errorf("invalid identity config")
 	}
+}
+
+// impl:Prioritizable
+
+func (config *IdentityConfig) GetPriority() int {
+	return config.Priority
 }
 
 // impl:IdentityConfigEvaluator

--- a/pkg/config/identity_test.go
+++ b/pkg/config/identity_test.go
@@ -21,7 +21,6 @@ func TestIdentityConfig_ResolveExtendedProperties(t *testing.T) {
 	var identityConfig IdentityConfig
 	var identityObject interface{}
 	var extendedIdentityObject interface{}
-	var authData interface{}
 	var err error
 
 	// Without extended properties
@@ -48,9 +47,7 @@ func TestIdentityConfig_ResolveExtendedProperties(t *testing.T) {
 	}
 
 	pipelineMock.EXPECT().GetResolvedIdentity().Return(nil, identityObject)
-
-	_ = json.Unmarshal([]byte(`{"context":{},"auth":{"identity":{"sub":"foo","exp":1629884250}}}`), &authData)
-	pipelineMock.EXPECT().GetDataForAuthorization().Return(authData)
+	pipelineMock.EXPECT().GetAuthorizationJSON().Return(`{"context":{},"auth":{"identity":{"sub":"foo","exp":1629884250}}}`)
 
 	extendedIdentityObject, err = identityConfig.ResolveExtendedProperties(pipelineMock)
 	assert.NilError(t, err)

--- a/pkg/config/metadata.go
+++ b/pkg/config/metadata.go
@@ -17,6 +17,7 @@ const (
 
 type MetadataConfig struct {
 	Name        string                `yaml:"name"`
+	Priority    int                   `yaml:"priority"`
 	UserInfo    *metadata.UserInfo    `yaml:"userinfo,omitempty"`
 	UMA         *metadata.UMA         `yaml:"uma,omitempty"`
 	GenericHTTP *metadata.GenericHttp `yaml:"http,omitempty"`
@@ -64,4 +65,10 @@ func (config *MetadataConfig) Call(pipeline common.AuthPipeline, ctx context.Con
 
 func (config *MetadataConfig) GetName() string {
 	return config.Name
+}
+
+// impl:Prioritizable
+
+func (config *MetadataConfig) GetPriority() int {
+	return config.Priority
 }

--- a/pkg/config/metadata/generic_http.go
+++ b/pkg/config/metadata/generic_http.go
@@ -29,8 +29,8 @@ func (h *GenericHttp) Call(pipeline common.AuthPipeline, ctx context.Context) (i
 		return nil, err
 	}
 
-	authData, _ := json.Marshal(pipeline.GetDataForAuthorization())
-	endpoint := common.ReplaceJSONPlaceholders(h.Endpoint, string(authData))
+	authJSON := pipeline.GetAuthorizationJSON()
+	endpoint := common.ReplaceJSONPlaceholders(h.Endpoint, authJSON)
 
 	var requestBody io.Reader
 	var contentType string
@@ -43,7 +43,7 @@ func (h *GenericHttp) Call(pipeline common.AuthPipeline, ctx context.Context) (i
 	case "POST":
 		var err error
 		contentType = h.ContentType
-		requestBody, err = h.buildRequestBody(string(authData))
+		requestBody, err = h.buildRequestBody(authJSON)
 		if err != nil {
 			return nil, err
 		}
@@ -57,7 +57,7 @@ func (h *GenericHttp) Call(pipeline common.AuthPipeline, ctx context.Context) (i
 	}
 
 	for _, header := range h.Headers {
-		req.Header.Set(header.Name, fmt.Sprintf("%s", header.Value.ResolveFor(string(authData))))
+		req.Header.Set(header.Name, fmt.Sprintf("%s", header.Value.ResolveFor(authJSON)))
 	}
 
 	req.Header.Set("Content-Type", contentType)

--- a/pkg/config/response.go
+++ b/pkg/config/response.go
@@ -19,9 +19,10 @@ const (
 	DEFAULT_WRAPPER = HTTP_HEADER_WRAPPER
 )
 
-func NewResponseConfig(name string, wrapper string, wrapperKey string) *ResponseConfig {
+func NewResponseConfig(name string, priority int, wrapper string, wrapperKey string) *ResponseConfig {
 	responseConfig := ResponseConfig{
 		Name:       name,
+		Priority:   priority,
 		Wrapper:    DEFAULT_WRAPPER,
 		WrapperKey: name,
 	}
@@ -39,6 +40,7 @@ func NewResponseConfig(name string, wrapper string, wrapperKey string) *Response
 
 type ResponseConfig struct {
 	Name       string `yaml:"name"`
+	Priority   int    `yaml:"priority"`
 	Wrapper    string `yaml:"wrapper"`
 	WrapperKey string `yaml:"wrapperKey"`
 
@@ -84,6 +86,12 @@ func (config *ResponseConfig) Call(pipeline common.AuthPipeline, ctx context.Con
 
 func (config *ResponseConfig) GetName() string {
 	return config.Name
+}
+
+// impl:Prioritizable
+
+func (config *ResponseConfig) GetPriority() int {
+	return config.Priority
 }
 
 // impl:ResponseConfigEvaluator

--- a/pkg/config/response/dynamic_json.go
+++ b/pkg/config/response/dynamic_json.go
@@ -2,7 +2,6 @@ package response
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/kuadrant/authorino/pkg/common"
 )
@@ -20,8 +19,7 @@ type DynamicJSON struct {
 func (j *DynamicJSON) Call(pipeline common.AuthPipeline, ctx context.Context) (interface{}, error) {
 	obj := make(map[string]interface{})
 
-	authData, _ := json.Marshal(pipeline.GetPostAuthorizationData())
-	authJSON := string(authData)
+	authJSON := pipeline.GetAuthorizationJSON()
 
 	for _, property := range j.Properties {
 		value := property.Value

--- a/pkg/config/response/dynamic_json_test.go
+++ b/pkg/config/response/dynamic_json_test.go
@@ -31,11 +31,8 @@ func TestDynamicJSONCall(t *testing.T) {
 		} `json:"auth"`
 	}
 
-	var data authData
-	_ = json.Unmarshal([]byte(`{"auth":{"identity":{"username":"john"}}}`), &data)
-
 	pipelineMock := mock_common.NewMockAuthPipeline(ctrl)
-	pipelineMock.EXPECT().GetPostAuthorizationData().Return(data)
+	pipelineMock.EXPECT().GetAuthorizationJSON().Return(`{"auth":{"identity":{"username":"john"}}}`)
 
 	response, err := jsonResponseEvaluator.Call(pipelineMock, context.TODO())
 	responseJSON, _ := json.Marshal(response)

--- a/pkg/config/response/wristband.go
+++ b/pkg/config/response/wristband.go
@@ -115,8 +115,7 @@ func (w *Wristband) Call(pipeline common.AuthPipeline, ctx context.Context) (int
 	}
 
 	if len(w.CustomClaims) > 0 {
-		authData, _ := json.Marshal(pipeline.GetPostAuthorizationData())
-		authJSON := string(authData)
+		authJSON := pipeline.GetAuthorizationJSON()
 
 		for _, claim := range w.CustomClaims {
 			value := claim.Value

--- a/pkg/service/auth_pipeline_test.go
+++ b/pkg/service/auth_pipeline_test.go
@@ -298,19 +298,14 @@ func TestEvaluateAnyAuthConfigsWithoutError(t *testing.T) {
 	assert.NilError(t, err)
 }
 
-func TestGetDataForAuthorization(t *testing.T) {
+func TestAuthPipelineGetAuthorizationJSON(t *testing.T) {
 	pipeline := newTestAuthPipeline(config.APIConfig{
 		IdentityConfigs: []common.AuthConfigEvaluator{&successConfig{}, &successConfig{}},
 	}, &requestMock)
 
-	data := pipeline.GetDataForAuthorization()
-	if dataJSON, err := json.Marshal(&data); err != nil {
-		t.Error(err)
-	} else {
-		requestJSON, _ := json.Marshal(requestMock.GetAttributes())
-		expectedJSON := fmt.Sprintf(`{"context":%s,"auth":{"identity":null,"metadata":{}}}`, requestJSON)
-		assert.Equal(t, expectedJSON, string(dataJSON))
-	}
+	requestJSON, _ := json.Marshal(requestMock.GetAttributes())
+	expectedJSON := fmt.Sprintf(`{"context":%s,"auth":{"authorization":{},"identity":null,"metadata":{},"response":{}}}`, requestJSON)
+	assert.Equal(t, pipeline.GetAuthorizationJSON(), expectedJSON)
 }
 
 func TestEvaluateWithCustomDenyOptions(t *testing.T) {


### PR DESCRIPTION
_Priorities_ allow to set sequence of execution for blocks of concurrent evaluators within phases of the Auth Pipeline.

Evaluators of same priority execute concurrently to each other "in a block". After syncing that block (i.e. after all evaluators of the block have returned), the next block of evaluator configs of consecutive priority is triggered.

Use cases for priorities are:
1. Saving expensive tasks to be triggered when there's a high chance of returning immediately after finishing executing a less expensive one – e.g.
    - an identity config that calls an external IdP to verify a token that is rarely used, compared to verifying JWTs preferred by most users of the service;
    - an authorization policy that performs some quick checks first, such as verifying allowed paths, and only if it passes, moves to the evaluation of a more expensive policy.
2. Establishing dependencies between evaluators - e.g.
    - an external metadata request that needs to wait until a previous metadata responds first (in order to use data from the response)

Closes #184

----

**Example:**

```yaml
apiVersion: authorino.3scale.net/v1beta1
kind: AuthConfig
metadata:
  name: talker-api-protection
spec:
  hosts:
    - talker-api
  identity:
    - name: tier-1
      priority: 0
      apiKey:
        labelSelectors:
          tier: "1"
    - name: tier-2
      priority: 1
      apiKey:
        labelSelectors:
          tier: "2"
    - name: tier-3
      priority: 1
      apiKey:
        labelSelectors:
          tier: "3"
  metadata:
    - name: first
      http:
        endpoint: http://talker-api:3000
        method: GET
    - name: second
      priority: 1
      http:
        endpoint: http://talker-api:3000/first_uuid={auth.metadata.first.uuid}
        method: GET
  authorization:
    - name: allowed-endpoints
      json:
        conditions:
          - selector: context.request.http.path
            operator: neq
            value: /hi
          - selector: context.request.http.path
            operator: neq
            value: /hello
          - selector: context.request.http.path
            operator: neq
            value: /aloha
          - selector: context.request.http.path
            operator: neq
            value: /ciao
        rules:
          - selector: deny
            operator: eq
            value: "true"
    - name: more-expensive-policy # no point in evaluating this one if it's not an allowed endpoint
      priority: 1
      opa:
        inlineRego: |
          allow { true }
  response:
    - name: x-auth-data
      json:
        properties:
          - name: tier
            valueFrom:
              authJSON: auth.identity.metadata.labels.tier
          - name: first-uuid
            valueFrom:
              authJSON: auth.metadata.first.uuid
          - name: second-uuid
            valueFrom:
              authJSON: auth.metadata.second.uuid
          - name: second-path
            valueFrom:
              authJSON: auth.metadata.second.path
```

Identity configs `tier-2` and `tier-3` (priority 1) will only trigger (concurrently) in case `tier-1` (priority 0) fails to validate the authentication token first. (The implementation is without perjudice of context canceling between concurrent evaluators – i.e. evaluators that are triggered concurrently to another, such as `tier-2` and `tier-3`, continue to cancel the context shared between them if any succeeds validating the token first.)

Metadata source `second` (priority 1) uses the response of the request issued by metadata source `first` (priority 0), so it will wait for `first` to finish by triggering only in the second block.

Authorization policy `allowed-endpoints` (piority 0) is considered to be a lot less expensive than `more-expensive-policy` (priority 1) and has a high chance of denying access to the protected service (if the path is not one of the allowed endpoints). By setting different priorities to these policies we ensure the more expensive policy if triggered in sequence of the less expensive one, instead of concurrently.

----
**TODOs**

- [x] Extend the API with a `spec.(identity|metadata|authorization|response).priority: integer` field
- [x] Refactor `AuthPipeline.GetDataForAuthorization()` and `AuthPipeline.GetPostAuthorizationData()` merging these functions into one `AuthPipeline.GetAuthorizationJSON() => { context, auth: { identity, metadata, authorization, response } }` - so priorities make sense for the response phase as well
- [x] Tests
- [x] Docs