### PR TITLE
K8s auth ClusterRole

### DIFF
--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -55,8 +55,6 @@ type AuthConfigReconciler struct {
 }
 
 // +kubebuilder:rbac:groups=authorino.kuadrant.io,resources=authconfigs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
-// +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 
 func (r *AuthConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Logger.WithValues("authconfig", req.NamespacedName)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -328,13 +328,14 @@ AUTH_CONFIG_LABEL_SELECTOR="!disabled"
 
 The table below describes the roles and role bindings defined by the Authorino service:
 
-|                 Role               |     Kind      | Scope(*) |             Description                 |                                                    Permissions                                                      |
-| ---------------------------------- | ------------- |:--------:| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `authorino-manager-role`           | `ClusterRole` | C/N      | Role of the Authorino manager service   | Watch and reconcile `AuthConfig`s and `Secret`s; create `TokenReview`s and `SubjectAccessReview`s (Kubernetes auth) |
-| `authorino-leader-election-role`   | `Role`        | N        | Leader election role                    | Create/update the `ConfigMap` used to coordinate which replica of Authorino is the leader                           |
-| `authorino-authconfig-editor-role` | `ClusterRole` | -        | `AuthConfig` editor                     | R/W `AuthConfig`s; Read `AuthConfig/status`                                                                         |
-| `authorino-authconfig-viewer-role` | `ClusterRole` | -        | `AuthConfig` viewer                     | Read `AuthConfig`s and `AuthConfig/status`                                                                          |
-| `authorino-proxy-role`             | `ClusterRole` | C/N      | Kube-rbac-proxy-role (sidecar)'s role   | Create `TokenReview`s and `SubjectAccessReview`s to check permissions to the `/metrics` endpoint                    |
-| `authorino-metrics-reader`         | `ClusterRole` | -        | Metrics reader                          | `GET /metrics`                                                                                                      |
+|                 Role               |     Kind      | Scope(*) |             Description                 |                                                    Permissions                                   |
+| ---------------------------------- | ------------- |:--------:| --------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `authorino-manager-role`           | `ClusterRole` | C/N      | Role of the Authorino manager service   | Watch and reconcile `AuthConfig`s and `Secret`s                                                  |
+| `authorino-manager-k8s-auth-role`  | `ClusterRole` | C/N      | Role for the Kubernetes auth features   | Create `TokenReview`s and `SubjectAccessReview`s (Kubernetes auth)                               |
+| `authorino-leader-election-role`   | `Role`        | N        | Leader election role                    | Create/update the `ConfigMap` used to coordinate which replica of Authorino is the leader        |
+| `authorino-authconfig-editor-role` | `ClusterRole` | -        | `AuthConfig` editor                     | R/W `AuthConfig`s; Read `AuthConfig/status`                                                      |
+| `authorino-authconfig-viewer-role` | `ClusterRole` | -        | `AuthConfig` viewer                     | Read `AuthConfig`s and `AuthConfig/status`                                                       |
+| `authorino-proxy-role`             | `ClusterRole` | C/N      | Kube-rbac-proxy-role (sidecar)'s role   | Create `TokenReview`s and `SubjectAccessReview`s to check permissions to the `/metrics` endpoint |
+| `authorino-metrics-reader`         | `ClusterRole` | -        | Metrics reader                          | `GET /metrics`                                                                                   |
 
 <small>(*) C - Cluster-wide | N - Authorino namespace | C/N - Cluster-wide or Authorino namespace (depending on the <a href="#cluster-wide-vs-namespaced-instances">deployment mode</a>).</small>

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -1210,8 +1210,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
-  name: authorino-manager-role
+  name: authorino-manager-k8s-auth-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -1219,6 +1218,19 @@ rules:
   - tokenreviews
   verbs:
   - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: authorino-manager-role
+rules:
 - apiGroups:
   - authorino.kuadrant.io
   resources:
@@ -1239,12 +1251,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/install/rbac/k8s_auth_role.yaml
+++ b/install/rbac/k8s_auth_role.yaml
@@ -1,0 +1,18 @@
+# For Authorino Kubernetes authn (TokenReview) and authz (SubjectAccessReview) features
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-k8s-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/install/rbac/kustomization.yaml
+++ b/install/rbac/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
 - role.yaml
+- k8s_auth_role.yaml
 - auth_config_editor_role.yaml
 - auth_config_viewer_role.yaml
 - auth_proxy_role.yaml

--- a/install/rbac/role.yaml
+++ b/install/rbac/role.yaml
@@ -7,12 +7,6 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
   - authorino.kuadrant.io
   resources:
   - authconfigs
@@ -32,12 +26,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
 - apiGroups:
   - coordination.k8s.io
   resources:


### PR DESCRIPTION
Defines a new `authorino-manager-k8s-auth-role` `Role` that extracts `tokenreviews` and `subjectaccessreviews`-related permissions out of the main `authorino-manager-role` `Role`, thus allowing for this role to the bound to the Authorino SA at cluster level.

Closes #127

----

### Verification steps

Build and deploy images of Authorino and Authorino Operator that contains the required changes:

```sh
cd $GOPATH/src/github.com/kuadrant/authorino-operator
git checkout authorino-k8s-auth-role
make docker-build OPERATOR_IMAGE=authorino-operator:local

cd $GOPATH/src/github.com/kuadrant/authorino
git checkout fix/k8s-auth-namespaced
make cluster
make cert-manager
make local-build # kind load docker-image authorino:local --name authorino
kind load docker-image authorino-operator:local --name authorino
make install-operator OPERATOR_VERSION=authorino-k8s-auth-role
kubectl -n authorino-operator patch deployment/authorino-operator-controller-manager -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","image":"authorino-operator:local"}]}}}}'
make install
make namespace
make deploy
```

Test k8s authn and authz features on the namespaced instance of Authorino:

```sh
make example-apps

kubectl -n authorino port-forward deployment/envoy 8000:8000 &

kubectl -n authorino apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: talker-api-protection
spec:
  hosts:
  - talker-api-authorino.127.0.0.1.nip.io
  identity:
  - name: k8s-authn
    kubernetes:
      audiences:
      - talker-api
  authorization:
  - name: k8s-authz
    kubernetes:
      user:
        valueFrom:
          authJSON: auth.identity.sub
EOF

kubectl -n authorino apply -f -<<EOF
apiVersion: v1
kind: ServiceAccount
metadata:
  name: api-consumer-1
EOF

kubectl apply -f -<<EOF
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: talker-api-greeter
rules:
- nonResourceURLs: ["/hello"]
  verbs: ["get"]
EOF

kubectl apply -f -<<EOF
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: talker-api-greeter-rolebinding
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: talker-api-greeter
subjects:
- kind: ServiceAccount
  name: api-consumer-1
  namespace: authorino
EOF

CURRENT_K8S_CONTEXT=$(kubectl config view -o json | jq -r '."current-context"')
CURRENT_K8S_USER=$(kubectl config view -o json | jq -r --arg K8S_CONTEXT "${CURRENT_K8S_CONTEXT}"  '.contexts[] | select(.name == $K8S_CONTEXT) | .context.user')
CURRENT_K8S_CLUSTER=$(kubectl config view -o json | jq -r --arg K8S_CONTEXT "${CURRENT_K8S_CONTEXT}"  '.contexts[] | select(.name == $K8S_CONTEXT) | .context.cluster')
KUBERNETES_API=$(kubectl config view -o json | jq -r --arg K8S_CLUSTER "${CURRENT_K8S_CLUSTER}" '.clusters[] | select(.name == $K8S_CLUSTER) | .cluster.server')
yq r ~/.kube/config "users(name==$CURRENT_K8S_USER).user.client-certificate-data" | base64 -d > /tmp/kind-cluster-user-cert.pem
yq r ~/.kube/config "users(name==$CURRENT_K8S_USER).user.client-key-data" | base64 -d > /tmp/kind-cluster-user-cert.key

export ACCESS_TOKEN=$(curl -k -X "POST" "$KUBERNETES_API/api/v1/namespaces/authorino/serviceaccounts/api-consumer-1/token" \
     --cert /tmp/kind-cluster-user-cert.pem --key /tmp/kind-cluster-user-cert.key \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{ "apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest", "spec": { "audiences": ["talker-api"], "expirationSeconds": 600 } }' | jq -r '.status.token')

curl -H "Authorization: Bearer $ACCESS_TOKEN" http://talker-api-authorino.127.0.0.1.nip.io:8000/hello -i
# HTTP/1.1 200 OK
```