### PR TITLE
[hotfix] Multi-Platform auto build (3)

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           image: authorino
           tags: ${{ env.IMG_TAGS }}
-          archs: amd64,arm64
+          platforms: linux/amd64,linux/arm64
           containerfiles: |
             ./Dockerfile
       - name: Push Image


### PR DESCRIPTION
Using 'platforms' option of redhat-actions/buildah-build instead of 'archs'