### PR TITLE
Add function to remove non printable characters

### DIFF
--- a/api/v1beta1/auth_config_types.go
+++ b/api/v1beta1/auth_config_types.go
@@ -80,7 +80,7 @@ type ValueFrom struct {
 	// It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
 	// or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
 	// Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-	// The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.
+	// The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
 	AuthJSON string `json:"authJSON,omitempty"`
 }
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -82,11 +82,15 @@ Examples below provided for the following Authorization JSON:
   "auth": {
     "identity": {
       "username": "jane",
-      "fullname": "Jane Smith"
+      "fullname": "Jane Smith",
+      "email": "\u0006jane\u0012@petcorp.com\n"
     },
   },
 }
 ```
+
+**`@strip`**<br/>
+Strips out any non printable characters such as carrige return. E.g. `auth.identity.email.@strip` → `"jane@petcorp.com"`.
 
 **`@case:upper|lower`**<br/>
 Changes the case of a string. E.g. `auth.identity.username.@case:upper` → `"JANE"`.

--- a/install/crd/authorino.kuadrant.io_authconfigs.yaml
+++ b/install/crd/authorino.kuadrant.io_authconfigs.yaml
@@ -105,7 +105,7 @@ spec:
                                     Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                     can be used. The following string modifiers are
                                     available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
                                   type: string
                               type: object
                           type: object
@@ -196,7 +196,8 @@ spec:
                                         Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                         can be used. The following string modifiers
                                         are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                        @case:upper|lower, @base64:encode|decode and
+                                        @strip.'
                                       type: string
                                   type: object
                               type: object
@@ -222,7 +223,8 @@ spec:
                                         Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                         can be used. The following string modifiers
                                         are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                        @case:upper|lower, @base64:encode|decode and
+                                        @strip.'
                                       type: string
                                   type: object
                               type: object
@@ -248,7 +250,8 @@ spec:
                                         Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                         can be used. The following string modifiers
                                         are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                        @case:upper|lower, @base64:encode|decode and
+                                        @strip.'
                                       type: string
                                   type: object
                               type: object
@@ -274,7 +277,8 @@ spec:
                                         Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                         can be used. The following string modifiers
                                         are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                        @case:upper|lower, @base64:encode|decode and
+                                        @strip.'
                                       type: string
                                   type: object
                               type: object
@@ -300,7 +304,8 @@ spec:
                                         Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                         can be used. The following string modifiers
                                         are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                        @case:upper|lower, @base64:encode|decode and
+                                        @strip.'
                                       type: string
                                   type: object
                               type: object
@@ -326,7 +331,8 @@ spec:
                                         Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                         can be used. The following string modifiers
                                         are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                        @case:upper|lower, @base64:encode|decode and
+                                        @strip.'
                                       type: string
                                   type: object
                               type: object
@@ -351,7 +357,7 @@ spec:
                                     Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                     can be used. The following string modifiers are
                                     available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
                                   type: string
                               type: object
                           type: object
@@ -526,7 +532,7 @@ spec:
                                   Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                   can be used. The following string modifiers are
                                   available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, and @base64:encode|decode.'
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
                                 type: string
                             type: object
                         type: object
@@ -560,7 +566,7 @@ spec:
                                     Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                     can be used. The following string modifiers are
                                     available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
                                   type: string
                               type: object
                           required:
@@ -585,7 +591,7 @@ spec:
                                   Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                   can be used. The following string modifiers are
                                   available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, and @base64:encode|decode.'
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
                                 type: string
                             type: object
                         type: object
@@ -612,7 +618,7 @@ spec:
                                   Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                   can be used. The following string modifiers are
                                   available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, and @base64:encode|decode.'
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
                                 type: string
                             type: object
                         type: object
@@ -646,7 +652,7 @@ spec:
                                     Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                     can be used. The following string modifiers are
                                     available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
                                   type: string
                               type: object
                           required:
@@ -671,7 +677,7 @@ spec:
                                   Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                   can be used. The following string modifiers are
                                   available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, and @base64:encode|decode.'
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
                                 type: string
                             type: object
                         type: object
@@ -781,7 +787,7 @@ spec:
                                     Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                     can be used. The following string modifiers are
                                     available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
                                   type: string
                               type: object
                           type: object
@@ -849,7 +855,7 @@ spec:
                                   Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                   can be used. The following string modifiers are
                                   available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, and @base64:encode|decode.'
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
                                 type: string
                             type: object
                         required:
@@ -991,7 +997,7 @@ spec:
                             by https://pkg.go.dev/github.com/tidwall/gjson can be
                             used. The following string modifiers are available: @extract:{sep:"
                             ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
-                            and @base64:encode|decode.'
+                            @base64:encode|decode and @strip.'
                           type: string
                       type: object
                     priority:
@@ -1074,7 +1080,7 @@ spec:
                                     Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                     can be used. The following string modifiers are
                                     available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
                                   type: string
                               type: object
                           type: object
@@ -1111,7 +1117,7 @@ spec:
                                     Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                     can be used. The following string modifiers are
                                     available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
                                   type: string
                               type: object
                           type: object
@@ -1141,7 +1147,8 @@ spec:
                                       Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                       can be used. The following string modifiers
                                       are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, and @base64:encode|decode.'
+                                      @case:upper|lower, @base64:encode|decode and
+                                      @strip.'
                                     type: string
                                 type: object
                             required:
@@ -1217,7 +1224,8 @@ spec:
                                       Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                       can be used. The following string modifiers
                                       are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, and @base64:encode|decode.'
+                                      @case:upper|lower, @base64:encode|decode and
+                                      @strip.'
                                     type: string
                                 type: object
                             required:
@@ -1412,7 +1420,7 @@ spec:
                                     Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                     can be used. The following string modifiers are
                                     available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
                                   type: string
                               type: object
                           type: object
@@ -1449,7 +1457,8 @@ spec:
                                       Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                       can be used. The following string modifiers
                                       are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, and @base64:encode|decode.'
+                                      @case:upper|lower, @base64:encode|decode and
+                                      @strip.'
                                     type: string
                                 type: object
                             required:
@@ -1551,7 +1560,8 @@ spec:
                                       Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                       can be used. The following string modifiers
                                       are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, and @base64:encode|decode.'
+                                      @case:upper|lower, @base64:encode|decode and
+                                      @strip.'
                                     type: string
                                 type: object
                             required:

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -123,7 +123,7 @@ spec:
                                     Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                     can be used. The following string modifiers are
                                     available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
                                   type: string
                               type: object
                           type: object
@@ -227,7 +227,8 @@ spec:
                                         Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                         can be used. The following string modifiers
                                         are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                        @case:upper|lower, @base64:encode|decode and
+                                        @strip.'
                                       type: string
                                   type: object
                               type: object
@@ -253,7 +254,8 @@ spec:
                                         Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                         can be used. The following string modifiers
                                         are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                        @case:upper|lower, @base64:encode|decode and
+                                        @strip.'
                                       type: string
                                   type: object
                               type: object
@@ -279,7 +281,8 @@ spec:
                                         Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                         can be used. The following string modifiers
                                         are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                        @case:upper|lower, @base64:encode|decode and
+                                        @strip.'
                                       type: string
                                   type: object
                               type: object
@@ -305,7 +308,8 @@ spec:
                                         Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                         can be used. The following string modifiers
                                         are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                        @case:upper|lower, @base64:encode|decode and
+                                        @strip.'
                                       type: string
                                   type: object
                               type: object
@@ -331,7 +335,8 @@ spec:
                                         Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                         can be used. The following string modifiers
                                         are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                        @case:upper|lower, @base64:encode|decode and
+                                        @strip.'
                                       type: string
                                   type: object
                               type: object
@@ -357,7 +362,8 @@ spec:
                                         Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                         can be used. The following string modifiers
                                         are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                        @case:upper|lower, @base64:encode|decode and
+                                        @strip.'
                                       type: string
                                   type: object
                               type: object
@@ -382,7 +388,7 @@ spec:
                                     Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                     can be used. The following string modifiers are
                                     available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
                                   type: string
                               type: object
                           type: object
@@ -570,7 +576,7 @@ spec:
                                   Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                   can be used. The following string modifiers are
                                   available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, and @base64:encode|decode.'
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
                                 type: string
                             type: object
                         type: object
@@ -604,7 +610,7 @@ spec:
                                     Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                     can be used. The following string modifiers are
                                     available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
                                   type: string
                               type: object
                           required:
@@ -629,7 +635,7 @@ spec:
                                   Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                   can be used. The following string modifiers are
                                   available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, and @base64:encode|decode.'
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
                                 type: string
                             type: object
                         type: object
@@ -656,7 +662,7 @@ spec:
                                   Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                   can be used. The following string modifiers are
                                   available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, and @base64:encode|decode.'
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
                                 type: string
                             type: object
                         type: object
@@ -690,7 +696,7 @@ spec:
                                     Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                     can be used. The following string modifiers are
                                     available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
                                   type: string
                               type: object
                           required:
@@ -715,7 +721,7 @@ spec:
                                   Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                   can be used. The following string modifiers are
                                   available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, and @base64:encode|decode.'
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
                                 type: string
                             type: object
                         type: object
@@ -875,7 +881,7 @@ spec:
                                     Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                     can be used. The following string modifiers are
                                     available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
                                   type: string
                               type: object
                           type: object
@@ -943,7 +949,7 @@ spec:
                                   Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                   can be used. The following string modifiers are
                                   available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, and @base64:encode|decode.'
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
                                 type: string
                             type: object
                         required:
@@ -1085,7 +1091,7 @@ spec:
                             by https://pkg.go.dev/github.com/tidwall/gjson can be
                             used. The following string modifiers are available: @extract:{sep:"
                             ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
-                            and @base64:encode|decode.'
+                            @base64:encode|decode and @strip.'
                           type: string
                       type: object
                     priority:
@@ -1200,7 +1206,7 @@ spec:
                                     Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                     can be used. The following string modifiers are
                                     available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
                                   type: string
                               type: object
                           type: object
@@ -1237,7 +1243,7 @@ spec:
                                     Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                     can be used. The following string modifiers are
                                     available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
                                   type: string
                               type: object
                           type: object
@@ -1267,7 +1273,8 @@ spec:
                                       Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                       can be used. The following string modifiers
                                       are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, and @base64:encode|decode.'
+                                      @case:upper|lower, @base64:encode|decode and
+                                      @strip.'
                                     type: string
                                 type: object
                             required:
@@ -1343,7 +1350,8 @@ spec:
                                       Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                       can be used. The following string modifiers
                                       are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, and @base64:encode|decode.'
+                                      @case:upper|lower, @base64:encode|decode and
+                                      @strip.'
                                     type: string
                                 type: object
                             required:
@@ -1551,7 +1559,7 @@ spec:
                                     Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                     can be used. The following string modifiers are
                                     available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
                                   type: string
                               type: object
                           type: object
@@ -1588,7 +1596,8 @@ spec:
                                       Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                       can be used. The following string modifiers
                                       are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, and @base64:encode|decode.'
+                                      @case:upper|lower, @base64:encode|decode and
+                                      @strip.'
                                     type: string
                                 type: object
                             required:
@@ -1703,7 +1712,8 @@ spec:
                                       Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
                                       can be used. The following string modifiers
                                       are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, and @base64:encode|decode.'
+                                      @case:upper|lower, @base64:encode|decode and
+                                      @strip.'
                                     type: string
                                 type: object
                             required:

--- a/pkg/json/json.go
+++ b/pkg/json/json.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/tidwall/gjson"
 )
@@ -284,9 +285,21 @@ var base64JSONStr = func(json, arg string) string {
 	}
 }
 
+var stripJSONstr = func(json, arg string) string {
+	json = strings.Map(func(r rune) rune {
+		if unicode.IsPrint(r) {
+			return r
+		}
+		return -1
+	}, json)
+
+	return json
+}
+
 func init() {
 	gjson.AddModifier("extract", extractJSONStr)
 	gjson.AddModifier("replace", replaceJSONStr)
 	gjson.AddModifier("case", caseJSONStr)
 	gjson.AddModifier("base64", base64JSONStr)
+	gjson.AddModifier("strip", stripJSONstr)
 }

--- a/pkg/json/json_test.go
+++ b/pkg/json/json_test.go
@@ -234,6 +234,12 @@ func TestBase64JSONStr(t *testing.T) {
 	assert.Equal(t, gjson.Get(jsonData, `auth.identity.username.decoded.@base64:encode`).String(), "am9obg==")
 }
 
+func TestStripJSONStr(t *testing.T) {
+	const jsonData = "{\"auth\":{\"identity\":{\"username\": \"\n\nbob\u0012\"}}}"
+
+	assert.Equal(t, gjson.Get(jsonData, "auth.identity.username.@strip").String(), "bob")
+}
+
 func TestStringifyJSON(t *testing.T) {
 	var source interface{}
 	var str string


### PR DESCRIPTION
This adds a function to strip out non printable Unicode characters returned in the authorization json. See issue #373.