### PR TITLE
Support for "host" lookup key passed as context extension

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -182,6 +182,8 @@ Each phase is sequential to the other, from (i) to (iv), while the evaluators wi
 
 Authorino reads the request host from `Attributes.Http.Host` of Envoy's [`CheckRequest`](https://pkg.go.dev/github.com/envoyproxy/go-control-plane/envoy/service/auth/v3?utm_source=gopls#CheckRequest) type, and uses it as key to lookup in the [cache](#resource-reconciliation-and-status-update) of `AuthConfig`s.
 
+Alternatively, `host` can be supplied in `Attributes.ContextExtensions`, which takes precedence before the actual host attribute of the HTTP request. This is useful to support use cases such as of **path prefix-based lookup** and **wildcard subdomains lookup**.
+
 If more than one host name is specified in the `AuthConfig`, all of them can be used as the key, i.e. all of them can be requested in the authorization request and will be mapped to the same config.
 
 The host can include the port number (i.e. `hostname:port`) or it can be just the name of the host. Authorino will first try finding a config in the cache that is associated to `hostname:port` as supplied in the authorization request; if the cache misses an entry for `hostname:port`, Authorino will then remove the `:port` suffix and lookup again using just `hostname` as key. This allows to change port numbers for a same host, as long as the name of the host is the same, without having to list multiple combinations of `hostname:port` to the `AuthConfig` spec.

--- a/docs/user-guides.md
+++ b/docs/user-guides.md
@@ -60,6 +60,9 @@ Provide Envoy with dynamic metadata from the external authorization process to b
 - **[Redirecting to a login page](./user-guides/deny-with-redirect-to-login.md)**<br/>
 Customize response status code and headers on failed requests. E.g. redirect users of a web application protected with Authorino to a login page instead of a `401 Unauthorized`; mask resources on access denied behind a `404 Not Found` response instead of `403 Forbidden`.
 
+- **[Host override via context extension](./user-guides/host-override.md)**<br/>
+Induce the lookup of an AuthConfig by supplying extended host context, for use cases such as of path prefix-based lookup and wildcard subdomains lookup.
+
 - **[Reducing the operational space: sharding, noise and multi-tenancy](./user-guides/sharding.md)**<br/>
 Have multiple instances of Authorino running in the same space (Kubernetes namespace or cluster-scoped), yet watching particular sets of resources.
 

