### PR TITLE
Fix os parameter for setting up for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ build: generate ## Builds the manager binary
 	go build -o bin/authorino main.go
 
 test: generate manifests envtest ## Runs the tests
-	KUBEBUILDER_ASSETS='$(strip $(shell $(ENVTEST) use -p path 1.21.2))' go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS='$(strip $(shell $(ENVTEST) use -p path 1.21.2 --os linux))' go test ./... -coverprofile cover.out
 
 cover: ## Shows test coverage
 	go tool cover -html=cover.out


### PR DESCRIPTION
Fixes the following error thrown when running the tests in the darwin/arm64 platform:

```
unable to fetch checksum for requested version: unable fetch metadata for kubebuilder-tools-1.21.2-darwin-arm64.tar.gz -- got status "404 Not Found" from GCS
```

This is okay because in the end we only build for linux OS anyway.

**Additional note to reviewers:**

We are not really using [controller-runtime/pkg/envtest](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest) in Authorino since the removal of `controllers/suite_test.go` (#274). We could remove the target that installs setup-envtest and refs in the Makefile altogether. However, in the spirit of aiming in the near future to standardise how integration tests are implemented across components and perhaps get the default suite_test.go file that is botstrapped by the Operator SDK back, we're keeping setup-envtest in the Makefile as is for now.