### PR TITLE
TLSv1.2

### DIFF
--- a/main.go
+++ b/main.go
@@ -266,6 +266,7 @@ func startExtAuthServerGRPC(authConfigCache cache.Cache) {
 				tlsConfig := &tls.Config{
 					Certificates: []tls.Certificate{tlsCert},
 					ClientAuth:   tls.NoClientCert,
+					MinVersion:   tls.VersionTLS12,
 				}
 				grpcServerOpts = append(grpcServerOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
 			}
@@ -307,7 +308,12 @@ func startOIDCServer(authConfigCache cache.Cache) {
 			var err error
 
 			if tlsEnabled {
-				err = http.ServeTLS(lis, nil, oidcTLSCertPath, oidcTLSCertKeyPath)
+				server := &http.Server{
+					TLSConfig: &tls.Config{
+						MinVersion: tls.VersionTLS12,
+					},
+				}
+				err = server.ServeTLS(lis, oidcTLSCertPath, oidcTLSCertKeyPath)
 			} else {
 				err = http.Serve(lis, nil)
 			}


### PR DESCRIPTION
Sets TLSv1.2 as minimum version of the protocol supported for all connections to the gRPC authorization server and OIDC Festival Wristband server.

### Verification steps

#### 1. Setup

- Deploy Sample API, Envoy and Authorino with TLS enabled
- Create an AuthConfig that issues a Festival Wristband token
- Make sure the OIDC Festival Wristband configs server is reachable – usually, for an instance of Authorino named 'authorino':
    ```sh
    kubectl -n authorino port-forward service/authorino-authorino-oidc 8083:8083 &
    ```

#### 2a. Test the TLS version for the gRPC authorization server

By default Envoy proxy will use TLSv1.2 and all connections to Authorino should work without issues.

Change in the Envoy configuration so an older version of the protocol is used instead of the default.

```yaml
[...]
clusters:
- name: external_auth
  transport_socket:
    name: envoy.transport_sockets.tls
    typed_config:
      "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
      common_tls_context:
        tls_params:
          tls_minimum_protocol_version: "TLSv1_1"
          tls_maximum_protocol_version: "TLSv1_1"
```

Restarting the pod might be needed.

Envoy should now fail to establish connection with Authorino.

#### 2b. Test the TLS version for the OIDC Festival Wristband server 

Client default (TLSv1.3):

```sh
$ curl -k https://localhost:8083 -v
*   Trying ::1:8083...
* TCP_NODELAY set
* Connected to localhost (::1) port 8083 (#0)
Handling connection for 8083
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: <redacted>/cacert.pem
  CApath: none
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: [NONE]
*  start date: Apr 27 16:19:24 2022 GMT
*  expire date: Jul 26 16:19:24 2022 GMT
*  issuer: CN=*.authorino.svc
*  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
> GET / HTTP/1.1
> Host: localhost:8083
> User-Agent: curl/7.65.3
> Accept: */*
>
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* Mark bundle as not supporting multiuse
< HTTP/1.1 404 Not Found
< Date: Wed, 27 Apr 2022 16:41:18 GMT
< Content-Length: 9
< Content-Type: text/plain; charset=utf-8
<
* Connection #0 to host localhost left intact
Not found
```

TLSv1.2:

```sh
$ curl -k https://localhost:8083 -v --tlsv1.2 --tls-max 1.2
*   Trying ::1:8083...
* TCP_NODELAY set
* Connected to localhost (::1) port 8083 (#0)
Handling connection for 8083
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: <redacted>/cacert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: [NONE]
*  start date: Apr 27 16:19:24 2022 GMT
*  expire date: Jul 26 16:19:24 2022 GMT
*  issuer: CN=*.authorino.svc
*  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
> GET / HTTP/1.1
> Host: localhost:8083
> User-Agent: curl/7.65.3
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 404 Not Found
< Date: Wed, 27 Apr 2022 16:41:22 GMT
< Content-Length: 9
< Content-Type: text/plain; charset=utf-8
<
* Connection #0 to host localhost left intact
Not found
```

TLSv1.1:

```sh
$ curl -k https://localhost:8083 -v --tlsv1.1 --tls-max 1.1
*   Trying ::1:8083...
* TCP_NODELAY set
* Connected to localhost (::1) port 8083 (#0)
Handling connection for 8083
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: <redacted>/cacert.pem
  CApath: none
* TLSv1.1 (OUT), TLS handshake, Client hello (1):
* TLSv1.1 (IN), TLS alert, protocol version (582):
* error:1409442E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version
* Closing connection 0

curl: (35) error:1409442E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version
```

----

Closes #266