### PR TITLE
Fuzzy OPA

### DIFF
--- a/api/v1beta1/auth_config_types.go
+++ b/api/v1beta1/auth_config_types.go
@@ -359,6 +359,12 @@ type Authorization_OPA struct {
 
 	// External registry of OPA policies.
 	ExternalRegistry ExternalRegistry `json:"externalRegistry,omitempty"`
+
+	// Use fuzzy OPA evaluation for each Rego rule to be exposed as a query, and thus whose value can be read in subsequent evaluators/phases of the Auth Pipeline.
+	// Otherwise, only the default `allow` rule will be exposed.
+	// The use of fuzzy OPA evaluation can affect performance of OPA policies in both during reconciliation (policy precompile) and runtime.
+	// +kubebuilder:default:=false
+	Fuzzy bool `json:"fuzzy,omitempty"`
 }
 
 // JSON pattern matching authorization policy.

--- a/api/v1beta1/auth_config_types.go
+++ b/api/v1beta1/auth_config_types.go
@@ -360,11 +360,11 @@ type Authorization_OPA struct {
 	// External registry of OPA policies.
 	ExternalRegistry ExternalRegistry `json:"externalRegistry,omitempty"`
 
-	// Use fuzzy OPA evaluation for each Rego rule to be exposed as a query, and thus whose value can be read in subsequent evaluators/phases of the Auth Pipeline.
+	// Returns the value of all Rego rules in the virtual document. Values can be read in subsequent evaluators/phases of the Auth Pipeline.
 	// Otherwise, only the default `allow` rule will be exposed.
-	// The use of fuzzy OPA evaluation can affect performance of OPA policies in both during reconciliation (policy precompile) and runtime.
+	// Returning all Rego rules can affect performance of OPA policies during reconciliation (policy precompile) and at runtime.
 	// +kubebuilder:default:=false
-	Fuzzy bool `json:"fuzzy,omitempty"`
+	AllValues bool `json:"allValues,omitempty"`
 }
 
 // JSON pattern matching authorization policy.

--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -339,7 +339,7 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 			}
 
 			var err error
-			translatedAuthorization.OPA, err = authorinoAuthorization.NewOPAAuthorization(policyName, opa.InlineRego, externalSource, index, ctxWithLogger)
+			translatedAuthorization.OPA, err = authorinoAuthorization.NewOPAAuthorization(policyName, opa.InlineRego, externalSource, opa.Fuzzy, index, ctxWithLogger)
 			if err != nil {
 				return nil, err
 			}

--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -339,7 +339,7 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 			}
 
 			var err error
-			translatedAuthorization.OPA, err = authorinoAuthorization.NewOPAAuthorization(policyName, opa.InlineRego, externalSource, opa.Fuzzy, index, ctxWithLogger)
+			translatedAuthorization.OPA, err = authorinoAuthorization.NewOPAAuthorization(policyName, opa.InlineRego, externalSource, opa.AllValues, index, ctxWithLogger)
 			if err != nil {
 				return nil, err
 			}

--- a/docs/features.md
+++ b/docs/features.md
@@ -386,11 +386,13 @@ spec:
 
 You can model authorization policies in [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/) and add them as part of the protection of your APIs.
 
-Policies can be either declared in-line (in Rego language) or as an HTTP endpoint where Authorino will fetch the source code of the policy in reconciliation-time.
+Policies can be either declared in-line in Rego language (`inlineRego`) or as an HTTP endpoint where Authorino will fetch the source code of the policy in reconciliation-time (`externalRegistry`).
 
-Authorino's built-in OPA module precompiles the policies in reconciliation-time and cache them for fast evaluation in request-time, where they receive the Authorization JSON as input.
+Authorino's built-in OPA module precompiles the policies during reconciliation of the AUthConfig and caches the precompiled policies for fast evaluation in runtime, where they receive the Authorization JSON as input.
 
