### PR TITLE
All valid hosts added to cache

### DIFF
--- a/controllers/auth_config_controller_test.go
+++ b/controllers/auth_config_controller_test.go
@@ -190,6 +190,7 @@ func TestHostColllision(t *testing.T) {
 	cacheMock := mock_cache.NewMockCache(mockController)
 
 	authConfig := newTestAuthConfig(map[string]string{})
+	authConfig.Spec.Hosts = append(authConfig.Spec.Hosts, "other.io")
 	authConfigName := types.NamespacedName{Name: authConfig.Name, Namespace: authConfig.Namespace}
 	secret := newTestOAuthClientSecret()
 	client := newTestK8sClient(&authConfig, &secret)
@@ -197,6 +198,8 @@ func TestHostColllision(t *testing.T) {
 
 	cacheMock.EXPECT().FindKeys(authConfigName.String()).Return([]string{})
 	cacheMock.EXPECT().FindId("echo-api").Return("other-namespace/other-auth-config-with-same-host", true)
+	cacheMock.EXPECT().FindId("other.io").Return("", false)
+	cacheMock.EXPECT().Set(authConfigName.String(), "other.io", gomock.Any(), true)
 
 	result, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: authConfigName})
 


### PR DESCRIPTION
Ensures all valid hosts are added to the cache despite presence of invalid (taken) ones among them.

Closes #323

### Verification steps

```sh
make local-setup # clusterWide: true

kubectl create namespace user-1
kubectl -n user-1 apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: auth-1
  namespace: user-1
spec:
  hosts:
  - talker-api.127.0.0.1.nip.io
  response:
  - name: x-auth-data
    json:
      properties:
      - name: authconfig
        value: auth-1
EOF

kubectl create namespace user-2
kubectl -n user-2 apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: auth-2
  namespace: user-2
spec:
  hosts:
  - talker-api.127.0.0.1.nip.io
  - talker-api.io
  response:
  - name: x-auth-data
    json:
      properties:
      - name: authconfig
        value: auth-2
EOF

kubectl port-forward deployment/envoy 8000:8000 &
```

```sh
curl -H 'Host: talker-api.127.0.0.1.nip.io' http://localhost:8000 -i
# x-auth-data.authconfig: auth-1
```

```sh
curl -H 'Host: talker-api.io' http://localhost:8000 -i
# x-auth-data.authconfig: auth-2
```