### PR TITLE
Adds custom response message body on request denial

### DIFF
--- a/api/v1beta1/auth_config_types.go
+++ b/api/v1beta1/auth_config_types.go
@@ -527,6 +527,9 @@ type DenyWithSpec struct {
 
 	// HTTP response headers to override the default denial headers.
 	Headers []JsonProperty `json:"headers,omitempty"`
+
+	// HTTP response body to override the default denial body.
+	Body *StaticOrDynamicValue `json:"body,omitempty"`
 }
 
 type DenyWith struct {

--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -538,19 +538,23 @@ func buildAuthorinoDenyWithValues(denyWithSpec *api.DenyWithSpec) *evaluators.De
 		headers = append(headers, json.JSONProperty{Name: header.Name, Value: json.JSONValue{Static: header.Value, Pattern: header.ValueFrom.AuthJSON}})
 	}
 
-	var message *json.JSONProperty
-	if denyWithSpec.Message != nil {
-		message = &json.JSONProperty{
-			Value: json.JSONValue{
-				Static:  denyWithSpec.Message.Value,
-				Pattern: denyWithSpec.Message.ValueFrom.AuthJSON,
-			},
-		}
-	}
-
 	return &evaluators.DenyWithValues{
 		Code:    int32(denyWithSpec.Code),
-		Message: message,
+		Message: getJsonFromStaticDynamic(denyWithSpec.Message),
 		Headers: headers,
+		Body:    getJsonFromStaticDynamic(denyWithSpec.Body),
+	}
+}
+
+func getJsonFromStaticDynamic(value *api.StaticOrDynamicValue) *json.JSONProperty {
+	if value == nil {
+		return nil
+	}
+
+	return &json.JSONProperty{
+		Value: json.JSONValue{
+			Static:  value.Value,
+			Pattern: value.ValueFrom.AuthJSON,
+		},
 	}
 }

--- a/install/crd/authorino.kuadrant.io_authconfigs.yaml
+++ b/install/crd/authorino.kuadrant.io_authconfigs.yaml
@@ -467,6 +467,29 @@ spec:
                   unauthenticated:
                     description: Denial status customization when the request is unauthenticated.
                     properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          value:
+                            description: Static value
+                            type: string
+                          valueFrom:
+                            description: Dynamic value
+                            properties:
+                              authJSON:
+                                description: 'Selector to fetch a value from the authorization
+                                  JSON. It can be any path pattern to fetch from the
+                                  authorization JSON (e.g. ''context.request.http.host'')
+                                  or a string template with variable placeholders
+                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following string modifiers are
+                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, and @base64:encode|decode.'
+                                type: string
+                            type: object
+                        type: object
                       code:
                         description: HTTP status code to override the default denial
                           status code.
@@ -530,6 +553,29 @@ spec:
                   unauthorized:
                     description: Denial status customization when the request is unauthorized.
                     properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          value:
+                            description: Static value
+                            type: string
+                          valueFrom:
+                            description: Dynamic value
+                            properties:
+                              authJSON:
+                                description: 'Selector to fetch a value from the authorization
+                                  JSON. It can be any path pattern to fetch from the
+                                  authorization JSON (e.g. ''context.request.http.host'')
+                                  or a string template with variable placeholders
+                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following string modifiers are
+                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, and @base64:encode|decode.'
+                                type: string
+                            type: object
+                        type: object
                       code:
                         description: HTTP status code to override the default denial
                           status code.

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -510,6 +510,29 @@ spec:
                   unauthenticated:
                     description: Denial status customization when the request is unauthenticated.
                     properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          value:
+                            description: Static value
+                            type: string
+                          valueFrom:
+                            description: Dynamic value
+                            properties:
+                              authJSON:
+                                description: 'Selector to fetch a value from the authorization
+                                  JSON. It can be any path pattern to fetch from the
+                                  authorization JSON (e.g. ''context.request.http.host'')
+                                  or a string template with variable placeholders
+                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following string modifiers are
+                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, and @base64:encode|decode.'
+                                type: string
+                            type: object
+                        type: object
                       code:
                         description: HTTP status code to override the default denial
                           status code.
