### PR TITLE
Local deploy to pre-existing namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ install-operator:
 
 # Creates a namespace where to deploy Authorino
 namespace:
-	kubectl create namespace $(NAMESPACE)
+	kubectl create namespace $(NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: certs


### PR DESCRIPTION
Modifies the Makefile so it is possible to deploy locally (dev env) to a pre-existing Kuberentes namespace (e.g. default).

### Verification steps

```sh
make local-setup NAMESPACE=default FF=1
```

Command above should NOT fail with:

```
Error from server (AlreadyExists): namespaces "default" already exists
```