### PR TITLE
[makefile] Default EDITOR set to vi if undefined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # Use bash as shell
 SHELL = /bin/bash
 
+# Use vi as default editor
+EDITOR ?= vi
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin


### PR DESCRIPTION
To prevent `make deploy` of raising a permission error when the `EDITOR` env var is not set.