### PR TITLE
Default to Anonymous access

### DIFF
--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -128,7 +128,16 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 	interfacedIdentityConfigs := make([]auth.AuthConfigEvaluator, 0)
 	ctxWithLogger = log.IntoContext(ctx, log.FromContext(ctx).WithName("identity"))
 
-	for _, identity := range authConfig.Spec.Identity {
+	authConfigIdentityConfigs := authConfig.Spec.Identity
+
+	if len(authConfigIdentityConfigs) == 0 {
+		authConfigIdentityConfigs = append(authConfigIdentityConfigs, &api.Identity{
+			Name:      "anonymous",
+			Anonymous: &api.Identity_Anonymous{},
+		})
+	}
+
+	for _, identity := range authConfigIdentityConfigs {
 		extendedProperties := make([]json.JSONProperty, 0)
 		for _, property := range identity.ExtendedProperties {
 			extendedProperties = append(extendedProperties, json.JSONProperty{

--- a/controllers/auth_config_controller_test.go
+++ b/controllers/auth_config_controller_test.go
@@ -267,3 +267,14 @@ func TestUnmatchingAuthConfigLabels(t *testing.T) {
 	assert.NilError(t, err)
 	assert.DeepEqual(t, result, ctrl.Result{}) // Result should be empty
 }
+
+func TestEmptyAuthConfigIdentitiesDefaultsToAnonymousAccess(t *testing.T) {
+	r := &AuthConfigReconciler{}
+	c, err := r.translateAuthConfig(context.TODO(), &api.AuthConfig{
+		Spec: api.AuthConfigSpec{
+			Hosts: []string{"app.com"},
+		},
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, len(c["app.com"].IdentityConfigs), 1)
+}


### PR DESCRIPTION
Default to Anonymous access whenever the AuthConfig does not include any identity verification policies.

This will simplify writing AuthConfig for authorization only.

Closes #268 

### Verification steps

```sh
make local-setup FF=1
kubectl -n authorino port-forward deployment/envoy 8000:8000 &
```

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: talker-api-protection
spec:
  hosts:
  - talker-api-authorino.127.0.0.1.nip.io
EOF
```

```sh
curl http://talker-api-authorino.127.0.0.1.nip.io -i
# HTTP/1.1 200 OK
```