### PR TITLE
Install Authorino Operator and cert-manager from manifests

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -64,11 +64,14 @@ The instructions here are for centralized gateway or centralized authorization s
   kubectl create namespace authorino
   ```
 
-  Create the TLS certificates – skip this step if you already have certificates and certificate keys created and stored in Kubernetes `Secret`s in the namespace:
+  Deploy [cert-manager](https://github.com/jetstack/cert-manager) <small>(skip if you already have certificates and certificate keys created and stored in Kubernetes `Secret`s in the namespace or cert-manager is installed and running in the cluster)</small>:
   ```sh
-  git clone --depth 1 --branch v0.5.0 https://github.com/kuadrant/authorino.git && cd authorino
-  make cert-manager # installs https://github.com/jetstack/cert-manager - skip it if already installed
-  make certs NAMESPACE=authorino
+  kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml
+  ```
+
+  Create the TLS certificates <small>(skip if you already have certificates and certificate keys created and stored in Kubernetes `Secret`s in the namespace)</small>:
+  ```sh
+  curl -sSL https://raw.githubusercontent.com/Kuadrant/authorino/main/deploy/certs.yaml | sed "s/\$(AUTHORINO_INSTANCE)/authorino/g;s/\$(NAMESPACE)/authorino/g" | kubectl -n authorino apply -f -
   ```
 
   Deploy Authorino:
@@ -126,11 +129,14 @@ The instructions here are for centralized gateway or centralized authorization s
   kubectl create namespace myapp
   ```
 
