### PR TITLE
AuthConfig status update after cache

### DIFF
--- a/controllers/auth_config_status_updater_test.go
+++ b/controllers/auth_config_status_updater_test.go
@@ -5,8 +5,11 @@ import (
 	"testing"
 
 	api "github.com/kuadrant/authorino/api/v1beta1"
+	"github.com/kuadrant/authorino/pkg/cache"
+	mock_cache "github.com/kuadrant/authorino/pkg/cache/mocks"
 	"github.com/kuadrant/authorino/pkg/log"
 
+	"github.com/golang/mock/gomock"
 	"gotest.tools/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,18 +38,23 @@ func newStatusUpdateAuthConfig(authConfigLabels map[string]string) api.AuthConfi
 	}
 }
 
-func newStatusUpdaterReconciler(client client.WithWatch) *AuthConfigStatusUpdater {
+func newStatusUpdaterReconciler(client client.WithWatch, c cache.Cache) *AuthConfigStatusUpdater {
 	return &AuthConfigStatusUpdater{
 		Client: client,
 		Logger: log.WithName("test").WithName("authconfigstatusupdater"),
+		Cache:  c,
 	}
 }
 
 func TestAuthConfigStatusUpdater_Reconcile(t *testing.T) {
+	mockctrl := gomock.NewController(t)
+	defer mockctrl.Finish()
+	cache := mock_cache.NewMockCache(mockctrl)
+	cache.EXPECT().FindKeys("authorino/auth-config-1").Return([]string{"echo-api"})
 	authConfig := newStatusUpdateAuthConfig(map[string]string{})
 	resourceName := types.NamespacedName{Namespace: authConfig.Namespace, Name: authConfig.Name}
 	client := newTestK8sClient(&authConfig)
-	reconciler := newStatusUpdaterReconciler(client)
+	reconciler := newStatusUpdaterReconciler(client, cache)
 
 	result, err := reconciler.Reconcile(context.Background(), controllerruntime.Request{NamespacedName: resourceName})
 
@@ -59,10 +67,14 @@ func TestAuthConfigStatusUpdater_Reconcile(t *testing.T) {
 }
 
 func TestAuthConfigStatusUpdater_MissingWatchedAuthConfigLabels(t *testing.T) {
+	mockctrl := gomock.NewController(t)
+	defer mockctrl.Finish()
+	cache := mock_cache.NewMockCache(mockctrl)
+	cache.EXPECT().FindKeys("authorino/auth-config-1").Return([]string{"echo-api"})
 	authConfig := newTestAuthConfig(map[string]string{"authorino.kuadrant.io/managed-by": "authorino"})
 	resourceName := types.NamespacedName{Namespace: authConfig.Namespace, Name: authConfig.Name}
 	client := newTestK8sClient(&authConfig)
-	reconciler := newStatusUpdaterReconciler(client)
+	reconciler := newStatusUpdaterReconciler(client, cache)
 
 	result, err := reconciler.Reconcile(context.Background(), controllerruntime.Request{NamespacedName: resourceName})
 
@@ -75,10 +87,14 @@ func TestAuthConfigStatusUpdater_MissingWatchedAuthConfigLabels(t *testing.T) {
 }
 
 func TestAuthConfigStatusUpdater_MatchingAuthConfigLabels(t *testing.T) {
+	mockctrl := gomock.NewController(t)
+	defer mockctrl.Finish()
+	cache := mock_cache.NewMockCache(mockctrl)
+	cache.EXPECT().FindKeys("authorino/auth-config-1").Return([]string{"echo-api"})
 	authConfig := newTestAuthConfig(map[string]string{"authorino.kuadrant.io/managed-by": "authorino"})
 	resourceName := types.NamespacedName{Namespace: authConfig.Namespace, Name: authConfig.Name}
 	client := newTestK8sClient(&authConfig)
-	reconciler := newStatusUpdaterReconciler(client)
+	reconciler := newStatusUpdaterReconciler(client, cache)
 	reconciler.LabelSelector = ToLabelSelector("authorino.kuadrant.io/managed-by=authorino")
 
 	result, err := reconciler.Reconcile(context.Background(), controllerruntime.Request{NamespacedName: resourceName})
@@ -92,15 +108,38 @@ func TestAuthConfigStatusUpdater_MatchingAuthConfigLabels(t *testing.T) {
 }
 
 func TestAuthConfigStatusUpdater_UnmatchingAuthConfigLabels(t *testing.T) {
+	mockctrl := gomock.NewController(t)
+	defer mockctrl.Finish()
+	cache := mock_cache.NewMockCache(mockctrl)
 	authConfig := newTestAuthConfig(map[string]string{"authorino.kuadrant.io/managed-by": "other"})
 	resourceName := types.NamespacedName{Namespace: authConfig.Namespace, Name: authConfig.Name}
 	client := newTestK8sClient(&authConfig)
-	reconciler := newStatusUpdaterReconciler(client)
+	reconciler := newStatusUpdaterReconciler(client, cache)
 	reconciler.LabelSelector = ToLabelSelector("authorino.kuadrant.io/managed-by=authorino")
 
 	result, err := reconciler.Reconcile(context.Background(), controllerruntime.Request{NamespacedName: resourceName})
 
 	assert.Equal(t, result, ctrl.Result{})
+	assert.NilError(t, err)
+
+	authConfigCheck := api.AuthConfig{}
+	_ = client.Get(context.TODO(), resourceName, &authConfigCheck)
+	assert.Check(t, !authConfigCheck.Status.Ready)
+}
+
+func TestAuthConfigStatusUpdater_NotReady(t *testing.T) {
+	mockctrl := gomock.NewController(t)
+	defer mockctrl.Finish()
+	cache := mock_cache.NewMockCache(mockctrl)
+	cache.EXPECT().FindKeys("authorino/auth-config-1").Return([]string{})
+	authConfig := newStatusUpdateAuthConfig(map[string]string{})
+	resourceName := types.NamespacedName{Namespace: authConfig.Namespace, Name: authConfig.Name}
+	client := newTestK8sClient(&authConfig)
+	reconciler := newStatusUpdaterReconciler(client, cache)
+
+	result, err := reconciler.Reconcile(context.Background(), controllerruntime.Request{NamespacedName: resourceName})
+
+	assert.Check(t, result.Requeue)
 	assert.NilError(t, err)
 
 	authConfigCheck := api.AuthConfig{}

--- a/main.go
+++ b/main.go
@@ -219,6 +219,7 @@ func main() {
 	if err = (&controllers.AuthConfigStatusUpdater{
 		Client:        statusUpdateManager.GetClient(),
 		Logger:        controllerLogger.WithName("authconfig").WithName("statusupdater"),
+		Cache:         cache,
 		LabelSelector: controllers.ToLabelSelector(watchedAuthConfigLabelSelector),
 	}).SetupWithManager(statusUpdateManager); err != nil {
 		logger.Error(err, "unable to create controller", "controller", "authconfigstatusupdate")


### PR DESCRIPTION
Makes the status updater to wait until the AuthConfig is added to the cache before marking the resource as ready.