### PR TITLE
Fix name of AuthConfig editor/viewer roles

### DIFF
--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -1107,7 +1107,7 @@ status:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: authorino-editor-role
+  name: authorino-authconfig-editor-role
 rules:
 - apiGroups:
   - authorino.3scale.net
@@ -1120,6 +1120,26 @@ rules:
   - list
   - patch
   - update
+- apiGroups:
+  - authorino.3scale.net
+  resources:
+  - authconfigs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-authconfig-viewer-role
+rules:
+- apiGroups:
+  - authorino.3scale.net
+  resources:
+  - authconfigs
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - authorino.3scale.net
   resources:
@@ -1210,23 +1230,3 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: authorino-viewer-role
-rules:
-- apiGroups:
-  - authorino.3scale.net
-  resources:
-  - authconfigs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - authorino.3scale.net
-  resources:
-  - authconfigs/status
-  verbs:
-  - get

--- a/install/rbac/auth_config_editor_role.yaml
+++ b/install/rbac/auth_config_editor_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: editor-role
+  name: authconfig-editor-role
 rules:
 - apiGroups:
   - authorino.3scale.net

--- a/install/rbac/auth_config_viewer_role.yaml
+++ b/install/rbac/auth_config_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: viewer-role
+  name: authconfig-viewer-role
 rules:
 - apiGroups:
   - authorino.3scale.net


### PR DESCRIPTION
Rename `authorino-(editor|viewer)-role` => `authorino-authconfig-(editor|viewer)-role`, so they won't collide with operator's homonimous roles associated to the `Authorino` crd.

Related to #189 and  https://github.com/Kuadrant/authorino-operator/pull/1#discussion_r750634235.