### PR TITLE
Embed the Authorino version info into the binary

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -30,6 +30,14 @@ jobs:
         id: add-branch-tag
         run: |
           echo "IMG_TAGS=${GITHUB_REF_NAME/\//-} ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+      - name: Set Authorino version
+        id: authorino-version
+        run: |
+          if [[ ${GITHUB_REF_NAME/\//-} =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
+          echo "VERSION=${GITHUB_REF_NAME/\//-}" >> $GITHUB_ENV
+          else
+          echo "VERSION=${{ github.sha }}" >> $GITHUB_ENV
+          fi
       - name: Install qemu dependency
         run: |
           sudo apt-get update
@@ -41,6 +49,8 @@ jobs:
           image: authorino
           tags: ${{ env.IMG_TAGS }}
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            version=${{ env.VERSION }}
           containerfiles: |
             ./Dockerfile
       - name: Push Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,14 @@ FROM registry.access.redhat.com/ubi8/go-toolset:1.17.10 as builder
 USER root
 WORKDIR /workspace
 COPY ./ ./
-RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o manager main.go
+ARG version=latest
+RUN CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags "-X main.version=${version}" -o authorino main.go
 
 # Use Red Hat minimal base image to package the binary
 # https://catalog.redhat.com/software/containers/ubi8-minimal
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/authorino .
 USER 1001
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/authorino"]

--- a/docs/user-guides/logging.md
+++ b/docs/user-guides/logging.md
@@ -56,6 +56,7 @@ Some typical log messages output by the Authorino service are listed in the tabl
 | logger                                                                     | level | message | extra values |
 |----------------------------------------------------------------------------|-------|---------|--------|
 | `authorino`                                                                | `info` | "setting instance base logger" | `min level=info\|debug`, `mode=production\|development` |
+| `authorino`                                                                | `info` | "botting up authorino" | `version` |
 | `authorino`                                                                | `debug` | "setting up with options" | `WATCH_NAMESPACE`, `AUTH_CONFIG_LABEL_SELECTOR`, `SECRET_LABEL_SELECTOR`, `LOG_LEVEL`, `LOG_MODE`, `TIMEOUT`, `EXT_AUTH_GRPC_PORT`, `EXT_AUTH_HTTP_PORT`, `TLS_CERT`, `TLS_CERT_KEY`, `OIDC_HTTP_PORT`, `OIDC_TLS_CERT`, `OIDC_TLS_CERT_KEY`, `EVALUATOR_CACHE_SIZE`, `DEEP_METRICS_ENABLED`, `metrics-addr`, `enable-leader-election` |
 | `authorino`                                                                | `info` | "attempting to acquire leader lease authorino/cb88a58a.authorino.kuadrant.io...\n" | |
 | `authorino`                                                                | `info` | "successfully acquired lease authorino/cb88a58a.authorino.kuadrant.io\n" | |

--- a/main.go
+++ b/main.go
@@ -118,6 +118,8 @@ var (
 	scheme  = runtime.NewScheme()
 	logOpts = log.Options{Level: log.ToLogLevel(logLevel), Mode: log.ToLogMode(logMode)}
 	logger  = log.NewLogger(logOpts).WithName("authorino")
+
+	version string
 )
 
 func init() {
@@ -138,6 +140,8 @@ func main() {
 	flag.StringVar(&metricsAddr, flagMetricsAddr, defaultMetricsAddr, "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, flagEnableLeaderElection, defaultEnableLeaderElection, "Enable leader election for status updater. Ensures only one instance of Authorino tries to update the status of reconciled resources.")
 	flag.Parse()
+
+	logger.Info("booting up authorino", "version", version)
 
 	logger.V(1).Info("setting up with options",
 		envWatchNamespace, watchNamespace,


### PR DESCRIPTION
The Authorino version info can be specified as a build argument (`VERSION`) of the `docker build` command, which is then set as an ldflag in the `go build` command.

When using the Makefile:
1. If `VERSION` is not specified, it defaults to the Git ref (SHA-1) of HEAD;
2. The image tag (`IMAGE_TAG`) is inferred from the value of `VERSION` (user-defined or set to default):
  - When it matches `^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$` (e.g. '0.10.0-pre'), the tag is set to `v$VERSION` (e.g. 'v0.10.0-pre');
  - otherwise, the tag is set to fixed value 'local'.

Additionally, a new parameter `IMAGE_REPO` was introduced to the Makefile (default: 'authorino'), and the existing parameter `AUTHORINO_IMAGE` now defaults to `$(IMAGE_REPO):$(IMAGE_TAG)`.

In CI, `VERSION` is inferred based on `GITHUB_REF_NAME`:
- When the Git ref (branch/tag name) matches `^v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$`, `VERSION` is set to `GITHUB_REF_NAME` (with all slashes replaced with dashes);
- otherwise, `VERSION` is set to the actual Git ref (i.e. `github.sha`)

Also in this chnage:
- New make target `docker-build`
- Rename the binary to 'authorino' (previously: 'manager')

## Verification steps

In all the scenarios below, you should be able to spot in the Auhtorino logs a message 'booting up authorino', with a label `version`, set to the value of the version build argument.

### Scenario: Build and run the binary locally

Setup a cluster to target the service to:

```sh
kind create cluster
kubectl create namespace authorino-operator && kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/install/manifests.yaml && make install
```

Build and run the binary locally:

```sh
make build
KUBECONFIG=$HOME/.kube/config ./bin/authorino
```

Try with a version number:

```sh
make build VERSION=0.10.0-pre
KUBECONFIG=$HOME/.kube/config ./bin/authorino
```

Cleanup:

```sh
kind delete cluster
```

### Scenario: Build and run container image in docker

Setup a cluster to target the service to:

```sh
kind create cluster
kubectl create namespace authorino-operator && kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/config/install/manifests.yaml && make install
```

Build and run container image in docker:

```sh
make docker-build
docker run \
  -v $HOME/.kube/config:/home/.kube/config \
  --env KUBECONFIG=/home/.kube/config \
  --network=host \
  authorino:local
```

Try with a version number:

```sh
make docker-build VERSION=0.10.0-pre
docker run \
  -v $HOME/.kube/config:/home/.kube/config \
  --env KUBECONFIG=/home/.kube/config \
  --network=host \
  authorino:v0.10.0-pre
```

Cleanup:

```sh
kind delete cluster
```

### Scenario: Build and run container image in kubernetes

```sh
make local-setup FF=1
```

Cleanup:

```sh
make local-cleanup
```