### PR TITLE
Refactor type of denyWith dynamic values (message and body)

### DIFF
--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -546,15 +546,13 @@ func buildAuthorinoDenyWithValues(denyWithSpec *api.DenyWithSpec) *evaluators.De
 	}
 }
 
-func getJsonFromStaticDynamic(value *api.StaticOrDynamicValue) *json.JSONProperty {
+func getJsonFromStaticDynamic(value *api.StaticOrDynamicValue) *json.JSONValue {
 	if value == nil {
 		return nil
 	}
 
-	return &json.JSONProperty{
-		Value: json.JSONValue{
-			Static:  value.Value,
-			Pattern: value.ValueFrom.AuthJSON,
-		},
+	return &json.JSONValue{
+		Static:  value.Value,
+		Pattern: value.ValueFrom.AuthJSON,
 	}
 }

--- a/pkg/evaluators/config.go
+++ b/pkg/evaluators/config.go
@@ -70,7 +70,7 @@ type DenyWith struct {
 
 type DenyWithValues struct {
 	Code    int32
-	Message *json.JSONProperty
+	Message *json.JSONValue
 	Headers []json.JSONProperty
-	Body    *json.JSONProperty
+	Body    *json.JSONValue
 }

--- a/pkg/service/auth_pipeline.go
+++ b/pkg/service/auth_pipeline.go
@@ -499,11 +499,11 @@ func (pipeline *AuthPipeline) customizeDenyWith(authResult auth.AuthResult, deny
 		authJSON := pipeline.GetAuthorizationJSON()
 
 		if denyWith.Message != nil {
-			authResult.Message, _ = json.StringifyJSON(denyWith.Message.Value.ResolveFor(authJSON))
+			authResult.Message, _ = json.StringifyJSON(denyWith.Message.ResolveFor(authJSON))
 		}
 
 		if denyWith.Body != nil {
-			authResult.Body, _ = json.StringifyJSON(denyWith.Body.Value.ResolveFor(authJSON))
+			authResult.Body, _ = json.StringifyJSON(denyWith.Body.ResolveFor(authJSON))
 		}
 
 		if len(denyWith.Headers) > 0 {

--- a/pkg/service/auth_pipeline_test.go
+++ b/pkg/service/auth_pipeline_test.go
@@ -334,10 +334,8 @@ func TestEvaluateWithCustomDenyOptions(t *testing.T) {
 					{Name: "X-Static-Header", Value: json.JSONValue{Static: "some-value"}},
 					{Name: "Location", Value: json.JSONValue{Pattern: "https://my-app.io/login?redirect_to=https://{context.request.http.host}{context.request.http.path}"}},
 				},
-				Body: &json.JSONProperty{
-					Value: json.JSONValue{
-						Static: authConfigStaticResponse,
-					},
+				Body: &json.JSONValue{
+					Static: authConfigStaticResponse,
 				},
 			},
 		},


### PR DESCRIPTION
We don't actually need a full `JSONProperty, only the value.