-  Create the TLS certificates – skip this step if you already have certificates and certificate keys created and stored in Kubernetes `Secret`s in the namespace:
+  Deploy [cert-manager](https://github.com/jetstack/cert-manager) <small>(skip if you already have certificates and certificate keys created and stored in Kubernetes `Secret`s in the namespace or cert-manager is installed and running in the cluster)</small>:
   ```sh
-  git clone --depth 1 --branch v0.5.0 https://github.com/kuadrant/authorino.git && cd authorino
-  make cert-manager # installs https://github.com/jetstack/cert-manager - skip it if already installed
-  make certs NAMESPACE=myapp
+  kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml
+  ```
+
+  Create the TLS certificates <small>(skip if you already have certificates and certificate keys created and stored in Kubernetes `Secret`s in the namespace)</small>:
+  ```sh
+  curl -sSL https://raw.githubusercontent.com/Kuadrant/authorino/main/deploy/certs.yaml | sed "s/\$(AUTHORINO_INSTANCE)/authorino/g;s/\$(NAMESPACE)/myapp/g" | kubectl -n myapp apply -f -
   ```
 
   Deploy Authorino:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,8 +47,7 @@ Check out the [Features](./features.md) specification for fature-specific requir
 ### 1. Clone and install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ### 2. Deploy an Authorino instance

--- a/docs/user-guides/api-key-authentication.md
+++ b/docs/user-guides/api-key-authentication.md
@@ -32,8 +32,7 @@ kind create cluster --name authorino-trial
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create the namespace
@@ -151,7 +150,7 @@ kubectl -n authorino delete secret/api-key-1
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -164,8 +163,8 @@ kubectl -n authorino namespace authorino
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
+++ b/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
@@ -34,8 +34,7 @@ kind create cluster --name authorino-trial
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create the namespace
@@ -193,7 +192,7 @@ curl -H 'Authorization: APIKEY 7BNaTmYGItSzXiwQLNHu82+x52p1XHgY' http://talker-a
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -206,8 +205,8 @@ kubectl -n authorino namespace authorino
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/deny-with-redirect-to-login.md
+++ b/docs/user-guides/deny-with-redirect-to-login.md
@@ -34,8 +34,7 @@ kind create cluster --name authorino-trial
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create the namespace
@@ -241,7 +240,7 @@ Click again on the cards and check that now you are able to access the inner pag
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -254,8 +253,8 @@ kubectl -n authorino namespace authorino
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/edge-authentication-architecture-festival-wristbands.md
+++ b/docs/user-guides/edge-authentication-architecture-festival-wristbands.md
@@ -59,8 +59,7 @@ kubectl -n keycloak port-forward deployment/keycloak 8080:8080 &
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create the namespaces
@@ -344,7 +343,7 @@ curl -H "Authorization: Bearer $WRISTBAND_TOKEN" http://talker-api-authorino.127
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -359,8 +358,8 @@ kubectl -n authorino namespace authorino-operator
 kubectl -n authorino namespace keycloak
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/external-metadata.md
+++ b/docs/user-guides/external-metadata.md
@@ -36,8 +36,7 @@ kind create cluster --name authorino-trial
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create the namespace
@@ -190,7 +189,7 @@ curl -H 'Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx' \
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -203,8 +202,8 @@ kubectl -n authorino namespace authorino
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/hello-world.md
+++ b/docs/user-guides/hello-world.md
@@ -56,8 +56,7 @@ curl http://talker-api-authorino.127.0.0.1.nip.io:8000/hello -i
 ### Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ### Deploy Authorino
@@ -110,7 +109,7 @@ Check out other [user guides](./../user-guides.md) for several AuthN/AuthZ use-c
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -123,8 +122,8 @@ kubectl -n authorino namespace hello-world
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/http-basic-authentication.md
+++ b/docs/user-guides/http-basic-authentication.md
@@ -35,8 +35,7 @@ kind create cluster --name authorino-trial
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create the namespace
@@ -211,7 +210,7 @@ kubectl -n authorino delete secret/basic-auth-1
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -224,8 +223,8 @@ kubectl -n authorino namespace authorino
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/injecting-data.md
+++ b/docs/user-guides/injecting-data.md
@@ -33,8 +33,7 @@ kind create cluster --name authorino-trial
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create the namespace
@@ -166,7 +165,7 @@ curl -H 'Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx' http://talker-a
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -179,8 +178,8 @@ kubectl -n authorino namespace authorino
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/json-pattern-matching-authorization.md
+++ b/docs/user-guides/json-pattern-matching-authorization.md
@@ -48,8 +48,7 @@ kubectl -n keycloak port-forward deployment/keycloak 8080:8080 &
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create the namespace
@@ -202,7 +201,7 @@ curl -H "Authorization: Bearer $ACCESS_TOKEN" \
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -215,8 +214,8 @@ kubectl -n authorino namespace authorino
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/kubernetes-subjectaccessreview.md
+++ b/docs/user-guides/kubernetes-subjectaccessreview.md
@@ -37,8 +37,7 @@ kind create cluster --name authorino-trial
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create the namespace
@@ -451,7 +450,7 @@ curl -H "Authorization: Bearer $ACCESS_TOKEN" http://talker-api-authorino.127.0.
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -464,8 +463,8 @@ kubectl -n authorino namespace authorino
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/kubernetes-tokenreview.md
+++ b/docs/user-guides/kubernetes-tokenreview.md
@@ -36,8 +36,7 @@ kind create cluster --name authorino-trial
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create the namespace
@@ -209,7 +208,7 @@ kubectl -n authorino logs -f api-consumer
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -222,8 +221,8 @@ kubectl -n authorino namespace authorino
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/oauth2-token-introspection.md
+++ b/docs/user-guides/oauth2-token-introspection.md
@@ -63,8 +63,7 @@ kubectl -n a12n-server port-forward deployment/a12n-server 8531:8531 &
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create the namespace
@@ -278,7 +277,7 @@ curl -H "Authorization: Bearer invalid" http://talker-api-authorino.127.0.0.1.ni
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -291,8 +290,8 @@ kubectl -n authorino namespace authorino
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/oidc-jwt-authentication.md
+++ b/docs/user-guides/oidc-jwt-authentication.md
@@ -47,8 +47,7 @@ kubectl -n keycloak port-forward deployment/keycloak 8080:8080 &
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create the namespace
@@ -151,7 +150,7 @@ curl http://talker-api-authorino.127.0.0.1.nip.io:8000/hello -i
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -164,8 +163,8 @@ kubectl -n authorino namespace authorino
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/oidc-user-info.md
+++ b/docs/user-guides/oidc-user-info.md
@@ -49,8 +49,7 @@ kubectl -n keycloak port-forward deployment/keycloak 8080:8080 &
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create the namespace
@@ -166,7 +165,7 @@ curl -H "Authorization: Bearer $ACCESS_TOKEN" http://talker-api-authorino.127.0.
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -179,8 +178,8 @@ kubectl -n authorino namespace authorino
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/opa-authorization.md
+++ b/docs/user-guides/opa-authorization.md
@@ -35,8 +35,7 @@ kind create cluster --name authorino-trial
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create the namespace
@@ -182,7 +181,7 @@ curl -H 'Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx' \
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -195,8 +194,8 @@ kubectl -n authorino namespace authorino
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/passing-credentials.md
+++ b/docs/user-guides/passing-credentials.md
@@ -33,8 +33,7 @@ kind create cluster --name authorino-trial
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create the namespace
@@ -230,7 +229,7 @@ curl http://talker-api-authorino.127.0.0.1.nip.io:8000/hello -i
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -243,8 +242,8 @@ kubectl -n authorino namespace authorino
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/resource-level-authorization-uma.md
+++ b/docs/user-guides/resource-level-authorization-uma.md
@@ -47,8 +47,7 @@ kubectl -n keycloak port-forward deployment/keycloak 8080:8080 &
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create the namespace
@@ -278,7 +277,7 @@ curl -H "Authorization: Bearer $ACCESS_TOKEN" -X DELETE http://talker-api-author
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -291,8 +290,8 @@ kubectl -n authorino namespace authorino
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/sharding.md
+++ b/docs/user-guides/sharding.md
@@ -35,8 +35,7 @@ kind create cluster --name authorino-trial
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create a namespace for the Authorino instances
@@ -215,7 +214,7 @@ kubectl -n authorino logs $(kubectl -n authorino get pods -l authorino-resource=
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -229,8 +228,8 @@ kubectl -n authorino namespace authorino
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```

--- a/docs/user-guides/token-normalization.md
+++ b/docs/user-guides/token-normalization.md
@@ -48,8 +48,7 @@ kubectl -n keycloak apply -f https://raw.githubusercontent.com/kuadrant/authorin
 ## 1. Install the Authorino Operator
 
 ```sh
-git clone https://github.com/kuadrant/authorino-operator && cd authorino-operator
-kubectl create namespace authorino-operator && make install deploy
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```
 
 ## 2. Create the namespace
@@ -215,7 +214,7 @@ curl -H "Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx" -X DELETE http:
 
 ## Cleanup
 
-If you have started a Kubernetes cluster locally with Kind only to test this user guide, delete it by running:
+If you have started a Kubernetes cluster locally with Kind to try this user guide, delete it by running:
 
 ```sh
 kind delete cluster --name authorino-trial
@@ -228,8 +227,8 @@ kubectl -n authorino namespace authorino
 kubectl -n authorino namespace authorino-operator
 ```
 
-To uninstall the Authorino and Authorino Operator manifests, run from the Authorino Operator directory:
+To uninstall the Authorino and Authorino Operator manifests, run:
 
 ```sh
-make uninstall
+kubectl delete -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/deploy/manifests.yaml
 ```


### PR DESCRIPTION
The PR changes instructions and make targets to install the Authorino Operator directly from the remote manifests, in contrast to having to clone the repo locally and run `make install deploy`.

In the same way, it changes the instructions in the Getting started page of the docs to install cert-manager and create the TLS certificates directly from the remote manifests as well, also in contrast to cloning the Authorino repo locally and running make `cert-manager`/`make certs`.