### PR TITLE
[bugfix] Envoy Dynamic Metadata with static values

### DIFF
--- a/pkg/service/auth_test.go
+++ b/pkg/service/auth_test.go
@@ -16,6 +16,7 @@ import (
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/gogo/googleapis/google/rpc"
 	"github.com/golang/mock/gomock"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func getHeader(headers []*envoy_core.HeaderValueOption, key string) string {
@@ -114,5 +115,17 @@ func TestAuthConfigLookup(t *testing.T) {
 		ContextExtensions: map[string]string{"host": "host-overwrite"},
 	}})
 	assert.Equal(t, int32(resp.GetDeniedResponse().Status.Code), int32(401))
+	assert.NilError(t, err)
+}
+
+func TestBuildDynamicEnvoyMetadata(t *testing.T) {
+	data := map[string]interface{}{
+		"foo": runtime.RawExtension{
+			Raw: []byte(`"value"`),
+		},
+	}
+
+	_, err := buildEnvoyDynamicMetadata(data)
+
 	assert.NilError(t, err)
 }


### PR DESCRIPTION
Prevents Envoy Dynamic Metadata generation to break with Kubernetes API RawExtension values.

Closes #232

----

### Verification steps

Deploy based on this branch:

```sh
make local-setup
make limitador
kubectl -n authorino port-forward deployment/envoy 8000:8000 &
```

Create the AuthConfig:

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: talker-api-protection
spec:
  hosts:
  - talker-api-authorino.127.0.0.1.nip.io
  identity:
  - name: anonymous
    anonymous: {}
  response:
  - name: rate-limit
    wrapper: envoyDynamicMetadata
    wrapperKey: ext_auth_data
    json:
      properties:
      - name: username
        value: john
EOF
```

Send requests:

```sh
curl http://talker-api-authorino.127.0.0.1.nip.io:8000 # 200
curl http://talker-api-authorino.127.0.0.1.nip.io:8000 # 200
curl http://talker-api-authorino.127.0.0.1.nip.io:8000 # 200
curl http://talker-api-authorino.127.0.0.1.nip.io:8000 # 200
curl http://talker-api-authorino.127.0.0.1.nip.io:8000 # 200
curl http://talker-api-authorino.127.0.0.1.nip.io:8000 # 429
```

Without the fix, the 6th request would also return a 200 instead of a 429. This is because Authorino would fail to generate the Envoy dynamic metadata due to the static value set in one of the properties of the source object, and that would cause Envoy not to call the rate-limit service.