### PR TITLE
Use GHA implicit git ref instead of user input in the e2e test workflow

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -3,11 +3,8 @@ name: End-to-end Tests
 on:
   workflow_dispatch:
     inputs:
-      gitRef:
-        description: Authorino Git ref to test
-        required: false
       operatorVersion:
-        description: Authorino Operator version. Changes to Authorino manifests (CRD, RBAC) in the tested branch will override the base manifests pulled from the Operator.
+        description: Authorino Operator version
         required: true
         default: latest
 
@@ -33,7 +30,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.inputs.gitRef || github.sha }}
+          ref: ${{ github.sha }}
       - name: Run make e2e
         env:
           OPERATOR_VERSION: ${{ github.event.inputs.operatorVersion }}


### PR DESCRIPTION
GitHub Actions already allows to pick a Git branch when dispatching manual workflows. We can use this ref for the e2e tests instead of asking for user input.

<img width="378" alt="Screenshot 2022-04-08 at 15 33 09" src="https://user-images.githubusercontent.com/1842261/162446171-7cabe3bc-e880-479b-b88c-ba2998a571df.png">

