### PR TITLE
e2e tests

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,0 +1,28 @@
+name: End-to-end Tests
+
+on: [workflow_dispatch, push]
+
+jobs:
+  e2e-tests:
+    name: End-to-end Tests
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+      - name: Install jq
+        run: sudo apt-get install jq
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run make e2e
+        run: |
+          make e2e

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,9 @@ deploy: certs
 	TEMP_FILE=/tmp/authorino-deploy-$$(openssl rand -hex 4).yaml ;\
 	cp $(AUTHORINO_CR) $$TEMP_FILE ;\
 	sed -i "s/\$$(AUTHORINO_INSTANCE)/$(AUTHORINO_INSTANCE)/g;s/\$$(TLS_ENABLED)/$(TLS_ENABLED)/g" $$TEMP_FILE ;\
+	if [ "$(FF)" != "1" ]; then \
 	$(EDITOR) $$TEMP_FILE ;\
+	fi ;\
 	kubectl -n $(NAMESPACE) apply -f $$TEMP_FILE ;\
 	rm -rf $$TEMP_FILE ;\
 	}
@@ -157,7 +159,7 @@ endif
 
 # Local setup...........................................................................................................
 
-.PHONY: namespace example-apps limitador cluster local-build local-setup local-rollout local-cleanup
+.PHONY: namespace example-apps limitador cluster local-build local-setup local-rollout local-cleanup e2e
 
 KIND_VERSION=v0.11.1
 kind:
@@ -217,3 +219,7 @@ endif
 # Install Limitador to the Kubernetes cluster
 limitador:
 	kubectl -n $(NAMESPACE) apply -f https://raw.githubusercontent.com/kuadrant/authorino-examples/main/limitador/limitador-deploy.yaml
+
+e2e:
+	$(MAKE) local-setup NAMESPACE=$(NAMESPACE) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) AUTHORINO_IMAGE=$(AUTHORINO_IMAGE) TLS_ENABLED=$(TLS_ENABLED) OPERATOR_BRANCH=$(OPERATOR_BRANCH) AUTHORINO_MANIFESTS=$(AUTHORINO_MANIFESTS) AUTHORINO_INSTANCE=$(AUTHORINO_INSTANCE) ENVOY_OVERLAY=$(ENVOY_OVERLAY) DEPLOY_KEYCLOAK=1 FF=1
+	NAMESPACE=$(NAMESPACE) ./tests/e2e-test.sh

