### PR TITLE
Reconciliation of individual API key secrets within an AuthConfig

### DIFF
--- a/controllers/secret_controller_test.go
+++ b/controllers/secret_controller_test.go
@@ -6,9 +6,12 @@ import (
 
 	"gotest.tools/assert"
 
-	api "github.com/kuadrant/authorino/api/v1beta1"
 	controller_builder "github.com/kuadrant/authorino/controllers/builder"
 	mock_controller_builder "github.com/kuadrant/authorino/controllers/builder/mocks"
+	"github.com/kuadrant/authorino/pkg/auth"
+	mock_cache "github.com/kuadrant/authorino/pkg/cache/mocks"
+	"github.com/kuadrant/authorino/pkg/evaluators"
+	identity_evaluators "github.com/kuadrant/authorino/pkg/evaluators/identity"
 	"github.com/kuadrant/authorino/pkg/log"
 
 	"github.com/golang/mock/gomock"
@@ -17,24 +20,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
-
-type fakeReconciler struct {
-	Reconciled bool
-	Finished   chan bool
-}
-
-func (r *fakeReconciler) Reconcile(_ context.Context, req ctrl.Request) (ctrl.Result, error) {
-	defer close(r.Finished)
-	r.Finished <- true
-	r.Reconciled = true
-	return ctrl.Result{}, nil
-}
 
 type isPredicate struct {
 }
@@ -48,14 +38,36 @@ func (c *isPredicate) String() string {
 	return "contains 1 predicate"
 }
 
-type secretReconcilerTest struct {
-	secret               v1.Secret
-	authConfig           api.AuthConfig
-	authConfigReconciler *fakeReconciler
-	secretReconciler     *SecretReconciler
+type fakeAPIKeyIdentityConfig struct {
+	evaluator          *identity_evaluators.APIKey
+	deleted, refreshed bool
 }
 
-func newSecretReconcilerTest(secretLabels map[string]string) secretReconcilerTest {
+func (i *fakeAPIKeyIdentityConfig) Call(_ auth.AuthPipeline, _ context.Context) (interface{}, error) {
+	return nil, nil
+}
+
+func (i *fakeAPIKeyIdentityConfig) RefreshAPIKeySecret(ctx context.Context, new v1.Secret) {
+	i.evaluator.RefreshAPIKeySecret(ctx, new)
+	i.refreshed = true
+}
+
+func (i *fakeAPIKeyIdentityConfig) DeleteAPIKeySecret(ctx context.Context, deleted types.NamespacedName) {
+	i.evaluator.DeleteAPIKeySecret(ctx, deleted)
+	i.deleted = true
+}
+
+func (i *fakeAPIKeyIdentityConfig) GetAPIKeyLabelSelectors() map[string]string {
+	return i.evaluator.GetAPIKeyLabelSelectors()
+}
+
+type secretReconcilerTest struct {
+	SecretReconciler *SecretReconciler
+	Secret           v1.Secret
+	AuthConfig       *evaluators.AuthConfig
+}
+
+func newSecretReconcilerTest(mockCtrl *gomock.Controller, secretLabels map[string]string) secretReconcilerTest {
 	secret := v1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
@@ -71,81 +83,53 @@ func newSecretReconcilerTest(secretLabels map[string]string) secretReconcilerTes
 		},
 	}
 
-	authConfig := api.AuthConfig{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "AuthConfig",
-			APIVersion: "authorino.kuadrant.io/v1beta1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "auth-config-1",
-			Namespace: "authorino",
-		},
-		Spec: api.AuthConfigSpec{
-			Hosts: []string{"echo-api"},
-			Identity: []*api.Identity{
-				{
-					Name: "friends",
-					APIKey: &api.Identity_APIKey{
-						LabelSelectors: map[string]string{
-							"authorino.kuadrant.io/managed-by": "authorino",
-							"target":                           "echo-api",
-						},
-					},
-				},
-			},
-			Metadata:      []*api.Metadata{},
-			Authorization: []*api.Authorization{},
-		},
-		Status: api.AuthConfigStatus{
-			Ready: false,
-		},
-	}
-
 	scheme := runtime.NewScheme()
-	_ = api.AddToScheme(scheme)
 	_ = v1.AddToScheme(scheme)
-	// Create a fake client with an auth config and a secret.
-	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(&authConfig, &secret).Build()
 
-	authConfigReconciler := &fakeReconciler{
-		Finished: make(chan bool),
+	// Create a fake k8s client with an existing secret.
+	fakeK8sClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(&secret).Build()
+
+	apiKeyLabelSelectors := map[string]string{"target": "echo-api"}
+	cachedAuthConfig := &evaluators.AuthConfig{
+		Labels: map[string]string{"namespace": "authorino", "name": "api-protection"},
+		IdentityConfigs: []auth.AuthConfigEvaluator{&fakeAPIKeyIdentityConfig{
+			evaluator: identity_evaluators.NewApiKeyIdentity("api-key", apiKeyLabelSelectors, "", auth.NewAuthCredential("", ""), fakeK8sClient, context.TODO()),
+		}},
 	}
+	cacheMock := mock_cache.NewMockCache(mockCtrl)
+	cacheMock.EXPECT().List().Return([]*evaluators.AuthConfig{cachedAuthConfig}).MaxTimes(1)
+	cacheMock.EXPECT().FindKeys("authorino/api-protection").Return([]string{}).MaxTimes(1)
 
 	secretReconciler := &SecretReconciler{
-		Client:               client,
-		Logger:               log.WithName("test").WithName("secretreconciler"),
-		Scheme:               nil,
-		LabelSelector:        ToLabelSelector("authorino.kuadrant.io/managed-by=authorino"),
-		AuthConfigReconciler: authConfigReconciler,
+		Client:        fakeK8sClient,
+		Logger:        log.WithName("test").WithName("secretreconciler"),
+		Scheme:        nil,
+		Cache:         cacheMock,
+		LabelSelector: ToLabelSelector("authorino.kuadrant.io/managed-by=authorino"),
 	}
 
-	t := secretReconcilerTest{
-		secret,
-		authConfig,
-		authConfigReconciler,
+	return secretReconcilerTest{
 		secretReconciler,
+		secret,
+		cachedAuthConfig,
 	}
-
-	return t
 }
 
 func (t *secretReconcilerTest) reconcile() (reconcile.Result, error) {
-	return t.secretReconciler.Reconcile(context.Background(), controllerruntime.Request{
+	return t.SecretReconciler.Reconcile(context.Background(), controllerruntime.Request{
 		NamespacedName: types.NamespacedName{
-			Namespace: t.secret.Namespace,
-			Name:      t.secret.Name,
+			Namespace: t.Secret.Namespace,
+			Name:      t.Secret.Name,
 		},
 	})
 }
 
 func TestSetupSecretReconcilerWithManager(t *testing.T) {
-	reconcilerTest := newSecretReconcilerTest(map[string]string{
-		"authorino.kuadrant.io/managed-by": "authorino",
-	})
-	secretReconciler := reconcilerTest.secretReconciler
-
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
+
+	reconcilerTest := newSecretReconcilerTest(mockCtrl, map[string]string{})
+	secretReconciler := reconcilerTest.SecretReconciler
 
 	builder := mock_controller_builder.NewMockControllerBuilder(mockCtrl)
 
@@ -160,41 +144,56 @@ func TestSetupSecretReconcilerWithManager(t *testing.T) {
 }
 
 func TestMissingWatchedSecretLabels(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
 	// secret missing the authorino "managed-by" label
-	reconcilerTest := newSecretReconcilerTest(map[string]string{
+	reconcilerTest := newSecretReconcilerTest(mockCtrl, map[string]string{
+		"target": "echo-api",
+	})
+
+	_, err := reconcilerTest.reconcile()
+
+	apiKeyIdentityConfig, _ := reconcilerTest.AuthConfig.IdentityConfigs[0].(*fakeAPIKeyIdentityConfig)
+
+	assert.Check(t, apiKeyIdentityConfig.deleted)
+	assert.Check(t, !apiKeyIdentityConfig.refreshed)
+	assert.NilError(t, err)
+}
+
+func TestUnmatchingSecretLabels(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	// secret with the authorino "managed-by" label but not the same labels as specified in the auth config
+	reconcilerTest := newSecretReconcilerTest(mockCtrl, map[string]string{
 		"authorino.kuadrant.io/managed-by": "authorino",
 	})
 
 	_, err := reconcilerTest.reconcile()
 
-	assert.Check(t, !reconcilerTest.authConfigReconciler.Reconciled)
+	apiKeyIdentityConfig, _ := reconcilerTest.AuthConfig.IdentityConfigs[0].(*fakeAPIKeyIdentityConfig)
+
+	assert.Check(t, apiKeyIdentityConfig.deleted)
+	assert.Check(t, !apiKeyIdentityConfig.refreshed)
 	assert.NilError(t, err)
 }
 
 func TestMatchingSecretLabels(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
 	// secret with the authorino "managed-by" label and the same labels as specified in the auth config
-	reconcilerTest := newSecretReconcilerTest(map[string]string{
+	reconcilerTest := newSecretReconcilerTest(mockCtrl, map[string]string{
 		"authorino.kuadrant.io/managed-by": "authorino",
 		"target":                           "echo-api",
 	})
 
 	_, err := reconcilerTest.reconcile()
 
-	finished := <-reconcilerTest.authConfigReconciler.Finished
+	apiKeyIdentityConfig, _ := reconcilerTest.AuthConfig.IdentityConfigs[0].(*fakeAPIKeyIdentityConfig)
 
-	assert.Check(t, finished)
-	assert.Check(t, reconcilerTest.authConfigReconciler.Reconciled)
-	assert.NilError(t, err)
-}
-
-func TestUnmatchingSecretLabels(t *testing.T) {
-	// secret with the authorino "managed-by" label but not the same labels as specified in the auth config
-	reconcilerTest := newSecretReconcilerTest(map[string]string{
-		"authorino.kuadrant.io/managed-by": "authorino",
-	})
-
-	_, err := reconcilerTest.reconcile()
-
-	assert.Check(t, !reconcilerTest.authConfigReconciler.Reconciled)
+	assert.Check(t, !apiKeyIdentityConfig.deleted)
+	assert.Check(t, apiKeyIdentityConfig.refreshed)
 	assert.NilError(t, err)
 }

--- a/controllers/secret_controller_test.go
+++ b/controllers/secret_controller_test.go
@@ -98,7 +98,6 @@ func newSecretReconcilerTest(mockCtrl *gomock.Controller, secretLabels map[strin
 	}
 	cacheMock := mock_cache.NewMockCache(mockCtrl)
 	cacheMock.EXPECT().List().Return([]*evaluators.AuthConfig{cachedAuthConfig}).MaxTimes(1)
-	cacheMock.EXPECT().FindKeys("authorino/api-protection").Return([]string{}).MaxTimes(1)
 
 	secretReconciler := &SecretReconciler{
 		Client:        fakeK8sClient,

--- a/main.go
+++ b/main.go
@@ -191,12 +191,12 @@ func main() {
 
 	// sets up secret reconciler
 	if err = (&controllers.SecretReconciler{
-		Client:               mgr.GetClient(),
-		Logger:               controllerLogger.WithName("secret"),
-		Scheme:               mgr.GetScheme(),
-		LabelSelector:        controllers.ToLabelSelector(watchedSecretLabelSelector),
-		AuthConfigReconciler: authConfigReconciler,
-		Namespace:            watchNamespace,
+		Client:        mgr.GetClient(),
+		Logger:        controllerLogger.WithName("secret"),
+		Scheme:        mgr.GetScheme(),
+		Cache:         cache,
+		LabelSelector: controllers.ToLabelSelector(watchedSecretLabelSelector),
+		Namespace:     watchNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		logger.Error(err, "unable to create controller", "controller", "secret")
 		os.Exit(1)

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -53,8 +53,10 @@ type IdentityConfigEvaluator interface {
 	ResolveExtendedProperties(AuthPipeline) (interface{}, error)
 }
 
-type APIKeySecretFinder interface {
-	FindSecretByName(types.NamespacedName) *v1.Secret
+type APIKeyIdentityConfigEvaluator interface {
+	RefreshAPIKeySecret(context.Context, v1.Secret)
+	DeleteAPIKeySecret(context.Context, types.NamespacedName)
+	GetAPIKeyLabelSelectors() map[string]string
 }
 
 type WristbandIssuer interface {

--- a/pkg/auth/mocks/mock_auth.go
+++ b/pkg/auth/mocks/mock_auth.go
@@ -413,41 +413,65 @@ func (mr *MockIdentityConfigEvaluatorMockRecorder) ResolveExtendedProperties(arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveExtendedProperties", reflect.TypeOf((*MockIdentityConfigEvaluator)(nil).ResolveExtendedProperties), arg0)
 }
 
-// MockAPIKeySecretFinder is a mock of APIKeySecretFinder interface.
-type MockAPIKeySecretFinder struct {
+// MockAPIKeyIdentityConfigEvaluator is a mock of APIKeyIdentityConfigEvaluator interface.
+type MockAPIKeyIdentityConfigEvaluator struct {
 	ctrl     *gomock.Controller
-	recorder *MockAPIKeySecretFinderMockRecorder
+	recorder *MockAPIKeyIdentityConfigEvaluatorMockRecorder
 }
 
-// MockAPIKeySecretFinderMockRecorder is the mock recorder for MockAPIKeySecretFinder.
-type MockAPIKeySecretFinderMockRecorder struct {
-	mock *MockAPIKeySecretFinder
+// MockAPIKeyIdentityConfigEvaluatorMockRecorder is the mock recorder for MockAPIKeyIdentityConfigEvaluator.
+type MockAPIKeyIdentityConfigEvaluatorMockRecorder struct {
+	mock *MockAPIKeyIdentityConfigEvaluator
 }
 
-// NewMockAPIKeySecretFinder creates a new mock instance.
-func NewMockAPIKeySecretFinder(ctrl *gomock.Controller) *MockAPIKeySecretFinder {
-	mock := &MockAPIKeySecretFinder{ctrl: ctrl}
-	mock.recorder = &MockAPIKeySecretFinderMockRecorder{mock}
+// NewMockAPIKeyIdentityConfigEvaluator creates a new mock instance.
+func NewMockAPIKeyIdentityConfigEvaluator(ctrl *gomock.Controller) *MockAPIKeyIdentityConfigEvaluator {
+	mock := &MockAPIKeyIdentityConfigEvaluator{ctrl: ctrl}
+	mock.recorder = &MockAPIKeyIdentityConfigEvaluatorMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockAPIKeySecretFinder) EXPECT() *MockAPIKeySecretFinderMockRecorder {
+func (m *MockAPIKeyIdentityConfigEvaluator) EXPECT() *MockAPIKeyIdentityConfigEvaluatorMockRecorder {
 	return m.recorder
 }
 
-// FindSecretByName mocks base method.
-func (m *MockAPIKeySecretFinder) FindSecretByName(arg0 types.NamespacedName) *v1.Secret {
+// DeleteAPIKeySecret mocks base method.
+func (m *MockAPIKeyIdentityConfigEvaluator) DeleteAPIKeySecret(arg0 context.Context, arg1 types.NamespacedName) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindSecretByName", arg0)
-	ret0, _ := ret[0].(*v1.Secret)
+	m.ctrl.Call(m, "DeleteAPIKeySecret", arg0, arg1)
+}
+
+// DeleteAPIKeySecret indicates an expected call of DeleteAPIKeySecret.
+func (mr *MockAPIKeyIdentityConfigEvaluatorMockRecorder) DeleteAPIKeySecret(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAPIKeySecret", reflect.TypeOf((*MockAPIKeyIdentityConfigEvaluator)(nil).DeleteAPIKeySecret), arg0, arg1)
+}
+
+// GetAPIKeyLabelSelectors mocks base method.
+func (m *MockAPIKeyIdentityConfigEvaluator) GetAPIKeyLabelSelectors() map[string]string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAPIKeyLabelSelectors")
+	ret0, _ := ret[0].(map[string]string)
 	return ret0
 }
 
-// FindSecretByName indicates an expected call of FindSecretByName.
-func (mr *MockAPIKeySecretFinderMockRecorder) FindSecretByName(arg0 interface{}) *gomock.Call {
+// GetAPIKeyLabelSelectors indicates an expected call of GetAPIKeyLabelSelectors.
+func (mr *MockAPIKeyIdentityConfigEvaluatorMockRecorder) GetAPIKeyLabelSelectors() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindSecretByName", reflect.TypeOf((*MockAPIKeySecretFinder)(nil).FindSecretByName), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPIKeyLabelSelectors", reflect.TypeOf((*MockAPIKeyIdentityConfigEvaluator)(nil).GetAPIKeyLabelSelectors))
+}
+
+// RefreshAPIKeySecret mocks base method.
+func (m *MockAPIKeyIdentityConfigEvaluator) RefreshAPIKeySecret(arg0 context.Context, arg1 v1.Secret) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RefreshAPIKeySecret", arg0, arg1)
+}
+
+// RefreshAPIKeySecret indicates an expected call of RefreshAPIKeySecret.
+func (mr *MockAPIKeyIdentityConfigEvaluatorMockRecorder) RefreshAPIKeySecret(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshAPIKeySecret", reflect.TypeOf((*MockAPIKeyIdentityConfigEvaluator)(nil).RefreshAPIKeySecret), arg0, arg1)
 }
 
 // MockWristbandIssuer is a mock of WristbandIssuer interface.

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -11,6 +11,7 @@ type Cache interface {
 	Set(id string, key string, config evaluators.AuthConfig, override bool) error
 	Get(key string) *evaluators.AuthConfig
 	Delete(id string)
+	List() []*evaluators.AuthConfig
 
 	FindId(key string) (id string, found bool)
 	FindKeys(id string) []string
@@ -89,4 +90,12 @@ func (c *AuthConfigsCache) FindKeys(id string) []string {
 	defer c.mu.Unlock()
 
 	return c.keys[id]
+}
+
+func (c *AuthConfigsCache) List() []*evaluators.AuthConfig {
+	var authConfigs []*evaluators.AuthConfig
+	for _, e := range c.entries {
+		authConfigs = append(authConfigs, &e.AuthConfig)
+	}
+	return authConfigs
 }

--- a/pkg/cache/mocks/mock_cache.go
+++ b/pkg/cache/mocks/mock_cache.go
@@ -89,6 +89,20 @@ func (mr *MockCacheMockRecorder) Get(key interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCache)(nil).Get), key)
 }
 
+// List mocks base method.
+func (m *MockCache) List() []*evaluators.AuthConfig {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List")
+	ret0, _ := ret[0].([]*evaluators.AuthConfig)
+	return ret0
+}
+
+// List indicates an expected call of List.
+func (mr *MockCacheMockRecorder) List() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockCache)(nil).List))
+}
+
 // Set mocks base method.
 func (m *MockCache) Set(id, key string, config evaluators.AuthConfig, override bool) error {
 	m.ctrl.T.Helper()

--- a/pkg/evaluators/identity.go
+++ b/pkg/evaluators/identity.go
@@ -202,15 +202,27 @@ func (config *IdentityConfig) ResolveExtendedProperties(pipeline auth.AuthPipeli
 	return extendedIdentityObject, nil
 }
 
-// impl:APIKeySecretFinder
+// impl:APIKeyIdentityConfigEvaluator
 
-func (config *IdentityConfig) FindSecretByName(lookup types.NamespacedName) *v1.Secret {
-	apiKey := config.APIKey
-	if apiKey != nil {
-		return apiKey.FindSecretByName(lookup)
-	} else {
+func (config *IdentityConfig) RefreshAPIKeySecret(ctx context.Context, new v1.Secret) {
+	if config.APIKey == nil {
+		return
+	}
+	config.APIKey.RefreshAPIKeySecret(ctx, new)
+}
+
+func (config *IdentityConfig) DeleteAPIKeySecret(ctx context.Context, deleted types.NamespacedName) {
+	if config.APIKey == nil {
+		return
+	}
+	config.APIKey.DeleteAPIKeySecret(ctx, deleted)
+}
+
+func (config *IdentityConfig) GetAPIKeyLabelSelectors() map[string]string {
+	if config.APIKey == nil {
 		return nil
 	}
+	return config.APIKey.LabelSelectors
 }
 
 // impl:metrics.Object

--- a/pkg/evaluators/identity/api_key_test.go
+++ b/pkg/evaluators/identity/api_key_test.go
@@ -50,12 +50,12 @@ func TestNewApiKeyIdentityAllNamespaces(t *testing.T) {
 	assert.Equal(t, apiKey.Name, "jedi")
 	assert.Equal(t, apiKey.LabelSelectors["planet"], "coruscant")
 	assert.Equal(t, apiKey.Namespace, "")
-	assert.Equal(t, len(apiKey.authorizedCredentials), 2)
-	_, exists := apiKey.authorizedCredentials["ObiWanKenobiLightSaber"]
+	assert.Equal(t, len(apiKey.secrets), 2)
+	_, exists := apiKey.secrets["ObiWanKenobiLightSaber"]
 	assert.Check(t, exists)
-	_, exists = apiKey.authorizedCredentials["MasterYodaLightSaber"]
+	_, exists = apiKey.secrets["MasterYodaLightSaber"]
 	assert.Check(t, exists)
-	_, exists = apiKey.authorizedCredentials["AnakinSkywalkerLightSaber"]
+	_, exists = apiKey.secrets["AnakinSkywalkerLightSaber"]
 	assert.Check(t, !exists)
 }
 
@@ -68,12 +68,12 @@ func TestNewApiKeyIdentitySingleNamespace(t *testing.T) {
 	assert.Equal(t, apiKey.Name, "jedi")
 	assert.Equal(t, apiKey.LabelSelectors["planet"], "coruscant")
 	assert.Equal(t, apiKey.Namespace, "ns1")
-	assert.Equal(t, len(apiKey.authorizedCredentials), 1)
-	_, exists := apiKey.authorizedCredentials["ObiWanKenobiLightSaber"]
+	assert.Equal(t, len(apiKey.secrets), 1)
+	_, exists := apiKey.secrets["ObiWanKenobiLightSaber"]
 	assert.Check(t, exists)
-	_, exists = apiKey.authorizedCredentials["MasterYodaLightSaber"]
+	_, exists = apiKey.secrets["MasterYodaLightSaber"]
 	assert.Check(t, !exists)
-	_, exists = apiKey.authorizedCredentials["AnakinSkywalkerLightSaber"]
+	_, exists = apiKey.secrets["AnakinSkywalkerLightSaber"]
 	assert.Check(t, !exists)
 }
 
@@ -121,18 +121,18 @@ func TestCallInvalidApiKeyFail(t *testing.T) {
 	assert.Error(t, err, "the API Key provided is invalid")
 }
 
-func TestGetCredentialsFromClusterSuccess(t *testing.T) {
+func TestLoadSecretsSuccess(t *testing.T) {
 	apiKey := NewApiKeyIdentity("X-API-KEY", map[string]string{"planet": "coruscant"}, "", nil, k8sClient, nil)
 
-	err := apiKey.GetCredentialsFromCluster(context.TODO())
+	err := apiKey.loadSecrets(context.TODO())
 	assert.NilError(t, err)
-	assert.Equal(t, len(apiKey.authorizedCredentials), 2)
+	assert.Equal(t, len(apiKey.secrets), 2)
 
-	secret1, exists := apiKey.authorizedCredentials["ObiWanKenobiLightSaber"]
+	secret1, exists := apiKey.secrets["ObiWanKenobiLightSaber"]
 	assert.Check(t, exists)
 	assert.Equal(t, apiKeySecret1.String(), secret1.String())
 
-	secret2, exists := apiKey.authorizedCredentials["MasterYodaLightSaber"]
+	secret2, exists := apiKey.secrets["MasterYodaLightSaber"]
 	assert.Check(t, exists)
 	assert.Equal(t, apiKeySecret2.String(), secret2.String())
 }
@@ -147,9 +147,9 @@ func (k *flawedAPIkeyK8sClient) List(_ context.Context, list client.ObjectList, 
 	return fmt.Errorf("something terribly wrong happened")
 }
 
-func TestGetCredentialsFromClusterFail(t *testing.T) {
+func TestLoadSecretsFail(t *testing.T) {
 	apiKey := NewApiKeyIdentity("X-API-KEY", map[string]string{"planet": "coruscant"}, "", nil, &flawedAPIkeyK8sClient{}, context.TODO())
 
-	err := apiKey.GetCredentialsFromCluster(context.TODO())
+	err := apiKey.loadSecrets(context.TODO())
 	assert.Error(t, err, "something terribly wrong happened")
 }


### PR DESCRIPTION
Avoids reconciling the entire AuthConfig whenever a new API Key secret is reconciled.

Ensures that API keys secrets are added, updated or removed individually in the cache of each AuthConfig where it applies, reflecting the corresponding operations of creating/updating/deleting Kubernetes Secrets, including modification in the labels of the Secret.

Closes #264

### Verification steps

Build and deploy:

```sh
make local-setup FF=1
kubectl -n authorino port-forward deployment/envoy 8000:8000 &
```

Create an AuthConfig:

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: talker-api-protection
spec:
  hosts:
  - talker-api-authorino.127.0.0.1.nip.io
  - talker-api.io
  identity:
  - name: friends
    apiKey:
      labelSelectors:
        group: friends
    credentials:
      in: authorization_header
      keySelector: APIKEY
EOF
```

Check the API is not yet accessible before creating the API key:

```sh
curl -H 'Authorization: APIKEY secret' http://talker-api-authorino.127.0.0.1.nip.io:8000/hello -i
# 401
```

```sh
curl -H 'Authorization: APIKEY secret' http://talker-api-authorino.127.0.0.1.nip.io:8000/hello -i -H 'Host: talker-api.io'
# 401
```

For every iteration involving modifying an API key Secret below, send requests to the API on the different host names. 

Create an API key:

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: v1
kind: Secret
metadata:
  name: api-key-1
  labels:
    authorino.kuadrant.io/managed-by: authorino
    group: friends
stringData:
  api_key: secret
type: Opaque
EOF
```

Modify the vaue of the API key:

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: v1
kind: Secret
metadata:
  name: api-key-1
  labels:
    authorino.kuadrant.io/managed-by: authorino
    group: friends
stringData:
  api_key: new-secret
type: Opaque
EOF
```

Remove the API key secret from teh scope of the AuthConfig:

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: v1
kind: Secret
metadata:
  name: api-key-1
  labels:
    authorino.kuadrant.io/managed-by: authorino
stringData:
  api_key: new-secret
type: Opaque
EOF
```

Add the API key back again to the scope of the AuthConfig:

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: v1
kind: Secret
metadata:
  name: api-key-1
  labels:
    authorino.kuadrant.io/managed-by: authorino
    group: friends
stringData:
  api_key: new-secret
type: Opaque
EOF
```

Remove the API key from the scope of Authorino:

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: v1
kind: Secret
metadata:
  name: api-key-1
  labels:
    group: friends
stringData:
  api_key: new-secret
type: Opaque
EOF
```

Add the API key back to the scope of Authorino:

```sh
kubectl -n authorino apply -f -<<EOF
apiVersion: v1
kind: Secret
metadata:
  name: api-key-1
  labels:
    authorino.kuadrant.io/managed-by: authorino
    group: friends
stringData:
  api_key: new-secret
type: Opaque
EOF
```

Delete the Api key:

```
kubectl -n authorino delete secret/api-key-1
```