### PR TITLE
Filter API keys by namespace

### DIFF
--- a/api/v1beta1/auth_config_types.go
+++ b/api/v1beta1/auth_config_types.go
@@ -199,6 +199,11 @@ type Identity_OidcConfig struct {
 type Identity_APIKey struct {
 	// The map of label selectors used by Authorino to match secrets from the cluster storing valid credentials to authenticate to this service
 	LabelSelectors map[string]string `json:"labelSelectors"`
+
+	// Whether Authorino should look for API key secrets in all namespaces or only in the same namespace of the AuthConfig.
+	// Enabling this option in namespaced Authorino instances has no effect.
+	// +kubebuilder:default:=false
+	AllNamespaces bool `json:"allNamespaces,omitempty"`
 }
 
 type Identity_KubernetesAuth struct {

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -3,8 +3,7 @@ package controllers
 import (
 	"context"
 
-	"github.com/kuadrant/authorino/api/v1beta1"
-	configv1beta1 "github.com/kuadrant/authorino/api/v1beta1"
+	api "github.com/kuadrant/authorino/api/v1beta1"
 	controller_builder "github.com/kuadrant/authorino/controllers/builder"
 	"github.com/kuadrant/authorino/pkg/common"
 
@@ -31,6 +30,7 @@ type SecretReconciler struct {
 	Scheme               *runtime.Scheme
 	LabelSelector        labels.Selector
 	AuthConfigReconciler reconcile.Reconciler
+	Namespace            string
 }
 
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;
@@ -38,7 +38,7 @@ type SecretReconciler struct {
 func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Logger.WithValues("secret", req.NamespacedName)
 
-	var reconcile func(configv1beta1.AuthConfig)
+	var reconcile func(api.AuthConfig)
 
 	secret := v1.Secret{}
 	if err := r.Client.Get(ctx, req.NamespacedName, &secret); err != nil && !errors.IsNotFound(err) {
@@ -48,10 +48,10 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// could not find the resouce: 404 Not found (resouce must have been deleted)
 		// or the resource misses required labels (i.e. not to be watched by this controller)
 		// try to find a secret with same name by digging into the cache of authconfigs
-		reconcile = func(authConfig configv1beta1.AuthConfig) {
+		reconcile = func(authConfig api.AuthConfig) {
 			for _, host := range authConfig.Spec.Hosts {
-				sr, _ := r.AuthConfigReconciler.(*AuthConfigReconciler)
-				for _, id := range sr.Cache.Get(host).IdentityConfigs {
+				authConfigReconciler, _ := r.AuthConfigReconciler.(*AuthConfigReconciler)
+				for _, id := range authConfigReconciler.Cache.Get(host).IdentityConfigs {
 					i, _ := id.(common.APIKeySecretFinder)
 					if s := i.FindSecretByName(req.NamespacedName); s != nil {
 						r.reconcileAuthConfig(ctx, authConfig)
@@ -63,11 +63,15 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	} else {
 		// resource found and it is to be watched by this controller
 		// straightforward – if the API key labels match, reconcile the auth config
-		reconcile = func(authConfig configv1beta1.AuthConfig) {
+		reconcile = func(authConfig api.AuthConfig) {
 			for _, id := range authConfig.Spec.Identity {
-				if id.GetType() == v1beta1.IdentityApiKey {
+				if id.GetType() == api.IdentityApiKey {
+					validNamespace := true
+					if !id.APIKey.AllNamespaces {
+						validNamespace = secret.Namespace == authConfig.Namespace
+					}
 					selector, _ := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: id.APIKey.LabelSelectors})
-					if selector != nil && selector.Matches(labels.Set(secret.Labels)) {
+					if validNamespace && (selector == nil || selector.Matches(labels.Set(secret.Labels))) {
 						r.reconcileAuthConfig(ctx, authConfig)
 						return
 					}
@@ -76,7 +80,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 	}
 
-	if err := r.reconcileAuthConfigsUsingAPIKey(ctx, req.Namespace, reconcile); err != nil {
+	if err := r.reconcileAuthConfigsUsingAPIKey(ctx, reconcile); err != nil {
 		logger.Info("could not reconcile authconfigs using api key authentication")
 		return ctrl.Result{}, err
 	} else {
@@ -85,36 +89,19 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 }
 
+func (r *SecretReconciler) ClusterWide() bool {
+	return r.Namespace == ""
+}
+
 func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return newController(mgr).
 		For(&v1.Secret{}, builder.WithPredicates(LabelSelectorPredicate(r.LabelSelector))).
 		Complete(r)
 }
 
-func (r *SecretReconciler) getAuthConfigsUsingAPIKey(ctx context.Context, namespace string) ([]configv1beta1.AuthConfig, error) {
-	var existingAuthConfigs = &configv1beta1.AuthConfigList{}
-	selectedAuthConfigs := make([]configv1beta1.AuthConfig, 0)
-
-	if err := r.List(ctx, existingAuthConfigs, &client.ListOptions{
-		Namespace: namespace,
-	}); err != nil {
-		return nil, err
-	} else {
-		for _, authConfig := range existingAuthConfigs.Items {
-			for _, id := range authConfig.Spec.Identity {
-				if id.GetType() == v1beta1.IdentityApiKey {
-					selectedAuthConfigs = append(selectedAuthConfigs, authConfig)
-					break
-				}
-			}
-		}
-		return selectedAuthConfigs, nil
-	}
-}
-
 // reconcileAuthConfigsUsingAPIKey invokes the reconcile(authConfig) func asynchronously, for each authConfig using API key identity
-func (r *SecretReconciler) reconcileAuthConfigsUsingAPIKey(ctx context.Context, namespace string, reconcile func(configv1beta1.AuthConfig)) error {
-	if authConfigs, err := r.getAuthConfigsUsingAPIKey(ctx, namespace); err != nil {
+func (r *SecretReconciler) reconcileAuthConfigsUsingAPIKey(ctx context.Context, reconcile func(api.AuthConfig)) error {
+	if authConfigs, err := r.listAuthConfigsUsingAPIKey(ctx); err != nil {
 		return err
 	} else {
 		for _, authConfig := range authConfigs {
@@ -127,7 +114,31 @@ func (r *SecretReconciler) reconcileAuthConfigsUsingAPIKey(ctx context.Context, 
 	}
 }
 
-func (r *SecretReconciler) reconcileAuthConfig(ctx context.Context, authConfig configv1beta1.AuthConfig) {
+func (r *SecretReconciler) listAuthConfigsUsingAPIKey(ctx context.Context) ([]api.AuthConfig, error) {
+	var existingAuthConfigs = &api.AuthConfigList{}
+	var selectedAuthConfigs []api.AuthConfig
+
+	opts := &client.ListOptions{}
+	if !r.ClusterWide() {
+		opts.Namespace = r.Namespace
+	}
+
+	if err := r.List(ctx, existingAuthConfigs, opts); err != nil {
+		return nil, err
+	} else {
+		for _, authConfig := range existingAuthConfigs.Items {
+			for _, id := range authConfig.Spec.Identity {
+				if id.GetType() == api.IdentityApiKey {
+					selectedAuthConfigs = append(selectedAuthConfigs, authConfig)
+					break
+				}
+			}
+		}
+		return selectedAuthConfigs, nil
+	}
+}
+
+func (r *SecretReconciler) reconcileAuthConfig(ctx context.Context, authConfig api.AuthConfig) {
 	_, _ = r.AuthConfigReconciler.Reconcile(ctx, ctrl.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: authConfig.Namespace,

--- a/install/crd/authorino.kuadrant.io_authconfigs.yaml
+++ b/install/crd/authorino.kuadrant.io_authconfigs.yaml
@@ -531,6 +531,13 @@ spec:
                       type: object
                     apiKey:
                       properties:
+                        allNamespaces:
+                          default: false
+                          description: Whether Authorino should look for API key secrets
+                            in all namespaces or only in the same namespace of the
+                            AuthConfig. Enabling this option in namespaced Authorino
+                            instances has no effect.
+                          type: boolean
                         labelSelectors:
                           additionalProperties:
                             type: string

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -610,6 +610,13 @@ spec:
                       type: object
                     apiKey:
                       properties:
+                        allNamespaces:
+                          default: false
+                          description: Whether Authorino should look for API key secrets
+                            in all namespaces or only in the same namespace of the
+                            AuthConfig. Enabling this option in namespaced Authorino
+                            instances has no effect.
+                          type: boolean
                         labelSelectors:
                           additionalProperties:
                             type: string

--- a/main.go
+++ b/main.go
@@ -156,6 +156,7 @@ func main() {
 		Logger:        controllerLogger.WithName("authconfig"),
 		Scheme:        mgr.GetScheme(),
 		LabelSelector: controllers.ToLabelSelector(watchedAuthConfigLabelSelector),
+		Namespace:     watchNamespace,
 	}
 	if err = authConfigReconciler.SetupWithManager(mgr); err != nil {
 		logger.Error(err, "unable to create controller", "controller", "authconfig")
@@ -169,6 +170,7 @@ func main() {
 		Scheme:               mgr.GetScheme(),
 		LabelSelector:        controllers.ToLabelSelector(watchedSecretLabelSelector),
 		AuthConfigReconciler: authConfigReconciler,
+		Namespace:            watchNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		logger.Error(err, "unable to create controller", "controller", "secret")
 		os.Exit(1)


### PR DESCRIPTION
Adds `spec.identity.apiKey.allNamespaces: bool` to the AuthConfig API. Default value: `false` – Breaking change!

- [x] Cache/watch API key secrets filtering by label selectors and namespace
    - Supported: all namespaces | same namespace of the AuthConfig (default)
    - All namespaces can only be used in cluster-wide Authorino instances
- [x] Tests
- [x] Docs

### Verification steps

Build and deploy Authorino in namespaced reconciliation/deployment mode:

```sh
make local-setup
kubectl -n authorino port-forward deployment/envoy 8000:8000 &
```

Create a couple API key secrets (different namespaces):

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: v1
kind: Secret
metadata:
  name: api-key-1
  labels:
    authorino.kuadrant.io/managed-by: authorino
    group: friends
stringData:
  api_key: ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx
type: Opaque
EOF

kubectl -n default apply -f -<<EOF
apiVersion: v1
kind: Secret
metadata:
  name: api-key-2
  labels:
    authorino.kuadrant.io/managed-by: authorino
    group: friends
stringData:
  api_key: 04e7013426dfe1a89be4a578a959b7e4
type: Opaque
EOF
```

Create the AuthConfig:

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: talker-api-protection
spec:
  hosts:
  - talker-api-authorino.127.0.0.1.nip.io
  identity:
  - name: friends
    apiKey:
      labelSelectors:
        group: friends
    credentials:
      in: authorization_header
      keySelector: APIKEY
EOF
```

Try the API with both API keys:

```sh
curl -H 'Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx' http://talker-api-authorino.127.0.0.1.nip.io:8000/hello -i
# HTTP/1.1 200 OK
```

```sh
curl -H 'Authorization: APIKEY 04e7013426dfe1a89be4a578a959b7e4' http://talker-api-authorino.127.0.0.1.nip.io:8000/hello -i
# HTTP/1.1 401 Unauthorized
```

Patch the AuthConfig to enable all-namespaces API keys: (It won't work because Authorino instance is in namespaced reconciliation/deployment mode):

```sh
kubectl -n authorino patch --type=merge authconfigs/talker-api-protection -p '{"spec":{"identity":[{"name":"friends","apiKey":{"allNamespaces":true,"labelSelectors":{"group":"friends"}},"credentials":{"in":"authorization_header","keySelector":"APIKEY"}}]}}'
```
    
Try with both API keys again (same result expected):

```sh
curl -H 'Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx' http://talker-api-authorino.127.0.0.1.nip.io:8000/hello -i
# HTTP/1.1 200 OK
```

```sh
curl -H 'Authorization: APIKEY 04e7013426dfe1a89be4a578a959b7e4' http://talker-api-authorino.127.0.0.1.nip.io:8000/hello -i
# HTTP/1.1 401 Unauthorized
```

Redeploy Authorino in cluster-wide reconciliation/deployment mode:

```sh
kubectl -n authorino delete authorinos/authorino

kubectl -n authorino apply -f -<<EOF
apiVersion: operator.authorino.kuadrant.io/v1beta1
kind: Authorino
metadata:
  name: authorino
spec:
  image: authorino:local
  imagePullPolicy: IfNotPresent
  replicas: 1
  clusterWide: true
  listener:
    tls:
      enabled: true
      certSecretRef:
        name: authorino-server-cert
  oidcServer:
    tls:
      enabled: true
      certSecretRef:
        name: authorino-oidc-server-cert
  logLevel: debug
  logMode: development
EOF
```

Try with both API keys again:

```sh
curl -H 'Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx' http://talker-api-authorino.127.0.0.1.nip.io:8000/hello -i
# HTTP/1.1 200 OK
```

```sh
curl -H 'Authorization: APIKEY 04e7013426dfe1a89be4a578a959b7e4' http://talker-api-authorino.127.0.0.1.nip.io:8000/hello -i
# HTTP/1.1 200 OK
```

Revoke the API key in the `default` namespace:

```sh
kubectl -n default delete secret/api-key-2
```

```sh
curl -H 'Authorization: APIKEY 04e7013426dfe1a89be4a578a959b7e4' http://talker-api-authorino.127.0.0.1.nip.io:8000/hello -i
# HTTP/1.1 401 Unauthorized
```
