### PR TITLE
Fix bootstrap index debug log message

### DIFF
--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -624,13 +624,13 @@ func (r *AuthConfigReconciler) bootstrapCacheIndex(ctx context.Context) error {
 		return nil
 	}
 
-	logger := r.Logger.WithName("bootstrap")
-	logger.Info("building cache index")
-
 	authConfigList := api.AuthConfigList{}
 	if err := r.List(ctx, &authConfigList); err != nil {
 		return err
 	}
+
+	logger := r.Logger.WithName("bootstrap")
+	logger.Info("building cache index", "count", len(authConfigList.Items))
 
 	sort.Sort(authConfigList.Items)
 
@@ -651,7 +651,7 @@ func (r *AuthConfigReconciler) bootstrapCacheIndex(ctx context.Context) error {
 		}
 
 		authConfigName := types.NamespacedName{Namespace: authConfig.Namespace, Name: authConfig.Name}
-		logger.V(1).Info("building cache index", "authconfig", authConfigName)
+		logger.V(1).Info("building cache index", "authconfig", authConfigName.String())
 
 		_, _, err := r.addToCache(
 			log.IntoContext(ctx, logger.WithValues("authconfig", authConfigName)),


### PR DESCRIPTION
- resource name printed to the logs in the format `<namespace>/<name>`
- number  of resources (`count`) printed to the logs

E.g.:

```jsonc
{"level":"info","ts":1659351123.8340561,"logger":"authorino.controller-runtime.manager.controller.authconfig.bootstrap","msg":"building cache index","count":4}
{"level":"debug","ts":1659351123.8347695,"logger":"authorino.controller-runtime.manager.controller.authconfig.bootstrap","msg":"building cache index","authconfig":"user-1/auth-1"}
{"level":"debug","ts":1659351123.834799,"logger":"authorino.controller-runtime.manager.controller.authconfig.bootstrap","msg":"building cache index","authconfig":"user-2/auth-2"}
{"level":"debug","ts":1659351123.8348057,"logger":"authorino.controller-runtime.manager.controller.authconfig.bootstrap","msg":"building cache index","authconfig":"user-3/auth-3"}
{"level":"debug","ts":1659351123.834812,"logger":"authorino.controller-runtime.manager.controller.authconfig.bootstrap","msg":"building cache index","authconfig":"user-4/auth-4"}
{"level":"info","ts":1659351123.8350182,"logger":"authorino.controller-runtime.manager.controller.authconfig","msg":"resource reconciled","authconfig":"user-4/auth-4"}
{"level":"info","ts":1659351123.8351173,"logger":"authorino.controller-runtime.manager.controller.authconfig","msg":"resource reconciled","authconfig":"user-1/auth-1"}
{"level":"info","ts":1659351123.8352134,"logger":"authorino.controller-runtime.manager.controller.authconfig","msg":"resource reconciled","authconfig":"user-2/auth-2"}
{"level":"info","ts":1659351123.835235,"logger":"authorino.controller-runtime.manager.controller.authconfig","msg":"resource reconciled","authconfig":"user-3/auth-3"}
```