@@ -573,6 +596,29 @@ spec:
                   unauthorized:
                     description: Denial status customization when the request is unauthorized.
                     properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          value:
+                            description: Static value
+                            type: string
+                          valueFrom:
+                            description: Dynamic value
+                            properties:
+                              authJSON:
+                                description: 'Selector to fetch a value from the authorization
+                                  JSON. It can be any path pattern to fetch from the
+                                  authorization JSON (e.g. ''context.request.http.host'')
+                                  or a string template with variable placeholders
+                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following string modifiers are
+                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, and @base64:encode|decode.'
+                                type: string
+                            type: object
+                        type: object
                       code:
                         description: HTTP status code to override the default denial
                           status code.

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -83,6 +83,9 @@ type AuthResult struct {
 	Headers []map[string]string `json:"headers,omitempty"`
 	// Metadata are Envoy dynamic metadata content
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	// Body in the response of the request
+	// auth check result
+	Body string `json:"body,omitempty"`
 }
 
 // Success tells whether the auth check result was successful and therefore access can be granted to the requested

--- a/pkg/evaluators/config.go
+++ b/pkg/evaluators/config.go
@@ -72,4 +72,5 @@ type DenyWithValues struct {
 	Code    int32
 	Message *json.JSONProperty
 	Headers []json.JSONProperty
+	Body    *json.JSONProperty
 }

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -133,6 +133,7 @@ func (a *AuthService) deniedResponse(authResult auth.AuthResult) *envoy_auth.Che
 					Code: httpCode,
 				},
 				Headers: buildResponseHeadersWithReason(authResult.Message, authResult.Headers),
+				Body:    authResult.Body,
 			},
 		},
 	}

--- a/pkg/service/auth_pipeline.go
+++ b/pkg/service/auth_pipeline.go
@@ -502,6 +502,10 @@ func (pipeline *AuthPipeline) customizeDenyWith(authResult auth.AuthResult, deny
 			authResult.Message, _ = json.StringifyJSON(denyWith.Message.Value.ResolveFor(authJSON))
 		}
 
+		if denyWith.Body != nil {
+			authResult.Body, _ = json.StringifyJSON(denyWith.Body.Value.ResolveFor(authJSON))
+		}
+
 		if len(denyWith.Headers) > 0 {
 			headers := make([]map[string]string, 0)
 			for _, header := range denyWith.Headers {


### PR DESCRIPTION
This PR adds the possibility to add a custom message to the response body of denied requests.

closes https://github.com/Kuadrant/authorino/issues/220

## Verification steps

1) Install and deploy an instance of authorino by running 
```
$ make local-setup
```
2) Apply an Authconfig CR
```
$ kubectl apply -n authorino -f https://raw.githubusercontent.com/kuadrant/authorino-examples/main/hello-world/authconfig.yaml
```
3) Add a denyWith policy to the Authconfig CR
```
spec:
...
  denyWith:
    unauthenticated:
      code: 302
      headers:
      - name: Location
        valueFrom:
          authJSON: http://matrix-quotes-authorino.127.0.0.1.nip.io:8000/login.html?redirect_to={context.request.http.path}
      body:
        valueFrom:
          authJSON: test{context.request.http.path}
```
4) Make a request against the talker API and check the response body has the custom message `test/hello`
```
$ curl http://talker-api-authorino.127.0.0.1.nip.io:8000/hello -i

HTTP/1.1 302 Found
location: http://matrix-quotes-authorino.127.0.0.1.nip.io:8000/login.html?redirect_to=/hello
date: Wed, 06 Apr 2022 10:48:27 GMT
server: envoy
content-length: 0

test/hello
```