### PR TITLE
Bugfix: auth credentials in cookies should be able to contain the equal sign ('=') in the value

### DIFF
--- a/pkg/common/auth_credentials/auth_credentials.go
+++ b/pkg/common/auth_credentials/auth_credentials.go
@@ -159,9 +159,9 @@ func getFromCookieHeader(headers map[string]string, keyName string) (string, err
 	}
 
 	for _, part := range strings.Split(header, ";") {
-		keyAndValue := strings.Split(strings.TrimSpace(part), "=")
-		if keyAndValue[0] == keyName {
-			return keyAndValue[1], nil
+		keyAndValue := strings.TrimSpace(part)
+		if strings.HasPrefix(keyAndValue, keyName+"=") {
+			return strings.TrimPrefix(keyAndValue, keyName+"="), nil
 		}
 	}
 

--- a/pkg/common/auth_credentials/auth_credentials_test.go
+++ b/pkg/common/auth_credentials/auth_credentials_test.go
@@ -114,6 +114,36 @@ func TestGetCredentialsFromCookieHeaderSuccess(t *testing.T) {
 	assert.Check(t, cred == "HumanInstrumentality")
 }
 
+func TestGetCredentialsFromCookieHeaderFirstKey(t *testing.T) {
+	var httpReq = envoyServiceAuthV3.AttributeContext_HttpRequest{
+		Headers: map[string]string{"cookie": "API-KEY=HumanInstrumentality; Expires=Tue, 01-Jan-2016 21:47:38 GMT"},
+	}
+
+	authCredentials := AuthCredential{
+		KeySelector: "API-KEY",
+		In:          "cookie",
+	}
+	cred, err := authCredentials.GetCredentialsFromReq(&httpReq)
+
+	assert.NilError(t, err)
+	assert.Check(t, cred == "HumanInstrumentality")
+}
+
+func TestGetCredentialsFromCookieHeaderWithEqualSign(t *testing.T) {
+	var httpReq = envoyServiceAuthV3.AttributeContext_HttpRequest{
+		Headers: map[string]string{"cookie": "Expires=Tue, 01-Jan-2016 21:47:38 GMT; API-KEY=SHVtYW5JbnN0cnVtZW50YWxpdHk="},
+	}
+
+	authCredentials := AuthCredential{
+		KeySelector: "API-KEY",
+		In:          "cookie",
+	}
+	cred, err := authCredentials.GetCredentialsFromReq(&httpReq)
+
+	assert.NilError(t, err)
+	assert.Check(t, cred == "SHVtYW5JbnN0cnVtZW50YWxpdHk=")
+}
+
 func TestGetCredentialsFromCookieHeaderNoCookieHeaderFail(t *testing.T) {
 	var httpReq = envoyServiceAuthV3.AttributeContext_HttpRequest{
 		Headers: map[string]string{"cookie": "Expires=Tue, 01-Jan-2016 21:47:38 GMT"},


### PR DESCRIPTION
Due to the using `strings.Split("=")` to read key-value pairs when extracting credentials from cookie headers, Authorino fails to read credentials whose values contain at least one equal sign ("="), quite common when using base64-encoded credentials with padding characters. This PR fixes the bug.