### PR TITLE
Safe concurrent access to the Auth Pipeline maps

### DIFF
--- a/pkg/service/auth_pipeline_test.go
+++ b/pkg/service/auth_pipeline_test.go
@@ -78,10 +78,10 @@ func (c *failConfig) GetPriority() int {
 	return c.priority
 }
 
-func newTestAuthPipeline(authConfig evaluators.AuthConfig, req *envoy_auth.CheckRequest) AuthPipeline {
+func newTestAuthPipeline(authConfig evaluators.AuthConfig, req *envoy_auth.CheckRequest) *AuthPipeline {
 	p := NewAuthPipeline(context.TODO(), req, authConfig)
 	pipeline, _ := p.(*AuthPipeline)
-	return *pipeline
+	return pipeline
 }
 
 func TestEvaluateOneAuthConfig(t *testing.T) {


### PR DESCRIPTION
Fixes concurrent read/write access to the maps of the Auth Pipeline that store identity, metadata, authorization and response objects per config/evaluator, thus avoiding fatal errors, e.g., when writing evaluated objects to the map whil at the same time requesting Authorization JSON and/or resolved identity object.

Closes #356