### PR TITLE
Fix phantom host association

### DIFF
--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -93,8 +93,14 @@ func (r *AuthConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, err
 		}
 
-		// delete related authconfigs from cache.
-		r.Cache.Delete(cacheId)
+		// delete unused hosts from cache
+		for _, host := range r.Cache.FindKeys(cacheId) {
+			if _, found := evaluatorConfigByHost[host]; found {
+				continue
+			}
+
+			r.Cache.DeleteKey(cacheId, host)
+		}
 
 		for host, evaluatorConfig := range evaluatorConfigByHost {
 			// Check for host collision with another namespace

--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -93,6 +93,9 @@ func (r *AuthConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, err
 		}
 
+		// delete related authconfigs from cache.
+		r.Cache.Delete(cacheId)
+
 		for host, evaluatorConfig := range evaluatorConfigByHost {
 			// Check for host collision with another namespace
 			if cachedKey, found := r.Cache.FindId(host); found {

--- a/controllers/auth_config_controller_test.go
+++ b/controllers/auth_config_controller_test.go
@@ -225,8 +225,7 @@ func TestHostColllision(t *testing.T) {
 	client := newTestK8sClient(&authConfig, &secret)
 	reconciler := newTestAuthConfigReconciler(client, cacheMock)
 
-	cacheMock.EXPECT().Delete(authConfigName.String())
-	cacheMock.EXPECT().FindKeys(authConfigName.String()).Return([]string{})
+	cacheMock.EXPECT().FindKeys(authConfigName.String()).Return([]string{}).AnyTimes()
 	cacheMock.EXPECT().FindId("echo-api").Return("other-namespace/other-auth-config-with-same-host", true)
 	cacheMock.EXPECT().FindId("other.io").Return("", false)
 	cacheMock.EXPECT().Set(authConfigName.String(), "other.io", gomock.Any(), true)
@@ -248,8 +247,7 @@ func TestMissingWatchedAuthConfigLabels(t *testing.T) {
 	client := newTestK8sClient(&authConfig, &secret)
 	reconciler := newTestAuthConfigReconciler(client, cacheMock)
 
-	cacheMock.EXPECT().Delete(authConfigName.String())
-	cacheMock.EXPECT().FindKeys(authConfigName.String()).Return([]string{})
+	cacheMock.EXPECT().FindKeys(authConfigName.String()).Return([]string{}).AnyTimes()
 	cacheMock.EXPECT().FindId("echo-api").Return("", false)
 	cacheMock.EXPECT().Set("authorino/auth-config-1", "echo-api", gomock.Any(), true)
 
@@ -271,8 +269,7 @@ func TestMatchingAuthConfigLabels(t *testing.T) {
 	reconciler := newTestAuthConfigReconciler(client, cacheMock)
 	reconciler.LabelSelector = ToLabelSelector("authorino.kuadrant.io/managed-by=authorino")
 
-	cacheMock.EXPECT().Delete(authConfigName.String())
-	cacheMock.EXPECT().FindKeys(authConfigName.String()).Return([]string{})
+	cacheMock.EXPECT().FindKeys(authConfigName.String()).Return([]string{}).AnyTimes()
 	cacheMock.EXPECT().FindId("echo-api").Return("", false)
 	cacheMock.EXPECT().Set("authorino/auth-config-1", "echo-api", gomock.Any(), true)
 
@@ -294,7 +291,7 @@ func TestUnmatchingAuthConfigLabels(t *testing.T) {
 	reconciler := newTestAuthConfigReconciler(client, cacheMock)
 	reconciler.LabelSelector = ToLabelSelector("authorino.kuadrant.io/managed-by=authorino")
 
-	cacheMock.EXPECT().FindKeys(authConfigName.String()).Return([]string{})
+	cacheMock.EXPECT().FindKeys(authConfigName.String()).Return([]string{}).AnyTimes()
 	cacheMock.EXPECT().Delete(authConfigName.String())
 
 	result, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: authConfigName})

--- a/pkg/cache/mocks/mock_cache.go
+++ b/pkg/cache/mocks/mock_cache.go
@@ -46,6 +46,18 @@ func (mr *MockCacheMockRecorder) Delete(id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockCache)(nil).Delete), id)
 }
 
+// DeleteKey mocks base method.
+func (m *MockCache) DeleteKey(id, key string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "DeleteKey", id, key)
+}
+
+// DeleteKey indicates an expected call of DeleteKey.
+func (mr *MockCacheMockRecorder) DeleteKey(id, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteKey", reflect.TypeOf((*MockCache)(nil).DeleteKey), id, key)
+}
+
 // FindId mocks base method.
 func (m *MockCache) FindId(key string) (string, bool) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Delete all entries in the cache related to an AuthConfig before adding again only to hosts that apply.

Ensures hosts occasionally removed from the AuthConfig on an update are no longer linked to the AuthConfig in the cache after the reconciliation.

Closes #326.

### Verification steps

Build, deploy, setup:

```sh
make local-setup
kubectl port-forward deployment/envoy 8000:8000 &
```

Create an AuthConfig for 2 hosts:

```sh
kubectl apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: talker-api-protection
spec:
  hosts: ["host-1", "host-2"]
EOF
```

Send requests to the hosts:

```sh
curl -H 'Host: host-1' http://localhost:8000 -i
# HTTP/1.1 200 OK
```

```sh
curl -H 'Host: host-2' http://localhost:8000 -i
# HTTP/1.1 200 OK
```

Remove one of the hosts from the AuthConfig:

```sh
kubectl apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: talker-api-protection
spec:
  hosts: ["host-1"]
EOF
```

Send requests again to the hosts:

```sh
curl -H 'Host: host-1' http://localhost:8000 -i
# HTTP/1.1 200 OK
```

```sh
curl -H 'Host: host-2' http://localhost:8000 -i
# HTTP/1.1 404 Not Found
```