### PR TITLE
Removes denyWith response message when body is not set

### DIFF
--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -225,7 +225,9 @@ func buildResponseHeadersWithReason(authReason string, extraHeaders []map[string
 		headers = make([]map[string]string, 0)
 	}
 
-	headers = append(headers, map[string]string{X_EXT_AUTH_REASON_HEADER: authReason})
+	if authReason != "" {
+		headers = append(headers, map[string]string{X_EXT_AUTH_REASON_HEADER: authReason})
+	}
 
 	return buildResponseHeaders(headers)
 }


### PR DESCRIPTION
This PR removes the `x-ext-auth-reason` header from the request response when a denyWith custom message is not set in the AuthConfig

```
AuthConfig
...
spec:
  denyWith:
    unauthenticated:
      code: 302
      headers:
      - name: Location
        valueFrom:
          authJSON: http://matrix-quotes-authorino.127.0.0.1.nip.io:8000/login.html?redirect_to={context.request.http.path}
      message:
        value: bla

## response 
HTTP/1.1 302 Found
location: http://matrix-quotes-authorino.127.0.0.1.nip.io:8000/login.html?redirect_to=/hello
x-ext-auth-reason: bla
date: Thu, 07 Apr 2022 09:01:19 GMT
server: envoy
content-length: 0
```

```
AuthConfig
...
spec:
  denyWith:
    unauthenticated:
      code: 302
      headers:
      - name: Location
        valueFrom:
          authJSON: http://matrix-quotes-authorino.127.0.0.1.nip.io:8000/login.html?redirect_to={context.request.http.path}

## response 
HTTP/1.1 302 Found
location: http://matrix-quotes-authorino.127.0.0.1.nip.io:8000/login.html?redirect_to=/hello
date: Thu, 07 Apr 2022 09:01:19 GMT
server: envoy
content-length: 0
```

## Verification steps

Follow the steps from this PR https://github.com/Kuadrant/authorino/pull/241 remove the `message` field from the AuthConfig and verify if the `x-ext-auth-reason` header has been removed from the response.
