### PR TITLE
HTTP request attributes passed in the call for the raw HTTP authorization check

### DIFF
--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -119,10 +119,16 @@ func (a *AuthService) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 			Attributes: &envoy_auth.AttributeContext{
 				Request: &envoy_auth.AttributeContext_Request{
 					Http: &envoy_auth.AttributeContext_HttpRequest{
-						Id:      requestId,
-						Host:    req.Host,
-						Headers: headers,
-						Body:    string(payload),
+						Id:       requestId,
+						Method:   req.Method,
+						Headers:  headers,
+						Path:     path,
+						Host:     req.Host,
+						Scheme:   req.URL.Scheme,
+						Query:    req.URL.Query().Encode(),
+						Fragment: req.URL.Fragment,
+						Protocol: req.Proto,
+						Body:     string(payload),
 					},
 				},
 			},

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -91,11 +91,6 @@ func (a *AuthService) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if req.Header.Get("Content-Type") != "application/json" {
-		closeWithStatus(envoy_type.StatusCode_BadRequest, resp, ctx, nil)
-		return
-	}
-
 	var payload []byte
 	var err error
 

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -110,13 +110,19 @@ func (a *AuthService) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	metrics.ReportTimedMetric(httpServerDuration, func() {
+		headers := make(map[string]string)
+		for key, values := range req.Header {
+			headers[strings.ToLower(key)] = strings.Join(values, " ")
+		}
+
 		checkRequest := &envoy_auth.CheckRequest{
 			Attributes: &envoy_auth.AttributeContext{
 				Request: &envoy_auth.AttributeContext_Request{
 					Http: &envoy_auth.AttributeContext_HttpRequest{
-						Id:   requestId,
-						Host: req.Host,
-						Body: string(payload),
+						Id:      requestId,
+						Host:    req.Host,
+						Headers: headers,
+						Body:    string(payload),
 					},
 				},
 			},

--- a/pkg/service/auth_test.go
+++ b/pkg/service/auth_test.go
@@ -202,18 +202,6 @@ func TestAuthServiceRawHTTPAuthorization_WithQueryString(t *testing.T) {
 	assert.Equal(t, response.Code, 200)
 }
 
-func TestAuthServiceRawHTTPAuthorization_UnsupportedContentType(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
-	cacheMock := mock_cache.NewMockCache(mockController)
-	authService := &AuthService{Cache: cacheMock}
-	request, _ := http.NewRequest("POST", "http://myapp.io/check", bytes.NewReader([]byte(`{}`)))
-	request.Header = map[string][]string{"Content-Type": {"text/plain"}}
-	response := gohttptest.NewRecorder()
-	authService.ServeHTTP(response, request)
-	assert.Equal(t, response.Code, 400)
-}
-
 type notReadable struct{}
 
 func (n *notReadable) Read(_ []byte) (int, error) {


### PR DESCRIPTION
- [x] Pass all attributes of the HTTP request in the inner call for the raw HTTP authorization check - it allows to write more elaborate AuthConfigs for authorization requests incoming through the raw HTTP interface, using these attributes
  - Method (either `GET` or `POST`)
  - Headers
  - Path (fixed: `/check`)
  - Host
  - Scheme
  - Query
  - Fragment
  - Protocol

- [x] Drop the requisite for `Content-Type: application/json` in the requests to the raw HTTP authorization interface - Authorino does not try to parse the body of the request and it is not up to Authorino to enforce such constraint to the payload anyway, but to the AuthConfigs.