### PR TITLE
Use RWMutex

### DIFF
--- a/controllers/status_report.go
+++ b/controllers/status_report.go
@@ -13,10 +13,13 @@ func NewStatusReportMap() *StatusReportMap {
 
 type StatusReportMap struct {
 	statuses map[string]StatusReport
-	mu       sync.Mutex
+	mu       sync.RWMutex
 }
 
 func (m *StatusReportMap) Get(id string) (status StatusReport, found bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	status, found = m.statuses[id]
 	return
 }
@@ -34,6 +37,9 @@ func (m *StatusReportMap) Set(id, reason, message string, hosts []string) {
 }
 
 func (m *StatusReportMap) Clear(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	delete(m.statuses, id)
 }
 

--- a/pkg/evaluators/authorization/opa.go
+++ b/pkg/evaluators/authorization/opa.go
@@ -77,10 +77,13 @@ type OPA struct {
 	policyName string
 	policyUID  string
 
-	mu sync.Mutex
+	mu sync.RWMutex
 }
 
 func (opa *OPA) Call(pipeline auth.AuthPipeline, ctx context.Context) (interface{}, error) {
+	opa.mu.RLock()
+	defer opa.mu.RUnlock()
+
 	var authJSON interface{}
 	if err := json.Unmarshal([]byte(pipeline.GetAuthorizationJSON()), &authJSON); err != nil {
 		return false, err

--- a/pkg/evaluators/authorization/opa.go
+++ b/pkg/evaluators/authorization/opa.go
@@ -112,10 +112,33 @@ func (opa *OPA) Clean(_ context.Context) error {
 	return opa.ExternalSource.cleanupRefresher()
 }
 
-func (opa *OPA) precompilePolicy() error {
-	policyName := fmt.Sprintf(`authorino.authz["%s"]`, opa.policyUID)
-	policyContent := fmt.Sprintf(policyTemplate, policyName, opa.Rego)
-	policyFileName := opa.policyUID + ".rego"
+func (opa *OPA) updateRego(rego string, ctx context.Context, force bool) (bool, error) {
+	opa.mu.Lock()
+	defer opa.mu.Unlock()
+
+	newRego := cleanUpRegoDocument(rego)
+	currentRego := opa.Rego
+
+	if !force && hash(newRego) == hash(currentRego) {
+		return false, nil
+	}
+
+	opa.Rego = newRego
+
+	if policy, err := precompilePolicy(opa.opaContext, opa.policyUID, opa.Rego, opa.AllValues); err != nil {
+		opa.Rego = currentRego
+		log.FromContext(ctx).Error(err, msg_OpaPolicyPrecompileError, "policy", opa.policyName)
+		return false, err
+	} else {
+		opa.policy = policy
+		return true, nil
+	}
+}
+
+func precompilePolicy(ctx context.Context, policyUID, policyRego string, allValues bool) (*rego.PreparedEvalQuery, error) {
+	policyName := fmt.Sprintf(`authorino.authz["%s"]`, policyUID)
+	policyContent := fmt.Sprintf(policyTemplate, policyName, policyRego)
+	policyFileName := policyUID + ".rego"
 	queryTemplate := `%s = object.get(data.` + policyName + `, "%s", null)`
 
 	var module *opaParser.Module
@@ -123,10 +146,10 @@ func (opa *OPA) precompilePolicy() error {
 	var err error
 
 	if module, err = opaParser.ParseModule(policyFileName, policyContent); err != nil {
-		return err
+		return nil, err
 	}
 
-	if opa.AllValues {
+	if allValues {
 		rules := map[string]interface{}{allowQuery: nil}
 		for _, rule := range module.Rules {
 			name := string(rule.Head.Name)
@@ -142,34 +165,11 @@ func (opa *OPA) precompilePolicy() error {
 		rego.ParsedModule(module),
 	)
 
-	if regoPolicy, err := r.PrepareForEval(opa.opaContext); err != nil {
-		return err
+	if regoPolicy, err := r.PrepareForEval(ctx); err != nil {
+		return nil, err
 	} else {
-		opa.policy = &regoPolicy
-		return nil
+		return &regoPolicy, nil
 	}
-}
-
-func (opa *OPA) updateRego(rego string, ctx context.Context, force bool) (bool, error) {
-	opa.mu.Lock()
-	defer opa.mu.Unlock()
-
-	newRego := cleanUpRegoDocument(rego)
-	currentRego := opa.Rego
-
-	if !force && hash(newRego) == hash(currentRego) {
-		return false, nil
-	}
-
-	opa.Rego = newRego
-
-	if err := opa.precompilePolicy(); err != nil {
-		opa.Rego = currentRego
-		log.FromContext(ctx).Error(err, msg_OpaPolicyPrecompileError, "policy", opa.policyName)
-		return false, err
-	}
-
-	return true, nil
 }
 
 func cleanUpRegoDocument(rego string) string {

--- a/pkg/evaluators/identity/api_key.go
+++ b/pkg/evaluators/identity/api_key.go
@@ -28,7 +28,7 @@ type APIKey struct {
 	Namespace      string              `yaml:"namespace"`
 
 	secrets   map[string]k8s.Secret
-	mutex     sync.Mutex
+	mutex     sync.RWMutex
 	k8sClient k8s_client.Reader
 }
 
@@ -73,6 +73,9 @@ func (a *APIKey) Call(pipeline auth.AuthPipeline, _ context.Context) (interface{
 	if reqKey, err := a.GetCredentialsFromReq(pipeline.GetHttp()); err != nil {
 		return nil, err
 	} else {
+		a.mutex.RLock()
+		defer a.mutex.RUnlock()
+
 		for key, secret := range a.secrets {
 			if key == reqKey {
 				return secret, nil

--- a/pkg/evaluators/identity/mtls.go
+++ b/pkg/evaluators/identity/mtls.go
@@ -26,7 +26,7 @@ type MTLS struct {
 	Namespace      string
 
 	rootCerts map[string]*x509.Certificate
-	mutex     sync.Mutex
+	mutex     sync.RWMutex
 	k8sClient k8s_client.Reader
 }
 
@@ -82,6 +82,9 @@ func (m *MTLS) Call(pipeline auth.AuthPipeline, ctx context.Context) (interface{
 	if cert == nil {
 		return nil, fmt.Errorf("invalid client certificate")
 	}
+
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
 
 	certs := x509.NewCertPool()
 	for _, cert := range m.rootCerts {


### PR DESCRIPTION
Apart from a good practice in general whenever multiple concurrent reads and writes are expected, this will fix the following race condition error related with the status update of the AuthConfigs:

```
concurrent map read and map write

goroutine 734 [running]:
runtime.throw({0x1cad2f9, 0xc0030e6ae0})
	/usr/lib/golang/src/runtime/panic.go:1198 +0x71 fp=0xc0005d5950 sp=0xc0005d5920 pc=0x436eb1
runtime.mapaccess2_faststr(0x1f4e7a8, 0xc0030e6bd0, {0xc0005d5bf0, 0x1c})
	/usr/lib/golang/src/runtime/map_faststr.go:116 +0x3d4 fp=0xc0005d59b8 sp=0xc0005d5950 pc=0x412c34
github.com/kuadrant/authorino/controllers.(*StatusReportMap).Get(...)
	/workspace/controllers/status_report.go:20
github.com/kuadrant/authorino/controllers.(*AuthConfigStatusUpdater).updateAuthConfigStatus(0xc00061e700, {0x1f4e7a8, 0xc0030e6bd0}, {0xc0005d5bf0, 0x1c}, 0xc0030c9d40)
	/workspace/controllers/auth_config_status_updater.go:62 +0xf5 fp=0xc0005d5b98 sp=0xc0005d59b8 pc=0x1833295
github.com/kuadrant/authorino/controllers.(*AuthConfigStatusUpdater).Reconcile(0xc00061e700, {0x1f4e7a8, 0xc0030e6ab0}, {{{0xc0030b6cd8, 0x4}, {0xc0030f8030, 0x17}}})
	/workspace/controllers/auth_config_status_updater.go:49 +0x314 fp=0xc0005d5c80 sp=0xc0005d5b98 pc=0x18330f4
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0xc00079abb0, {0x1f4e7a8, 0xc0030e69f0}, {{{0xc0030b6cd8, 0x1baabe0}, {0xc0030f8030, 0x413bf4}}})
	/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:114 +0x26f fp=0xc0005d5d68 sp=0xc0005d5c80 pc=0x1430f4f
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc00079abb0, {0x1f4e700, 0xc00061e600}, {0x1a90780, 0xc0030f2200})
	/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:311 +0x33e fp=0xc0005d5ed8 sp=0xc0005d5d68 pc=0x1432fde
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc00079abb0, {0x1f4e700, 0xc00061e600})
	/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:266 +0x205 fp=0xc0005d5f80 sp=0xc0005d5ed8 pc=0x1432825
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:227 +0x85 fp=0xc0005d5fe0 sp=0xc0005d5f80 pc=0x14321e5
runtime.goexit()
	/usr/lib/golang/src/runtime/asm_amd64.s:1581 +0x1 fp=0xc0005d5fe8 sp=0xc0005d5fe0 pc=0x4682c1
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:223 +0x357
```

cc @pehala