### PR TITLE
Fix skipping escape characters within string templates

### DIFF
--- a/pkg/json/json.go
+++ b/pkg/json/json.go
@@ -186,7 +186,9 @@ func ReplaceJSONPlaceholders(source string, jsonData string) string {
 			if insidePlaceholder {
 				buffer = append(buffer, b)
 			} else {
-				replaced = append(replaced, b)
+				if escaping {
+					replaced = append(replaced, b)
+				}
 				escaping = !escaping
 			}
 		default:

--- a/pkg/json/json_test.go
+++ b/pkg/json/json_test.go
@@ -180,17 +180,20 @@ func TestReplaceJSONPlaceholders(t *testing.T) {
 	replaced = ReplaceJSONPlaceholders(`Github username: {auth.identity.github\.com|@extract:{"sep":"/","pos":3}|@case:upper}`, jsonData)
 	assert.Equal(t, replaced, "Github username: JOHN")
 
-	replaced = ReplaceJSONPlaceholders(`This is NOT a \{variable placeholder\}`, jsonData)
-	assert.Equal(t, replaced, `This is NOT a \{variable placeholder\}`)
+	replaced = ReplaceJSONPlaceholders(`This is NOT a \{variable placeholder\}, {auth.identity.username}!`, jsonData)
+	assert.Equal(t, replaced, `This is NOT a {variable placeholder}, john!`)
+
+	replaced = ReplaceJSONPlaceholders(`\{"msg":"I can build a JSON with dynamic values","username":"{auth.identity.github\.com|@extract:{"sep":"/","pos":3}|@case:upper}"\}`, jsonData)
+	assert.Equal(t, replaced, `{"msg":"I can build a JSON with dynamic values","username":"JOHN"}`)
 
 	replaced = ReplaceJSONPlaceholders("{auth.identity.username}", jsonData)
 	assert.Equal(t, replaced, "john")
 
-	replaced = ReplaceJSONPlaceholders(`\\{auth.identity.username}`, jsonData)
-	assert.Equal(t, replaced, `\\john`)
+	replaced = ReplaceJSONPlaceholders(`\\{auth.identity.username} \\o/`, jsonData)
+	assert.Equal(t, replaced, `\john \o/`)
 
 	replaced = ReplaceJSONPlaceholders(`\\\{auth.identity.username\}`, jsonData)
-	assert.Equal(t, replaced, `\\\{auth.identity.username\}`)
+	assert.Equal(t, replaced, `\{auth.identity.username}`)
 
 	// invalid placeholder
 	replaced = ReplaceJSONPlaceholders("username: {auth.identity.username", jsonData)


### PR DESCRIPTION
Closes #249

## Verification steps

Build and deploy:

```sh
make local-setup
kubectl -n authorino port-forward deployment/envoy 8000:8000 &
```

Apply te AuthConfig:

```
kubectl -n authorino apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: talker-api-protection
spec:
  hosts:
  - talker-api-authorino.127.0.0.1.nip.io
  denyWith:
    unauthenticated:
      body:
        valueFrom:
          authJSON: |
            \{"request_path":"{context.request.http.path}"\}
      headers:
      - name: x-content-type
        value: application/json
  identity:
  - apiKey:
      allNamespaces: false
      labelSelectors:
        group: friends
    credentials:
      in: authorization_header
      keySelector: APIKEY
    name: api-clients
```

Send a request:

```sh
curl http://talker-api-authorino.127.0.0.1.nip.io:8000/hello -i
# HTTP/1.1 401 Unauthorized
# x-content-type: application/json
# x-ext-auth-reason: credential not found
# content-length: 26
# content-type: text/plain
# date: Fri, 08 Apr 2022 09:28:03 GMT
# server: envoy
# 
# {"request_path":"/hello"}
```