### PR TITLE
[hotfix] Multi-Platform auto build (4)

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'master'
+  workflow_dispatch: {}
 
 env:
   IMG_TAGS: ${{ github.sha }}
@@ -24,6 +25,10 @@ jobs:
         id: add-latest-tag
         run: |
           echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+      - name: Install qemu dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ WORKDIR /workspace
 COPY ./ ./
 
 # Build
-ARG TARGETOS TARGETARCH
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
This is yet another attempt to make multi-platform build to work with buildah.

Following the example provided by [redhat-actions/buildah-build](https://github.com/redhat-actions/buildah-build/blob/main/.github/workflows/multiarch.yml), we are giving a try with enabling qemu in the environment while again letting for Golang to auto-detect the platform.

In the same PR, we're adding `workflow_dispatch` to the triggers.