### PR TITLE
Fix links to remote resources to deploy Keycloak, Dex, Limitador

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,12 +207,12 @@ example-apps:
 	kubectl -n $(NAMESPACE) apply -f https://raw.githubusercontent.com/kuadrant/authorino-examples/main/talker-api/talker-api-deploy.yaml
 	kubectl -n $(NAMESPACE) apply -f https://raw.githubusercontent.com/kuadrant/authorino-examples/main/envoy/envoy-$(ENVOY_OVERLAY)-deploy.yaml
 ifneq (, $(DEPLOY_KEYCLOAK))
-	kubectl -n $(NAMESPACE) apply -f https://raw.githubusercontent.com/kuadrant/authorino-examples/keycloak/keycloak-deploy.yaml
+	kubectl -n $(NAMESPACE) apply -f https://raw.githubusercontent.com/kuadrant/authorino-examples/main/keycloak/keycloak-deploy.yaml
 endif
 ifneq (, $(DEPLOY_DEX))
-	kubectl -n $(NAMESPACE) apply -f https://raw.githubusercontent.com/kuadrant/authorino-examples/dex/dex-deploy.yaml
+	kubectl -n $(NAMESPACE) apply -f https://raw.githubusercontent.com/kuadrant/authorino-examples/main/dex/dex-deploy.yaml
 endif
 
 # Install Limitador to the Kubernetes cluster
 limitador:
-	kubectl -n $(NAMESPACE) apply -f https://raw.githubusercontent.com/kuadrant/authorino-examples/limitador/limitador-deploy.yaml
+	kubectl -n $(NAMESPACE) apply -f https://raw.githubusercontent.com/kuadrant/authorino-examples/main/limitador/limitador-deploy.yaml


### PR DESCRIPTION
Missing the tag name was causing these resources to fail to deploy locally via make targets (devs workflow).