### PR TITLE
Update template of the Authorino CR

### DIFF
--- a/deploy/authorino.yaml
+++ b/deploy/authorino.yaml
@@ -1,22 +1,54 @@
 # To deploy an Authorino instance using the Authorino Operator
+# For more info, see https://github.com/kuadrant/authorino-operator#the-authorino-custom-resource-definition-crd
 apiVersion: operator.authorino.kuadrant.io/v1beta1
 kind: Authorino
 metadata:
   name: $(AUTHORINO_INSTANCE)
 spec:
+  clusterWide: false
+  authConfigLabelSelectors: ""
+  secretLabelSelectors: authorino.kuadrant.io/managed-by=authorino
+
+  replicas: 1
+
+  evaluatorCacheSize: 1 # (in mb)
+
   image: authorino:local
   imagePullPolicy: IfNotPresent
-  replicas: 1
-  clusterWide: false
-  listener:
-    tls:
-      enabled: $(TLS_ENABLED)
-      certSecretRef:
-        name: authorino-server-cert
-  oidcServer:
-    tls:
-      enabled: $(TLS_ENABLED)
-      certSecretRef:
-        name: authorino-oidc-server-cert
+
   logLevel: debug
   logMode: development
+
+  listener:
+    ports:
+      grpc: 50051 # set '0' to disable the gRPC interface of the External Authorization server
+      http: 5001 # set '0' to disable the HTTP interface of the External Authorization server
+    tls:
+      enabled: $(TLS_ENABLED)
+      certSecretRef:
+        name: authorino-server-cert # Kubernetes secret must contain `tls.crt` and `tls.key` entries
+    timeout: 0 # (in ms) - set to '0' to disable timeout of the ext-authz request controlled internally
+
+  oidcServer:
+    port: 8083 # set to '0' to disable the Festival Wristband OIDC Discovery server
+    tls:
+      enabled: $(TLS_ENABLED)
+      certSecretRef:
+        name: authorino-oidc-server-cert # Kubernetes secret must contain `tls.crt` and `tls.key` entries
+
+  ## Uncomment to customize settings of the metrics server
+  # metrics:
+  #   port: 8080
+  #   deep: false # set to 'true' to allow users to request metrics at the level of a particular evaluator of an AuthConfig
+
+  ## Uncomment to project additional volumes in the authorino pod
+  # volumes:
+  #   items:
+  #   - name: keycloak-tls-cert
+  #     mountPath: /etc/ssl/certs
+  #     configMaps:
+  #     - keycloak-tls-cert
+  #     items: # details to mount the k8s configmap in the authorino pods
+  #     - key: keycloak.crt
+  #       path: keycloak.crt
+  #   defaultMode: 420


### PR DESCRIPTION
Updates the template file for creating the Authorino CR on local deployments.

Makes sure all fields of the CRD (as of today) are in the template, with values set to their corresponding defaults.