### PR TITLE
Reject linking AuthConfigs to hosts already taken regardless of namespace

### DIFF
--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strings"
 	"sync"
 
 	api "github.com/kuadrant/authorino/api/v1beta1"
@@ -589,13 +588,11 @@ func (r *AuthConfigReconciler) addToIndex(ctx context.Context, resourceNamespace
 	looseHosts = []string{}
 
 	for _, host := range hosts {
-		// check for host collision with another namespace
-		if indexedResourceId, found := r.Index.FindId(host); found {
-			if indexedResourceIdParts := strings.Split(indexedResourceId, string(types.Separator)); indexedResourceIdParts[0] != resourceNamespace {
-				looseHosts = append(looseHosts, host)
-				logger.Info("host already taken in another namespace", "host", host)
-				continue
-			}
+		// check for host name collision between resources
+		if indexedResourceId, found := r.Index.FindId(host); found && indexedResourceId != resourceId {
+			looseHosts = append(looseHosts, host)
+			logger.Info("host already taken", "host", host)
+			continue
 		}
 
 		// add to the index

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,7 @@ metadata:
   name: my-api-protection
 spec:
   # List of one or more hostname[:port] entries, lookup keys to find this config in request-time
-  # Authorino will try to prevent hostname collision across Kubernetes namespaces by rejecting a hostname already taken.
+  # Authorino will try to prevent hostname collision by rejecting a hostname already taken.
   hosts:
     - my-api.io # north-south traffic
     - my-api.ns.svc.cluster.local # east-west traffic
@@ -209,9 +209,9 @@ The host can include the port number (i.e. `hostname:port`) or it can be just th
 
 ### Avoiding host name collision
 
-Authorino tries to prevent host name collision across namespaces by rejecting `AuthConfig`s that include at least one host name already taken by another `AuthConfig` in a different namespace. This is intentionally designed to avoid that, in [cluster-wide deployments](#cluster-wide-vs-namespaced-instances) of Authorino, users of one namespace can surpersed `AuthConfig` of each other.
+Authorino tries to prevent host name collision between `AuthConfig`s by rejecting to link in the index any `AuthConfig` and host name if the host name is already linked to a different `AuthConfig` in the index. This was intentionally designed to prevent users from surperseding each others' `AuthConfig`s, partially or fully, by just picking the same host names or overlapping host names as others.
 
-With wildcards, a host that matches a higher level wildcard already added to the index will be considered already taken. That
+When wildcards are involved, a host name that matches a host wildcard already linked in the index to another `AuthConfig` will be considered taken, and therefore the newest `AuthConfig` will be rejected to be linked to that host.
 
 ## The Authorization JSON
 

--- a/docs/user-guides/logging.md
+++ b/docs/user-guides/logging.md
@@ -84,7 +84,7 @@ Some typical log messages output by the Authorino service are listed in the tabl
 | `authorino.controller-runtime.manager.events`                              | `debug` | "Normal" | `object={kind=ConfigMap, apiVersion=v1}`, `reauthorino.ason=LeaderElection`, `message="authorino-controller-manager-* became leader"`
 | `authorino.controller-runtime.manager.events`                              | `debug` | "Normal" | `object={kind=Lease, apiVersion=coordination.k8s.io/v1}`, `reauthorino.ason=LeaderElection`, `message="authorino-controller-manager-* became leader"`
 | `authorino.controller-runtime.manager.controller.authconfig`               | `info` | "resource reconciled" | `authconfig` |
-| `authorino.controller-runtime.manager.controller.authconfig`               | `info` | "host already taken in another namespace" | `authconfig`, `host` |
+| `authorino.controller-runtime.manager.controller.authconfig`               | `info` | "host already taken" | `authconfig`, `host` |
 | `authorino.controller-runtime.manager.controller.authconfig.statusupdater` | `debug` | "resource status did not change" | `authconfig` |
 | `authorino.controller-runtime.manager.controller.authconfig.statusupdater` | `debug` | "resource status changed" | `authconfig`, `authconfig/status` |
 | `authorino.controller-runtime.manager.controller.authconfig.statusupdater` | `error` | "failed to update the resource" | `authconfig` |


### PR DESCRIPTION
Unifies the two traditional behaviours for `namespaced` reconciliation mode and for `cluster-wide` reconciliation mode regarding how a host is considered to be taken or not into one single behaviour. I.e., the namespace that the AuthConfigs belong to no longer matters; if a host is taken by an AuthConfig, it cannot be linked to another one.

Users who want to link a host to a different AuthConfig will first need to remove the host from the existing AuthConfig linked to the host and then add the new one. In the case of specific hosts vs. wildcard hosts, the more specific ones will always have to be linked before and then the more generic ones.

----

Contains commits of #339 and #342