### PR TITLE
Bugfix: avoid panic when external OPA response misses Content-Type header

### DIFF
--- a/pkg/evaluators/authorization/opa.go
+++ b/pkg/evaluators/authorization/opa.go
@@ -221,7 +221,7 @@ func (ext *OPAExternalSource) downloadRegoDataFromUrl() (string, error) {
 
 		result := string(body)
 		//json
-		if resp.Header["Content-Type"][0] == "application/json" {
+		if strings.Contains(resp.Header.Get("Content-Type"), "application/json") {
 			var jsonResponse responseOpaJson
 			if err := json.Unmarshal(body, &jsonResponse); err != nil {
 				return "", fmt.Errorf("unable to unmarshal json response: %v", err)

--- a/pkg/evaluators/authorization/opa_test.go
+++ b/pkg/evaluators/authorization/opa_test.go
@@ -105,6 +105,25 @@ func TestOPAExternalUrlJsonResponse(t *testing.T) {
 	assertOPAAuthorization(t, opa)
 }
 
+func TestOPAExternalUrlMissingContentType(t *testing.T) {
+	extHttpMetadataServer := httptest.NewHttpServerMock(opaExtHttpServerMockAddr, map[string]httptest.HttpServerMockResponseFunc{
+		"/rego": func() httptest.HttpServerMockResponse {
+			return httptest.HttpServerMockResponse{Status: 200, Body: opaInlineRegoDataMock, Headers: map[string]string{"Content-Type": ""}}
+		},
+	})
+	defer extHttpMetadataServer.Close()
+
+	externalSource := &OPAExternalSource{
+		Endpoint:        "http://" + opaExtHttpServerMockAddr + "/rego",
+		AuthCredentials: auth.NewAuthCredential("", ""),
+	}
+
+	opa, err := NewOPAAuthorization("test-opa", "", externalSource, false, 0, context.TODO())
+
+	assert.NilError(t, err)
+	assertOPAAuthorization(t, opa)
+}
+
 func TestOPAExternalUrlWithTTL(t *testing.T) {
 	changed := false
 	extHttpMetadataServer := httptest.NewHttpServerMock(opaExtHttpServerMockAddr, map[string]httptest.HttpServerMockResponseFunc{


### PR DESCRIPTION
Closes #346.