--- a/docs/user-guides/host-override.md
+++ b/docs/user-guides/host-override.md
@@ -1,0 +1,118 @@
+# Host override via context extension
+
+By default, Authorino uses the host information of the HTTP request ([`Attributes.Http.Host`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/attribute_context.proto#service-auth-v3-attributecontext-httprequest)) to lookup for a cached AuthConfig to be enforced. The host info be overridden by supplying a `host` entry as a (per-route) context entension ([`Attributes.ContextExtensions`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/attribute_context.proto#envoy-v3-api-field-service-auth-v3-attributecontext-context-extensions)), which takes precedence whenever present.
+
+Overriding the host attribute of the HTTP request can be useful to support use cases such as of **path prefix-based lookup** and **wildcard subdomains lookup**.
+
+- [Example of host override for path prefix-based lookup](#example-of-host-override-for-path-prefix-based-lookup)
+- [Example of host override for wildcard subdomain lookup](#example-of-host-override-for-wildcard-subdomain-lookup)
+
+For further details about Authorino lookup of AuthConfig, check out [Host lookup](./../architecture.md#host-lookup).
+
+## Example of host override for path prefix-based lookup
+
+In this use case, 2 different APIs (i.e. **Dogs API** and **Cats API**) are served under the same base domain, and differentiated by the path prefix:
+- `pets.com/dogs` →  Dogs API
+- `pets.com/cats` →  Cats API
+
+Edit the Envoy config to extend the external authorization settings at the level of the routes, with the `host` value that will be favored by Authorino before the actual host attribute of the HTTP request:
+
+```yaml
+virtual_hosts:
+- name: pets-api
+  domains: ['pets.com']
+  routes:
+  - match:
+      prefix: /dogs
+    route:
+      cluster: dogs-api
+    typed_per_filter_config:
+      envoy.filters.http.ext_authz:
+        \"@type\": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+        check_settings:
+          context_extensions:
+            host: dogs.pets.com
+  - match:
+      prefix: /cats
+    route:
+      cluster: cats-api
+    typed_per_filter_config:
+      envoy.filters.http.ext_authz:
+        \"@type\": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+        check_settings:
+          context_extensions:
+            host: cats.pets.com
+```
+
+Create the AuthConfig for the **Pets API**:
+
+```yaml
+apiVersion: authorino.kuadrant.io/v1beta1
+kind: AuthConfig
+metadata:
+  name: dogs-api-protection
+spec:
+  hosts:
+  - dogs.pets.com
+
+  identity: [...]
+```
+
+Create the AuthConfig for the **Cats API**:
+
+```yaml
+apiVersion: authorino.kuadrant.io/v1beta1
+kind: AuthConfig
+metadata:
+  name: cats-api-protection
+spec:
+  hosts:
+  - cats.pets.com
+
+  identity: [...]
+```
+
+Notice that the host subdomains `dogs.pets.com` and `cats.pets.com` are not really requested by the API consumers. Rather, users send requests to `pets.com/dogs` and `pets.com/cats`. When routing those requests, Envoy makes sure to inject the corresponding context extensions that will induce the right lookup in Authorino.
+
+## Example of host override for wildcard subdomain lookup
+
+In this use case, a single **Pets API** serves requests for any subdomain that matches `*.pets.com`, e.g.:
+- `dogs.pets.com` →  Pets API
+- `cats.pets.com` →  Pets API
+
+Edit the Envoy config to extend the external authorization settings at the level of the virtual host, with the `host` value that will be favored by Authorino before the actual host attribute of the HTTP request:
+
+```yaml
+virtual_hosts:
+- name: pets-api
+  domains: ['*.pets.com']
+  typed_per_filter_config:
+    envoy.filters.http.ext_authz:
+      \"@type\": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+      check_settings:
+        context_extensions:
+          host: pets.com
+  routes:
+  - match:
+      prefix: /
+    route:
+      cluster: pets-api
+```
+
+The `host` context extension used above is any key that matches one of the hosts listed in the targeted AuthConfig.
+
+Create the AuthConfig for the **Pets API**:
+
+```yaml
+apiVersion: authorino.kuadrant.io/v1beta1
+kind: AuthConfig
+metadata:
+  name: pets-api-protection
+spec:
+  hosts:
+  - pets.com
+
+  identity: [...]
+```
+
+Notice that requests to `dogs.pets.com` and to `cats.pets.com` are all routed by Envoy to the same API, with same external authorization configuration. in all the cases, Authorino will lookup for the cached AuthConfig associated with `pets.com`. The same is valid for a request sent, e.g., to `birds.pets.com`.


### PR DESCRIPTION
Adds support for the "host" AuthConfig lookup key to be provided in the payload to the /Check request as Envoy ext-authz per-route "context extension".

Authorino will favor the "host" lookup key whenever passed in the context extensions before the actual "host" HTTP attribute.

This is an alternative approach for enhanced AuthConfig lookups, without changing the lookup structure too much, although relying more on Envoy to set the right payload.

This should be enough to cover use cases such as of path-based AuthConfig lookup and wildcard subdomains AuthConfig lookup.

Closes #222
Closes #171

----

### Verification steps

#### Path-based AuthConfig lookup use case

In this use case, 2 different APIs are behind the same base domain and differentiated by the path prefix:
- `pets.com/dogs` →  Dogs API
- `pets.com/cats` →  Cats API

Build and deploy this branch:

```
make local-setup
```

Edit the sample Envoy config to include the required 'host' context extension that will make Authorino to favour this as lookup key before the actual host of the request:

```sh
kubectl -n authorino edit configmap/envoy
```

```yaml
[...]
routes:
- match:
    prefix: /dogs
  route:
    cluster: talker-api
  typed_per_filter_config:
    envoy.filters.http.ext_authz:
      \"@type\": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
      check_settings:
        context_extensions:
          host: dogs.pets.com
- match:
    prefix: /cats
  route:
    cluster: talker-api
  typed_per_filter_config:
    envoy.filters.http.ext_authz:
      \"@type\": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
      check_settings:
        context_extensions:
          host: cats.pets.com
[...]
```

In the above, we've used the same upstream API (i.e. `talker-api`) for both routes only for demo purposes. In a real-life scenario, "dogs" and "cats" would be 2 different upstream APIs.

Restart Envoy:

```sh
kubectl -n authorino rollout restart deployments/envoy
```

Forward the requests:

```sh
kubectl -n authorino port-forward deployment/envoy 8000:8000 &
```

Apply the AuthConfigs:

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: dogs
spec:
  hosts:
  - dogs.pets.com
  identity:
  - name: friends
    apiKey:
      labelSelectors:
        api: dogs-api
    credentials:
      in: authorization_header
      keySelector: APIKEY
EOF
```

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: cats
spec:
  hosts:
  - cats.pets.com
  identity:
  - name: friends
    apiKey:
      labelSelectors:
        api: cats-api
    credentials:
      in: authorization_header
      keySelector: APIKEY
EOF
```

Create the API keys:

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: v1
kind: Secret
metadata:
  name: api-key-1
  labels:
    authorino.kuadrant.io/managed-by: authorino
    api: dogs-api
stringData:
  api_key: ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx
type: Opaque
EOF
```

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: v1
kind: Secret
metadata:
  name: api-key-2
  labels:
    authorino.kuadrant.io/managed-by: authorino
    api: cats-api
stringData:
  api_key: WBGo87IR29ifJKUfxZvL8zLqBKYPRg2g
type: Opaque
EOF
```

Consume the APIs under same base domain:

```sh
curl -H 'Host: pets.com' -H 'Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx' http://localhost:8000/dogs -i
# 200

curl -H 'Host: pets.com' -H 'Authorization: APIKEY WBGo87IR29ifJKUfxZvL8zLqBKYPRg2g' http://localhost:8000/dogs -i
# 401
```

```sh
curl -H 'Host: pets.com' -H 'Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx' http://localhost:8000/cats -i
# 401

curl -H 'Host: pets.com' -H 'Authorization: APIKEY WBGo87IR29ifJKUfxZvL8zLqBKYPRg2g' http://localhost:8000/cats -i
# 200
```

#### Wildcard subdomain AuthConfig lookup use case

In this use case, a single Pets API serves requests for any subdomain that matches `*.pets.com`, e.g.:
- `dogs.pets.com` →  Pets API
- `cats.pets.com` →  Pets API

Build and deploy this branch:

```
make local-setup
```

Edit the sample Envoy config to include the required 'host' context extension that will make Authorino to favour this as lookup key before the actual host of the request:

```sh
kubectl -n authorino edit configmap/envoy
```

```yaml
[...]
virtual_hosts:
- name: local_service
  domains: ['*.pets.com']
  typed_per_filter_config:
    envoy.filters.http.ext_authz:
      \"@type\": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
      check_settings:
        context_extensions:
          host: pets.com
[...]
```

The "host" context extension above is any key that matches one of the hosts listed in the targeted AuthConfig.

Restart Envoy:

```sh
kubectl -n authorino rollout restart deployments/envoy
```

Forward the requests:

```sh
kubectl -n authorino port-forward deployment/envoy 8000:8000 &
```

Apply the AuthConfig:

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: pets
spec:
  hosts:
  - pets.com
  identity:
  - name: friends
    apiKey:
      labelSelectors:
        group: friends
    credentials:
      in: authorization_header
      keySelector: APIKEY
EOF
```

Create an API key:

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: v1
kind: Secret
metadata:
  name: api-key-1
  labels:
    authorino.kuadrant.io/managed-by: authorino
    group: friends
stringData:
  api_key: ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx
type: Opaque
EOF
```

Consume the API under different subdomains:

```sh
curl -H 'Host: dogs.pets.com' -H 'Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx' http://localhost:8000 -i
# 200
```

```sh
curl -H 'Host: cats.pets.com' -H 'Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx' http://localhost:8000 -i
# 200
```