### PR TITLE
Replace MD5 usage with SHA-256

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"crypto/tls"
 	"encoding/hex"
 	"flag"
@@ -211,7 +211,7 @@ func main() {
 	}()
 
 	// status update manager
-	leaderElectionId := md5.Sum([]byte(watchedAuthConfigLabelSelector))
+	leaderElectionId := sha256.Sum256([]byte(watchedAuthConfigLabelSelector))
 	managerOptions.LeaderElection = enableLeaderElection
 	managerOptions.LeaderElectionID = fmt.Sprintf("%v.%v", hex.EncodeToString(leaderElectionId[:4]), leaderElectionIDSuffix)
 	managerOptions.MetricsBindAddress = "0"

--- a/pkg/evaluators/authorization/opa.go
+++ b/pkg/evaluators/authorization/opa.go
@@ -2,7 +2,7 @@ package authorization
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -180,7 +180,7 @@ func generatePolicyUID(policyName string, policyContent string, nonce int) strin
 
 func hash(s string) string {
 	data := []byte(s)
-	return fmt.Sprintf("%x", md5.Sum(data))
+	return fmt.Sprintf("%x", sha256.Sum256(data))
 }
 
 type responseOpaJson struct {

--- a/pkg/service/oidc.go
+++ b/pkg/service/oidc.go
@@ -1,8 +1,7 @@
 package service
 
 import (
-	"crypto/md5"
-	"encoding/hex"
+	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -34,8 +33,8 @@ type OidcService struct {
 func (o *OidcService) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	uri := req.URL.String()
 
-	requestId := md5.Sum([]byte(fmt.Sprint(req)))
-	requestLogger := log.WithName("service").WithName("oidc").WithValues("request id", hex.EncodeToString(requestId[:16]), "uri", uri)
+	requestId := fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprint(req))))
+	requestLogger := log.WithName("service").WithName("oidc").WithValues("request id", requestId, "uri", uri)
 
 	var statusCode int
 	var responseBody string


### PR DESCRIPTION
Replace all usage of the MD5 algorithm with SHA-256:
- Tracing logs of the OIDC server (`request id`)
- Precompiled OPA policies
- Leader election secrets

Although neither of the above raises security concerns due to not being used for storing hashed sensitive data, but since MD5 algorithm may be disabled altogether in specific deployments, at the level of the operating system, and as a good practice in general, those applications of this algorithms by Authorino should be replaced to rely on at least SHA-1 instead.

Closes #269

### Verification steps

#### Setup

```sh
make local-setup FF=1
kubectl -n authorino patch --type=json deployment/authorino --patch '[{"op":"replace","path":"/spec/template/spec/containers/0/args","value":["--enable-leader-election"]}]'
kubectl -n authorino wait --timeout=300s --for=condition=Available deployments --all
kubectl -n authorino port-forward service/authorino-authorino-oidc 8083:8083 &

kubectl -n authorino apply -f -<<EOF
apiVersion: v1
kind: Secret
metadata:
  name: wristband-signing-key
stringData:
  key.pem: |
    -----BEGIN EC PRIVATE KEY-----
    MHcCAQEEIDHvuf81gVlWGo0hmXGTAnA/HVxGuH8vOc7/8jewcVvqoAoGCCqGSM49
    AwEHoUQDQgAETJf5NLVKplSYp95TOfhVPqvxvEibRyjrUZwwtpDuQZxJKDysoGwn
    cnUvHIu23SgW+Ee9lxSmZGhO4eTdQeKxMA==
    -----END EC PRIVATE KEY-----
type: Opaque
EOF

kubectl -n authorino apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: md5-to-sha1
spec:
  hosts:
  - localhost
  identity:
  - name: anonymous
    anonymous: {}
  authorization:
  - name: trivial-opa
    opa:
      inlineRego: |
        allow = true
  response:
  - name: wristband
    wristband:
      issuer: http://authorino-authorino-oidc.authorino.svc.cluster.local:8083/authorino/md5-to-sha1/wristband
      signingKeyRefs:
      - name: wristband-signing-key
        algorithm: ES256
EOF
```

Watch the logs of the Authorino instance – _It holds the shell!_:
```sh
kubectl -n authorino logs -f $(kubectl -n authorino get pods -l authorino-resource=authorino -o name)
```

#### Check the leader election `Secret`

```sh
kubectl -n authorino get configmaps/e3b0c442.authorino.kuadrant.io -o name
# configmap/e3b0c442.authorino.kuadrant.io
```

where 'e3b0c442' is the first 4 hex bytes of the SHA-256 hash generated out of the empty string (default value of `AUTH_CONFIG_LABEL_SELECTOR`). [Try](https://go.dev/play/p/-siTGl9QLld?v=goprev).

#### Check the `request id` in the tracing logs of the OIDC Festival Wristband server

```sh
curl -k https://localhost:8083
```

Spot in the logs something similar to:

```
INFO	authorino.service.oidc	response sent	{"request id": "fab95f00bd2882e9007e671d520e8d88e9b3ba1ce5c0e267cc978e77dfb1da63", "uri": "/", "status": 404}
```

where 'fab95f00bd2882e9007e671d520e8d88e9b3ba1ce5c0e267cc978e77dfb1da63' is the SHA-256 hash that uniquely identifies the request.

#### Check the internal ID of the OPA policy

By editing the inline Rego to an invalid value, the policy ID shows up in the logs in an error message:

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: md5-to-sha1
spec:
  hosts:
  - localhost
  identity:
  - name: anonymous
    anonymous: {}
  authorization:
  - name: trivial-opa
    opa:
      inlineRego: |
        -invalid-
  response:
  - name: wristband
    wristband:
      issuer: http://authorino-authorino-oidc.authorino.svc.cluster.local:8083/authorino/md5-to-sha1/wristband
      signingKeyRefs:
      - name: wristband-signing-key
        algorithm: ES256
EOF
```

Spot in the logs an error similar to:

```
ERROR	authorino.controller.authconfig	Reconciler error	{"reconciler group": "authorino.kuadrant.io", "reconciler kind": "AuthConfig", "name": "md5-to-sha1", "namespace": "authorino", "error": "2 errors occurred:\n67ba394fc00e0166b4e20f33d722001638dd842eb75082b258a076463aef92e6.rego:4: rego_parse_error: unexpected eof token\n\t-invalid-\n\t        ^\n67ba394fc00e0166b4e20f33d722001638dd842eb75082b258a076463aef92e6.rego:2: rego_parse_error: illegal default rule (value cannot contain call)\n\tdefault allow = false\n\t^"}
```

where '67ba394fc00e0166b4e20f33d722001638dd842eb75082b258a076463aef92e6' is the SHA-256 hash that uniquely identifies the OPA policy.