### PR TITLE
Avoid static IP addresses in the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ vendor
 *~
 tmp
 target
+.scannerwork

--- a/controllers/auth_config_controller_test.go
+++ b/controllers/auth_config_controller_test.go
@@ -100,13 +100,6 @@ func newTestAuthConfig(authConfigLabels map[string]string) api.AuthConfig {
 									Value:    "admin",
 								},
 							},
-							{
-								JSONPatternExpression: api.JSONPatternExpression{
-									Selector: "attributes.source.address.Address.SocketAddress.address",
-									Operator: "eq",
-									Value:    "80.133.21.75",
-								},
-							},
 						},
 					},
 				},


### PR DESCRIPTION
This will prevent a false-positive on static code analysis pointing to vulnerabilities such as CVE-2006-5901 and CVE-2005-3725, and it is completely unneeded for testing the AuthConfig controller.