### PR TITLE
[Bugfix] Only bootstrap AuthConfigs in scope

### DIFF
--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -624,7 +624,11 @@ func (r *AuthConfigReconciler) bootstrapIndex(ctx context.Context) error {
 	}
 
 	authConfigList := api.AuthConfigList{}
-	if err := r.List(ctx, &authConfigList); err != nil {
+	listOptions := []client.ListOption{}
+	if r.LabelSelector != nil {
+		listOptions = append(listOptions, client.MatchingLabelsSelector{Selector: r.LabelSelector})
+	}
+	if err := r.List(ctx, &authConfigList, listOptions...); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The AuthConfig reconciler, when bootstrapping the index of AuthConfigs, was not taking the label selectors into account when selecting the list of resources to reconcile, causing hosts out os scope to the added to the index. This changes makes sure the label selectors are used when selecting the resources.