--- a/tests/authconfig.yaml
+++ b/tests/authconfig.yaml
@@ -1,0 +1,290 @@
+apiVersion: authorino.kuadrant.io/v1beta1
+kind: AuthConfig
+metadata:
+  name: e2e-test
+spec:
+  hosts:
+  - talker-api-authorino.127.0.0.1.nip.io
+
+  patterns:
+    admin-path:
+    - selector: context.request.http.path
+      operator: matches
+      value: ^/admin(/.*)?$
+    resource-path:
+    - selector: context.request.http.path
+      operator: matches
+      value: ^/greetings/\d+$
+
+  identity:
+  - name: k8s-auth
+    kubernetes:
+      audiences:
+      - https://kubernetes.default.svc.cluster.local
+    extendedProperties:
+    - name: kubernetes-rbac
+      value: true
+    - name: username
+      valueFrom: { authJSON: auth.identity.sub }
+  - name: api-key
+    apiKey:
+      labelSelectors:
+        app: talker-api
+    credentials:
+      in: custom_header
+      keySelector: X-API-KEY
+    extendedProperties:
+    - name: kubernetes-rbac
+      value: true
+    - name: username
+      valueFrom: { authJSON: auth.identity.metadata.annotations.username }
+  - name: keycloak
+    oidc:
+      endpoint: http://keycloak.authorino.svc.cluster.local:8080/auth/realms/kuadrant
+      ttl: 60
+    extendedProperties:
+    - name: jwt-rbac
+      value: true
+    - name: username
+      valueFrom: { authJSON: auth.identity.preferred_username }
+    - name: roles
+      valueFrom: { authJSON: auth.identity.realm_access.roles }
+  - name: oauth2-introspection
+    oauth2:
+      tokenIntrospectionUrl: http://keycloak.authorino.svc.cluster.local:8080/auth/realms/kuadrant/protocol/openid-connect/token/introspect
+      tokenTypeHint: requesting_party_token
+      credentialsRef:
+        name: oauth2-token-introspection-credentials-keycloak
+    credentials:
+      in: authorization_header
+      keySelector: Opaque
+    extendedProperties:
+    - name: jwt-rbac
+      value: true
+    - name: username
+      valueFrom: { authJSON: auth.identity.preferred_username }
+    - name: roles
+      valueFrom: { authJSON: auth.identity.realm_access.roles }
+  - name: anonymous
+    anonymous: {}
+    priority: 1
+    when:
+    - selector: context.request.http.method
+      operator: eq
+      value: GET
+    - selector: context.request.http.path
+      operator: matches
+      value: ^/(geo(/)?)?$
+    extendedProperties:
+    - name: username
+      value: global
+
+  metadata:
+  - name: geo-info
+    when:
+    - selector: context.request.http.path
+      operator: matches
+      value: ^/geo(/)?$
+    http:
+      endpoint: http://ip-api.com/json/{context.request.http.headers.x-forwarded-for.@extract:{"sep":","}}
+      method: GET
+      headers:
+      - name: Accept
+        value: application/json
+  - name: user-info
+    userInfo:
+      identitySource: keycloak
+  - name: resource-info
+    when:
+    - patternRef: resource-path
+    uma:
+      endpoint: http://keycloak.authorino.svc.cluster.local:8080/auth/realms/kuadrant
+      credentialsRef:
+        name: talker-api-uma-credentials
+
+  authorization:
+  - name: allowed-methods
+    opa:
+      externalRegistry:
+        endpoint: https://raw.githubusercontent.com/guicassolato/authorino-opa/main/allowed-methods.rego
+        ttl: 300
+  - name: geofence
+    opa:
+      inlineRego: |
+        country = object.get(object.get(input.auth.metadata, "geo-info", {}), "countryCode", null)
+        allow { is_null(country) }
+        allow {
+          allowed_countries := ["ES", "FR", "IT"]
+          allowed_countries[_] == country
+        }
+      allValues: true
+  - name: admin-kubernetes-rbac
+    when:
+    - patternRef: admin-path
+    - selector: auth.identity.kubernetes-rbac
+      operator: eq
+      value: "true"
+    kubernetes:
+      user:
+        valueFrom: { authJSON: auth.identity.username }
+  - name: admin-jwt-rbac
+    when:
+    - patternRef: admin-path
+    - selector: auth.identity.jwt-rbac
+      operator: eq
+      value: "true"
+    json:
+      rules:
+      - selector: auth.identity.roles
+        operator: incl
+        value: admin
+  - name: resource-owner
+    when:
+    - patternRef: resource-path
+    opa:
+      inlineRego: |
+        allow {
+          resource_attrs := object.get(input.auth.metadata, "resource-info", [])[0]
+          resource_owner := object.get(object.get(resource_attrs, "owner", {}), "id", "")
+          resource_owner == input.auth.identity.sub
+        }
+  - name: timestamp
+    opa:
+      inlineRego: |
+        now = time.now_ns() / 1000000000
+        allow = true
+      allValues: true
+    priority: 1
+
+  response:
+  - name: x-auth-data
+    json:
+      properties:
+      - name: username
+        valueFrom: { authJSON: auth.identity.username }
+      - name: geo
+        valueFrom: { authJSON: auth.metadata.geo-info }
+      - name: timestamp
+        valueFrom: { authJSON: auth.authorization.timestamp.now }
+  - name: rate-limit-data
+    wrapper: envoyDynamicMetadata
+    wrapperKey: ext_auth_data
+    json:
+      properties:
+      - name: username
+        valueFrom: { authJSON: auth.identity.username }
+  - name: wristband
+    wristband:
+      issuer: http://authorino-authorino-oidc.authorino.svc.cluster.local:8083/authorino/all-features/wristband
+      tokenDuration: 300
+      customClaims:
+      - name: username
+        valueFrom: { authJSON: auth.identity.username }
+      - name: uri
+        valueFrom: { authJSON: context.request.http.path }
+      - name: scope
+        valueFrom: { authJSON: context.request.http.method.@case:lower }
+      signingKeyRefs:
+        - name: wristband-signing-key
+          algorithm: ES256
+    when:
+    - selector: auth.identity.anonymous
+      operator: neq
+      value: "true"
+
+  denyWith:
+    unauthenticated:
+      message: "Authentication failed"
+    unauthorized:
+      message: "Access denied"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oauth2-token-introspection-credentials-keycloak
+stringData:
+  clientID: talker-api
+  clientSecret: 523b92b6-625d-4e1e-a313-77e7a8ae4e88
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: talker-api-uma-credentials
+stringData:
+  clientID: talker-api
+  clientSecret: 523b92b6-625d-4e1e-a313-77e7a8ae4e88
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wristband-signing-key
+stringData:
+  key.pem: |
+    -----BEGIN EC PRIVATE KEY-----
+    MHcCAQEEIDHvuf81gVlWGo0hmXGTAnA/HVxGuH8vOc7/8jewcVvqoAoGCCqGSM49
+    AwEHoUQDQgAETJf5NLVKplSYp95TOfhVPqvxvEibRyjrUZwwtpDuQZxJKDysoGwn
+    cnUvHIu23SgW+Ee9lxSmZGhO4eTdQeKxMA==
+    -----END EC PRIVATE KEY-----
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bob-api-key
+  labels:
+    authorino.kuadrant.io/managed-by: authorino
+    app: talker-api
+  annotations:
+    username: bob
+stringData:
+  api_key: ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alice-api-key
+  labels:
+    authorino.kuadrant.io/managed-by: authorino
+    app: talker-api
+  annotations:
+    username: alice
+stringData:
+  api_key: pR2zLorYFIYOE4LLiQAWMPIRei1YgRBy
+type: Opaque
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: app-1-sa
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: app-2-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: talker-api-admin
+rules:
+- nonResourceURLs: ["/admin*"]
+  verbs: ["get", "post"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: talker-api-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: talker-api-admin
+subjects:
+- kind: User
+  name: bob
+  namespace: bob
+- kind: ServiceAccount
+  name: app-1-sa
+  namespace: authorino

--- a/tests/authconfig.yaml
+++ b/tests/authconfig.yaml
@@ -86,7 +86,7 @@ spec:
       operator: matches
       value: ^/geo(/)?$
     http:
-      endpoint: http://ip-api.com/json/{context.request.http.headers.x-forwarded-for.@extract:{"sep":","}}
+      endpoint: http://ip-location.authorino.svc.cluster.local:3000/{context.request.http.headers.x-forwarded-for.@extract:{"sep":","}}
       method: GET
       headers:
       - name: Accept
@@ -111,7 +111,7 @@ spec:
   - name: geofence
     opa:
       inlineRego: |
-        country = object.get(object.get(input.auth.metadata, "geo-info", {}), "countryCode", null)
+        country = object.get(object.get(input.auth.metadata, "geo-info", {}), "country_iso_code", null)
         allow { is_null(country) }
         allow {
           allowed_countries := ["ES", "FR", "IT"]

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+
+namespace=${NAMESPACE:-"authorino"}
+authconfig=${AUTHCONFIG:-"$(dirname $(realpath $0))/authconfig.yaml"}
+
+HOSTNAME="talker-api-authorino.127.0.0.1.nip.io"
+IP_IN="109.69.200.56" # IT
+IP_OUT="79.123.45.67" # GB
+
+test_count=0
+
+function wait_until {
+  local what=$1; shift
+  local condition=$1; shift
+  printf "waiting ${what}"
+  while : ; do
+    if [[ "$($1)" =~ $condition ]]; then
+      break
+    fi
+    printf "."
+    sleep 3
+  done
+  echo " condition met"
+}
+
+function teardown {
+  local result=$1
+
+  echo
+  echo
+  echo $result
+
+  if [ "$result" == "FAIL" ]; then
+    exit 1
+  fi
+}
+
+function send {
+  local expected=$1; shift
+  local method=$1; shift
+  local path=$1; shift
+  local region=$1; shift
+  local auth="$@"
+
+  test_count=$((test_count+1))
+  actual=$(curl -H "Host: $HOSTNAME" -H "$auth" -H "X-Forwarded-For: $region" -L -s -o /dev/null -w '%{http_code}' "http://localhost:8000$path" -X $method)
+
+  if [ $actual -ne $expected ]; then
+    echo
+    echo "Test failed [#$test_count]:"
+    echo "  $method $path"
+    if [ "$auth" != "" ]; then
+      echo "  $auth"
+    fi
+    echo "  X-Forwarded-For: $region"
+    echo
+    echo "  Expected: $expected"
+    echo "  Actual: $actual"
+
+    teardown "FAIL"
+  else
+    printf "."
+  fi
+}
+
+function send_requests {
+  local region=$1; shift
+  local auth=$1; shift
+
+  while IFS= read -r line; do
+    req=${line##*( )}
+    if [ "$req" != "" ]; then
+      IFS=' ' read -ra r <<< "$req"
+      send "${r[3]}" "${r[0]}" "${r[1]}" $region $auth
+    fi
+  done <<< "$@"
+}
+
+function send_k8s_sa_requests {
+  local region=$1; shift
+  local sa=$1; shift
+  local access_token=""
+  while [ "$access_token" == "" ]; do
+    access_token=$(curl -k -s -X "POST" "http://localhost:8181/api/v1/namespaces/$namespace/serviceaccounts/$sa/token" \
+      -H 'Content-Type: application/json; charset=utf-8' \
+      -d $'{ "apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest", "spec": { "expirationSeconds": 600 } }' | jq -r '.status.token')
+    sleep 1
+  done
+  local requests="$@"
+
+  send_requests $region "Authorization: Bearer $access_token" "$requests"
+}
+
+function send_api_key_requests {
+  local region=$1; shift
+  local api_key_name=$1; shift
+  local api_key=""
+  while [ "$api_key" == "" ]; do
+    api_key=$(kubectl -n $namespace get secret/$api_key_name -o jsonpath="{.data.api_key}" | base64 -d)
+    sleep 1
+  done
+  local requests="$@"
+
+  send_requests $region "X-API-KEY: $api_key" "$requests"
+}
+
+function send_oidc_requests {
+  local region=$1; shift
+  local user=$1; shift
+  local passwd=$1; shift
+  local access_token=""
+  while [ "$access_token" == "" ]; do
+    access_token=$(kubectl -n $namespace run token-$(hexdump -n 4 -e '4/4 "%0x"' /dev/urandom) --attach --rm --restart=Never -q --image=curlimages/curl -- http://keycloak.$namespace.svc.cluster.local:8080/auth/realms/kuadrant/protocol/openid-connect/token -s -d 'grant_type=password' -d 'client_id=demo' -d "username=$user" -d "password=$passwd" 2>/dev/null | jq -r .access_token)
+    sleep 1
+  done
+  local requests="$@"
+
+  send_requests $region "Authorization: Bearer $access_token" "$requests"
+}
+
+function send_oauth_opaque_requests {
+  local region=$1; shift
+  local user=$1; shift
+  local passwd=$1; shift
+  local access_token=""
+  while [ "$access_token" == "" ]; do
+    access_token=$(kubectl -n $namespace run token-$(hexdump -n 4 -e '4/4 "%0x"' /dev/urandom) --attach --rm --restart=Never -q --image=curlimages/curl -- http://keycloak.$namespace.svc.cluster.local:8080/auth/realms/kuadrant/protocol/openid-connect/token -s -d 'grant_type=password' -d 'client_id=demo' -d "username=$user" -d "password=$passwd" 2>/dev/null | jq -r .access_token)
+    sleep 1
+  done
+  local requests="$@"
+
+  send_requests $region "Authorization: Opaque $access_token" "$requests"
+}
+
+function send_anonymous_requests {
+  local region=$1; shift
+  local requests="$@"
+
+  send_requests $region "" "$requests"
+}
+
+kubectl -n kube-system wait --timeout=300s --for=condition=Available deployments --all
+kubectl proxy --port=8181 2>&1 >/dev/null &
+
+kubectl -n $namespace wait --timeout=300s --for=condition=Available deployments --all
+kubectl -n $namespace port-forward deployment/envoy 8000:8000 2>&1 >/dev/null &
+
+# waiting for keycloak to be ready is hard
+wait_until "keycloak ready" "Admin console listening" "kubectl -n $namespace logs $(kubectl -n $namespace get pods -l app=keycloak -o name) --tail 1"
+kubectl -n $namespace port-forward deployment/keycloak 8080:8080 2>&1 >/dev/null &
+wait_until "oidc config ready" "^200$" "curl -o /dev/null -s -w %{http_code} --max-time 2 http://localhost:8080/auth/realms/kuadrant/.well-known/openid-configuration"
+
+# authconfig
+kubectl -n $namespace apply -f $authconfig
+wait_until "authconfig ready" "^true$" "kubectl -n $namespace get authconfigs/e2e-test -o jsonpath={.status.ready}"
+
+# tests
+echo
+echo "running tests"
+
+send_k8s_sa_requests $IP_IN "app-1-sa" "
+    GET / => 200
+    POST / => 200
+    DELETE / => 403
+    GET /admin => 200
+    GET /greetings/1 => 403"
+
+send_k8s_sa_requests $IP_IN "app-2-sa" "
+    GET / => 200
+    POST / => 200
+    DELETE / => 403
+    GET /admin => 403
+    GET /greetings/1 => 403"
+
+send_api_key_requests $IP_IN "bob-api-key" "
+    GET / => 200
+    POST / => 200
+    DELETE / => 403
+    GET /admin => 200
+    GET /greetings/1 => 403"
+
+send_api_key_requests $IP_IN "alice-api-key" "
+    GET / => 200
+    POST / => 200
+    DELETE / => 403
+    GET /admin => 403
+    GET /greetings/1 => 403"
+
+send_oidc_requests $IP_IN "john" "p" "
+    GET / => 200
+    POST / => 200
+    DELETE / => 403
+    GET /admin => 403
+    GET /greetings/1 => 200"
+
+send_oidc_requests $IP_IN "jane" "p" "
+    GET / => 200
+    POST / => 200
+    DELETE / => 403
+    GET /admin => 200
+    GET /greetings/1 => 403"
+
+send_oauth_opaque_requests $IP_IN "peter" "p" "
+    GET / => 200
+    POST / => 200
+    DELETE / => 403
+    GET /admin => 403
+    GET /greetings/1 => 403"
+
+send_anonymous_requests $IP_IN "
+    GET / => 200
+    POST / => 401
+    DELETE / => 401
+    GET /admin => 401
+    GET /greetings/1 => 401"
+
+send_anonymous_requests $IP_IN "
+    GET /geo => 200"
+
+send_anonymous_requests $IP_OUT "
+    GET /geo => 403"
+
+teardown "SUCCESS"

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -142,6 +142,7 @@ function send_anonymous_requests {
 kubectl -n kube-system wait --timeout=300s --for=condition=Available deployments --all
 kubectl proxy --port=8181 2>&1 >/dev/null &
 
+kubectl -n $namespace apply -f https://raw.githubusercontent.com/Kuadrant/authorino-examples/main/ip-location/ip-location-deploy.yaml
 kubectl -n $namespace wait --timeout=300s --for=condition=Available deployments --all
 kubectl -n $namespace port-forward deployment/envoy 8000:8000 2>&1 >/dev/null &
 


### PR DESCRIPTION
Plan:
1. End-to-end tests (revamps #39) <==== this PR
2. Remove auto-trigger from 'End-to-end Tests' workflow
3. Add 'Integration Tests'

**End-to-end Tests:** triggered manually for any arbitrary branch/Operator version
```
[Manual trigger] -> Fetch the code -> Install deps -> Build the image -> Deploy -> Run the tests
```

**Integration Tests:** triggered automatically on success of ‘Build and push image’
```
[Build and push image] -> Install deps -> Pull image from quay.io -> Deploy -> Run the tests
```

### Detailed workflow steps

```
.------------------.   .-------------------.
| End-to-end Tests |   | Integration Tests |
 ------------------     -------------------
                      
                 Install Go
                     |
                 Install jq
                   /   \
  Fetch the branch      Install kind
          |                  |
      make e3e             Create
 (make local-setup      kind cluster
   + e2e-test.sh)            |
                     Install cert-manager
                             |
                  Install Authorino Operator
                             |
                      Create namespace
                             |
                      Create Authorino
                      TLS certificates
                             |
                 Create Authorino instance
                             |
                    Deploy Talker API
                             |
                       Deploy Envoy
                             |
                     Deploy Keycloak
                             |
                  Run integrations tests
                       (e2e-test.sh)
```

**e2e-test.sh:**
1. Deploy [ip-location](https://github.com/Kuadrant/authorino-examples#ip-location) service
2. Ensure all components are ready
3. Tunnel required services for access from localhost (kube proxy and envoy port-forward)
4. Apply AuthConfig
    - K8s SA tokens authn
    - API key authn
    - OIDC/JWT authn (cache TTL on)
    - OAuth2 token introspection authn
    - Token normalization
    - Anonymous access (restricted endpoints/methods)
    - HTTP external metadata
    - OIDC userinfo metadata
    - UMA resource metadata
    - OPA authz (external policy, cache TTL on)
    - OPA authz (inline Rego, with and without "fuzzy" response)
    - K8s SubjectAccessReview authz (non-resource attributes)
    - JSON pattern-matching authz
    - Dynamic JSON response (injected header)
    - Dynamic JSON response (Envoy Dynamic Metadata)
    - Wristband token
    - Custom denial status messages
    - Conditional evaluators (at least 1 in each phase)
5. Send requests (with curl) checking each expected HTTP response status

### Try locally

```
make e2e
```