### PR TITLE
OAuth2 Token Introspection authentication rejects inactive tokens

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -454,7 +454,7 @@ curl -H "Content-Type: application/x-www-form-urlencoded" -d "refresh_token=$REF
 Send another request:
 
 ```sh
-curl -H 'Host: talker-api' -H "Authorization: Bearer $ACCESS_TOKEN" http://localhost:8000/hello # 403
+curl -H 'Host: talker-api' -H "Authorization: Bearer $ACCESS_TOKEN" http://localhost:8000/hello # 401
 ```
 
 ----

--- a/examples/simple-oauth2.yaml
+++ b/examples/simple-oauth2.yaml
@@ -12,13 +12,6 @@ spec:
         tokenTypeHint: requesting_party_token
         credentialsRef:
           name: oauth2-token-introspection-credentials
-  authorization:
-    - name: active-access-tokens-only
-      json:
-        rules:
-          - selector: "auth.identity.active"
-            operator: eq
-            value: "true"
 ---
 apiVersion: v1
 kind: Secret

--- a/pkg/config/identity/oauth2.go
+++ b/pkg/config/identity/oauth2.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -78,6 +79,10 @@ func (oauth *OAuth2) Call(pipeline common.AuthPipeline, ctx context.Context) (in
 	if err := json.NewDecoder(resp.Body).Decode(&claims); err != nil {
 		return nil, err
 	} else {
-		return claims, nil
+		if claims["active"].(bool) {
+			return claims, nil
+		} else {
+			return nil, fmt.Errorf("token is not active")
+		}
 	}
 }

--- a/pkg/config/identity/oauth2_test.go
+++ b/pkg/config/identity/oauth2_test.go
@@ -43,10 +43,8 @@ func TestOAuth2Call(t *testing.T) {
 
 	{
 		oauthEvaluator := NewOAuth2Identity(fmt.Sprintf("http://%v/introspect-inactive", oauthServerHost), "access_token", "client-id", "client-secret", authCredMock)
-		obj, err := oauthEvaluator.Call(pipelineMock, ctx)
-		assert.NilError(t, err)
-		claims := obj.(map[string]interface{})
-		assert.Assert(t, claims["active"] == false)
+		_, err := oauthEvaluator.Call(pipelineMock, ctx)
+		assert.Error(t, err, "token is not active")
 	}
 }
 


### PR DESCRIPTION
Makes Authorino’s OAuth2 token introspection authentication method to reject access tokens that are inactive. This was originally left to be implemented via authorization policy added to the `AuthConfig`. However, to be fully compliant with [RFC 7662](https://tools.ietf.org/html/rfc7662), inactive tokens should be rejected right in the identity verification step by default.

### Try this change

Start the cluster:
```sh
kind create cluster --name authorino-trial
```

Create the namespace:
```sh
kubectl create namespace authorino
```

Deploy Keycloak:
```sh
kubectl -n authorino apply -f https://raw.githubusercontent.com/kuadrant/authorino-examples/main/keycloak/keycloak-deploy.yaml
echo '127.0.0.1 keycloak' >> /etc/hosts
```

Forward local requests to the instance of Keycloak running in the cluster:
```sh
kubectl -n authorino port-forward deployment/keycloak 8080:8080 &
```

Deploy the Talker API:
```sh
kubectl -n authorino apply -f https://raw.githubusercontent.com/kuadrant/authorino-examples/main/talker-api/talker-api-deploy.yaml
```

Build an image of Authorino based on this branch and push it to the cluster’s registry:
```sh
make docker-build AUTHORINO_IMAGE=authorino:local
kind load docker-image authorino:local --name authorino-trial
```

Deploy Authorino with the Authorino Operator:
```sh
git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
kubectl create namespace authorino-operator && make install deploy
kubectl -n authorino apply -f -<<EOF
apiVersion: operator.authorino.kuadrant.io/v1beta1
kind: Authorino
metadata:
  name: authorino
spec:
  image: authorino:local
  imagePullPolicy: IfNotPresent
  listener:
    tls:
      enabled: false
  oidcServer:
    tls:
      enabled: false
EOF
```

Setup Envoy:
```sh
kubectl -n authorino apply -f https://raw.githubusercontent.com/kuadrant/authorino-examples/main/envoy/overlays/notls/configmap.yaml
kubectl -n authorino apply -f https://raw.githubusercontent.com/kuadrant/authorino-examples/main/envoy/base/envoy.yaml
```

Apply the `AuthConfig`:
```sh
kubectl -n authorino apply -f ./examples/simple-oauth2.yaml
```

Expose envoy
```sh
kubectl -n authorino port-forward deployment/envoy 8000:8000
```

Obtain an access token and send a request:
```sh
export $(curl -d 'grant_type=password' -d 'client_id=demo' -d 'username=john' -d 'password=p' "http://keycloak:8080/auth/realms/kuadrant/protocol/openid-connect/token" | jq -r '"ACCESS_TOKEN="+.access_token,"REFRESH_TOKEN="+.refresh_token')

curl -H 'Host: talker-api' -H "Authorization: Bearer $ACCESS_TOKEN" http://localhost:8000/hello # 200
```

Revoke the access token and send another request:

```sh
curl -H "Content-Type: application/x-www-form-urlencoded" -d "refresh_token=$REFRESH_TOKEN" -d 'token_type_hint=requesting_party_token' -u demo: "http://keycloak:8080/auth/realms/kuadrant/protocol/openid-connect/logout" # 204

curl -H 'Host: talker-api' -H "Authorization: Bearer $ACCESS_TOKEN" http://localhost:8000/hello # 401
```

Cleanup:
```sh
kind delete cluster --name authorino-trial
```