### PR TITLE
Red Hat Universal Base Image (UBI) 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
 # Build the authorino binary
-FROM golang:1.17 as builder
-
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17.10 as builder
+USER root
 WORKDIR /workspace
 COPY ./ ./
-
-# Build
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+# Use Red Hat minimal base image to package the binary
+# https://catalog.redhat.com/software/containers/ubi8-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+USER 1001
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Changes container base image to Red Hat UBI 8 images.

- **Builder:** [registry.access.redhat.com/ubi8/go-toolset:1.17.10](https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1?tag=1.17.10)
- **Runtime:** [registry.access.redhat.com/ubi8/ubi-minimal:latest](https://catalog.redhat.com/software/containers/ubi8-minimal/5c64772edd19c77a158ea216?tag=latest)

As a side effect, image size will grow from ~25-27 MB to ~59-63 MB (depending on the platform – linux/arm64 or linux/amd64, respectively).

On the good side, automated security scans in Quay.io will work (closes #310).