-![OPA](http://www.plantuml.com/plantuml/png/ZSv1IiH048NXVPsYc7tYVY0oeuYB0IFUeEcKfh2xAdPUATxUB4GG5B9_F-yxhKWDKGkjhsfBQgboTVCyDw_2Q254my1Fajso5arGjmvQXOU1pe7PcvfpTys7cz22Jet7n_E1ZrlqeYkayU95yoVz7loPt7fTjCX_nPRyN98vX8iyuyWvvLc8-hx_rhw5hDZ9l1Vmv3cg6FX3CRFQ4jZ3lNjF9H9sURVvUBbw62zq4fkYbYy0)
+![OPA](http://www.plantuml.com/plantuml/png/TP71IWD138RlynHXJmfklHTMMaKyMle6OPgwmKoopcQiHNntjqjTc8F79D__vm_PZ8xPIv8mlhCEc351ChNOPqi4dWk5CBMT8m-e3jlYlMLM0nm1_ueAQHuBYxUiyBhRDXVE1go9dGd7CsHwuz7p-G8jHGXT1tkAff65qTcqTKu4NHUMXT0-B09OmmrzEML5WM5sleLT4GaBqKxuegrTfcoJmNucAL_ruT9TXa-M1XQgPfMXcXC87NqD4MDF8QnMg-iT7uL6hm-eLx-Gmy5YIQGE9_OUM8VYTOJdJvI2_d-6YVc61aNirApdlzqVKKQwWoaA_8GDwQ4a-GK0)
+
+A field option `fuzzy: boolean` makes the values of all rules declared in the Rego document to be returned in the OPA output after policy evaluation. When disabled (default), only the boolean value `allow` is returned. Values of internal rules of the Rego document can be referenced in subsequent policies/phases of the Auth Pipeline.
 
 ### Kubernetes SubjectAccessReview ([`authorization.kubernetes`](https://pkg.go.dev/github.com/kuadrant/authorino/api/v1beta1?utm_source=gopls#Authorization_KubernetesAuthz))
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -392,7 +392,7 @@ Authorino's built-in OPA module precompiles the policies during reconciliation o
 
 ![OPA](http://www.plantuml.com/plantuml/png/TP71IWD138RlynHXJmfklHTMMaKyMle6OPgwmKoopcQiHNntjqjTc8F79D__vm_PZ8xPIv8mlhCEc351ChNOPqi4dWk5CBMT8m-e3jlYlMLM0nm1_ueAQHuBYxUiyBhRDXVE1go9dGd7CsHwuz7p-G8jHGXT1tkAff65qTcqTKu4NHUMXT0-B09OmmrzEML5WM5sleLT4GaBqKxuegrTfcoJmNucAL_ruT9TXa-M1XQgPfMXcXC87NqD4MDF8QnMg-iT7uL6hm-eLx-Gmy5YIQGE9_OUM8VYTOJdJvI2_d-6YVc61aNirApdlzqVKKQwWoaA_8GDwQ4a-GK0)
 
-A field option `fuzzy: boolean` makes the values of all rules declared in the Rego document to be returned in the OPA output after policy evaluation. When disabled (default), only the boolean value `allow` is returned. Values of internal rules of the Rego document can be referenced in subsequent policies/phases of the Auth Pipeline.
+An optional field `allValues: boolean` makes the values of all rules declared in the Rego document to be returned in the OPA output after policy evaluation. When disabled (default), only the boolean value `allow` is returned. Values of internal rules of the Rego document can be referenced in subsequent policies/phases of the Auth Pipeline.
 
 ### Kubernetes SubjectAccessReview ([`authorization.kubernetes`](https://pkg.go.dev/github.com/kuadrant/authorino/api/v1beta1?utm_source=gopls#Authorization_KubernetesAuthz))
 

--- a/install/crd/authorino.kuadrant.io_authconfigs.yaml
+++ b/install/crd/authorino.kuadrant.io_authconfigs.yaml
@@ -295,6 +295,15 @@ spec:
                     opa:
                       description: Open Policy Agent (OPA) authorization policy.
                       properties:
+                        allValues:
+                          default: false
+                          description: Returns the value of all Rego rules in the
+                            virtual document. Values can be read in subsequent evaluators/phases
+                            of the Auth Pipeline. Otherwise, only the default `allow`
+                            rule will be exposed. Returning all Rego rules can affect
+                            performance of OPA policies during reconciliation (policy
+                            precompile) and at runtime.
+                          type: boolean
                         externalRegistry:
                           description: External registry of OPA policies.
                           properties:
@@ -357,16 +366,6 @@ spec:
                               - name
                               type: object
                           type: object
-                        fuzzy:
-                          default: false
-                          description: Use fuzzy OPA evaluation for each Rego rule
-                            to be exposed as a query, and thus whose value can be
-                            read in subsequent evaluators/phases of the Auth Pipeline.
-                            Otherwise, only the default `allow` rule will be exposed.
-                            The use of fuzzy OPA evaluation can affect performance
-                            of OPA policies in both during reconciliation (policy
-                            precompile) and runtime.
-                          type: boolean
                         inlineRego:
                           description: Authorization policy as a Rego language document.
                             The Rego document must include the "allow" condition,

--- a/install/crd/authorino.kuadrant.io_authconfigs.yaml
+++ b/install/crd/authorino.kuadrant.io_authconfigs.yaml
@@ -357,6 +357,16 @@ spec:
                               - name
                               type: object
                           type: object
+                        fuzzy:
+                          default: false
+                          description: Use fuzzy OPA evaluation for each Rego rule
+                            to be exposed as a query, and thus whose value can be
+                            read in subsequent evaluators/phases of the Auth Pipeline.
+                            Otherwise, only the default `allow` rule will be exposed.
+                            The use of fuzzy OPA evaluation can affect performance
+                            of OPA policies in both during reconciliation (policy
+                            precompile) and runtime.
+                          type: boolean
                         inlineRego:
                           description: Authorization policy as a Rego language document.
                             The Rego document must include the "allow" condition,

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -387,6 +387,16 @@ spec:
                               - name
                               type: object
                           type: object
+                        fuzzy:
+                          default: false
+                          description: Use fuzzy OPA evaluation for each Rego rule
+                            to be exposed as a query, and thus whose value can be
+                            read in subsequent evaluators/phases of the Auth Pipeline.
+                            Otherwise, only the default `allow` rule will be exposed.
+                            The use of fuzzy OPA evaluation can affect performance
+                            of OPA policies in both during reconciliation (policy
+                            precompile) and runtime.
+                          type: boolean
                         inlineRego:
                           description: Authorization policy as a Rego language document.
                             The Rego document must include the "allow" condition,

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -325,6 +325,15 @@ spec:
                     opa:
                       description: Open Policy Agent (OPA) authorization policy.
                       properties:
+                        allValues:
+                          default: false
+                          description: Returns the value of all Rego rules in the
+                            virtual document. Values can be read in subsequent evaluators/phases
+                            of the Auth Pipeline. Otherwise, only the default `allow`
+                            rule will be exposed. Returning all Rego rules can affect
+                            performance of OPA policies during reconciliation (policy
+                            precompile) and at runtime.
+                          type: boolean
                         externalRegistry:
                           description: External registry of OPA policies.
                           properties:
@@ -387,16 +396,6 @@ spec:
                               - name
                               type: object
                           type: object
-                        fuzzy:
-                          default: false
-                          description: Use fuzzy OPA evaluation for each Rego rule
-                            to be exposed as a query, and thus whose value can be
-                            read in subsequent evaluators/phases of the Auth Pipeline.
-                            Otherwise, only the default `allow` rule will be exposed.
-                            The use of fuzzy OPA evaluation can affect performance
-                            of OPA policies in both during reconciliation (policy
-                            precompile) and runtime.
-                          type: boolean
                         inlineRego:
                           description: Authorization policy as a Rego language document.
                             The Rego document must include the "allow" condition,

--- a/pkg/config/authorization/opa.go
+++ b/pkg/config/authorization/opa.go
@@ -81,7 +81,7 @@ func (opa *OPA) Call(pipeline common.AuthPipeline, ctx context.Context) (interfa
 			return nil, err
 		} else if len(results) == 0 {
 			return nil, fmt.Errorf(invalidOPAResponseErrorMsg)
-		} else if allowed := results[0].Bindings[allowQuery].(bool); !allowed {
+		} else if allowed, ok := results[0].Bindings[allowQuery].(bool); !ok || !allowed {
 			return nil, fmt.Errorf(unauthorizedErrorMsg)
 		} else {
 			return results[0].Bindings, nil

--- a/pkg/config/authorization/opa.go
+++ b/pkg/config/authorization/opa.go
@@ -30,7 +30,7 @@ default allow = false
 	invalidOPAResponseErrorMsg  = "Invalid response from OPA policy evaluation"
 )
 
-func NewOPAAuthorization(policyName string, rego string, externalSource OPAExternalSource, fuzzy bool, nonce int, ctx context.Context) (*OPA, error) {
+func NewOPAAuthorization(policyName string, rego string, externalSource OPAExternalSource, allValues bool, nonce int, ctx context.Context) (*OPA, error) {
 	logger := log.FromContext(ctx).WithName("opa")
 
 	if rego == "" && externalSource.Endpoint != "" {
@@ -47,7 +47,7 @@ func NewOPAAuthorization(policyName string, rego string, externalSource OPAExter
 	o := &OPA{
 		Rego:              rego,
 		OPAExternalSource: externalSource,
-		Fuzzy:             fuzzy,
+		AllValues:         allValues,
 		policyUID:         generatePolicyUID(policyName, rego, nonce),
 		opaContext:        context.TODO(),
 	}
@@ -62,7 +62,7 @@ func NewOPAAuthorization(policyName string, rego string, externalSource OPAExter
 type OPA struct {
 	Rego              string `yaml:"rego"`
 	OPAExternalSource OPAExternalSource
-	Fuzzy             bool
+	AllValues         bool
 
 	opaContext context.Context
 	policy     *rego.PreparedEvalQuery
@@ -103,7 +103,7 @@ func (opa *OPA) precompilePolicy() error {
 		return err
 	}
 
-	if opa.Fuzzy {
+	if opa.AllValues {
 		rules := map[string]interface{}{allowQuery: nil}
 		for _, rule := range module.Rules {
 			name := string(rule.Head.Name)

--- a/pkg/config/authorization/opa_test.go
+++ b/pkg/config/authorization/opa_test.go
@@ -100,7 +100,7 @@ func TestOPAExternalUrlJsonResponse(t *testing.T) {
 	assertOPAAuthorization(t, opa)
 }
 
-func TestOPAFuzzy(t *testing.T) {
+func TestOPAAllValues(t *testing.T) {
 	ctrl := NewController(t)
 	defer ctrl.Finish()
 


### PR DESCRIPTION
Adds the option to return all values in the OPA virtual document (all rules), instead of just the "allow" rule that is used by Authorino to decide about the policy overall.

This allows to extract individual values from the Rego virtual documents, e.g. to be used in subsequent authorization policies (i.e. `> priority`) and custom responses and implement use cases such as of fuzzy authorization.

Partial OPA policies can be defined to evaluate complex authorization rules and "export" values via Authorization JSON to other evaluators. The overall authorization decision can be postponed by setting `allow = true` in the partial policies.

E.g.:

```yaml
spec:
  authorization:
  - name: pre
    priority: 0
    opa:
      inlineRego: |
        some_rule = x { x := ... } # some complex computation
        allow = true # postponing the authz decision
      allValues: true

  - name: policy-1
    priority: 1
    opa:
      inlineRego: |
        other_rule { ... }
        allow {
          other_rule
          input.auth.authorization.pre.some_rule != "foo"
        }

  - name: policy-2
    priority: 1
    json:
      rules:
      - selector: auth.authorization.pre.some_rule
        operator: neq
        value: baz

  response:
  - name: pre-authz
    json:
      properties:
      - name: some_rule
        valueFrom: { authJSON: auth.authorization.pre.some_rule }
```

### Verification steps

```sh
make local-setup

kubectl -n authorino apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: talker-api-protection
spec:
  hosts:
  - talker-api-authorino.127.0.0.1.nip.io
  identity:
  - name: anonymous
    anonymous: {}
  authorization:
  - name: fuzzy
    opa:
      inlineRego: |
        import input.context.request.http.method

        allowed_methods := ["GET", "POST"]

        is_allowed { allowed_methods[_] == method }

        allow = true
      allValues: true
  response:
  - name: authorization-data
    json:
      properties:
      - name: fuzzy
        valueFrom: { authJSON: auth.authorization.fuzzy }
EOF

kubectl -n authorino port-forward deployment/envoy 8000:8000
```

```sh
curl http://talker-api-authorino.127.0.0.1.nip.io:8000
# ...
# "Authorization-Data": "{\"fuzzy\":{\"allow\":true,\"allowed_methods\":[\"GET\",\"POST\"],\"is_allowed\":true}}",
# ...
```

```sh
curl http://talker-api-authorino.127.0.0.1.nip.io:8000 -X PUT
# ...
# "Authorization-Data": "{\"fuzzy\":{\"allow\":true,\"allowed_methods\":[\"GET\",\"POST\"],\"is_allowed\":null}}",
# ...
```

### Breaking changes

The resolved object returned by the OPA authorization evaluators is no longer a simple boolean value, but now an actual object `{ "allow": boolean, ...other rules }`, where `...other rules` is only available when `allValues: true`.

### Bug fixes

Fixed non-boolean values set for the ‘allow’ rule crashes Authorino (Thanks, @maleck13!)

---

Related to #109 