### PR TITLE
WIP: Add propagation to external services

### DIFF
--- a/pkg/evaluators/authorization/opa.go
+++ b/pkg/evaluators/authorization/opa.go
@@ -17,6 +17,9 @@ import (
 
 	opaParser "github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
+
+	"go.opentelemetry.io/otel"
+	otel_propagation "go.opentelemetry.io/otel/propagation"
 )
 
 const (
@@ -207,6 +210,8 @@ func (ext *OPAExternalSource) downloadRegoDataFromUrl() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	otel.GetTextMapPropagator().Inject(req.Context(), otel_propagation.HeaderCarrier(req.Header))
 
 	if resp, err := http.DefaultClient.Do(req); err != nil {
 		return "", fmt.Errorf("failed to fetch Rego config: %v", err)

--- a/pkg/evaluators/identity/oauth2.go
+++ b/pkg/evaluators/identity/oauth2.go
@@ -11,6 +11,9 @@ import (
 	"github.com/kuadrant/authorino/pkg/auth"
 	"github.com/kuadrant/authorino/pkg/context"
 	"github.com/kuadrant/authorino/pkg/log"
+
+	"go.opentelemetry.io/otel"
+	otel_propagation "go.opentelemetry.io/otel/propagation"
 )
 
 type OAuth2 struct {
@@ -67,6 +70,8 @@ func (oauth *OAuth2) Call(pipeline auth.AuthPipeline, ctx gocontext.Context) (in
 	}
 
 	log.FromContext(ctx).WithName("oauth2").V(1).Info("sending token introspection request", "url", tokenIntrospectionURL.String(), "data", encodedFormData)
+
+	otel.GetTextMapPropagator().Inject(ctx, otel_propagation.HeaderCarrier(req.Header))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/pkg/evaluators/metadata/generic_http.go
+++ b/pkg/evaluators/metadata/generic_http.go
@@ -15,6 +15,9 @@ import (
 	"github.com/kuadrant/authorino/pkg/json"
 	"github.com/kuadrant/authorino/pkg/log"
 	"github.com/kuadrant/authorino/pkg/oauth2"
+
+	"go.opentelemetry.io/otel"
+	otel_propagation "go.opentelemetry.io/otel/propagation"
 )
 
 type GenericHttp struct {
@@ -128,6 +131,7 @@ func (h *GenericHttp) buildRequest(ctx gocontext.Context, endpoint, authJSON str
 	}
 
 	req.Header.Set("Content-Type", contentType)
+	otel.GetTextMapPropagator().Inject(ctx, otel_propagation.HeaderCarrier(req.Header))
 
 	if logger := log.FromContext(ctx).WithName("http").V(1); logger.Enabled() {
 		logData := []interface{}{

--- a/pkg/evaluators/metadata/uma.go
+++ b/pkg/evaluators/metadata/uma.go
@@ -13,6 +13,9 @@ import (
 	"github.com/kuadrant/authorino/pkg/context"
 	"github.com/kuadrant/authorino/pkg/json"
 	"github.com/kuadrant/authorino/pkg/log"
+
+	"go.opentelemetry.io/otel"
+	otel_propagation "go.opentelemetry.io/otel/propagation"
 )
 
 type providerJSON struct {
@@ -132,6 +135,7 @@ func (pat *PAT) Get(rawurl string, ctx gocontext.Context, v interface{}) error {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+pat.String())
 
+	otel.GetTextMapPropagator().Inject(ctx, otel_propagation.HeaderCarrier(req.Header))
 	// get the response
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -241,6 +245,7 @@ func (uma *UMA) requestPAT(ctx gocontext.Context, pat *PAT) error {
 
 	log.FromContext(ctx).V(1).Info("requesting pat", "url", tokenURL.String(), "data", encodedData, "headers", req.Header)
 
+	otel.GetTextMapPropagator().Inject(ctx, otel_propagation.HeaderCarrier(req.Header))
 	// get the response
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/pkg/evaluators/metadata/user_info.go
+++ b/pkg/evaluators/metadata/user_info.go
@@ -10,6 +10,9 @@ import (
 	"github.com/kuadrant/authorino/pkg/context"
 	"github.com/kuadrant/authorino/pkg/evaluators/identity"
 	"github.com/kuadrant/authorino/pkg/log"
+
+	"go.opentelemetry.io/otel"
+	otel_propagation "go.opentelemetry.io/otel/propagation"
 )
 
 type UserInfo struct {
@@ -53,6 +56,8 @@ func fetchUserInfo(userInfoEndpoint string, accessToken string, ctx gocontext.Co
 	if err != nil {
 		return nil, err
 	}
+
+	otel.GetTextMapPropagator().Inject(ctx, otel_propagation.HeaderCarrier(req.Header))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
Fixes #385 
cc @guicassolato 

Verification steps courtesy @guicassolato :

Step 1: Initialize cluster
```
make cluster install build
```

Step 2: Bring up authorino
```
bin/authorino server --tracing-service-endpoint http://localhost:14268/api/traces
```
Step 3: Apply auth-config
```
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: talker-api-protection
spec:
  hosts:
  - talker-api-authorino.127.0.0.1.nip.io
  metadata:
  - name: echo
    http:
      endpoint: https://echo-api.3scale.net/
  response:
  - name: echo
    json:
      properties:
      - name: response
        valueFrom:
          authJSON: auth.metadata.echo
```
Step 4: Sending an external authorization request to a gRPC server using `grpcurl`
```
for repo in \
envoyproxy/data-plane-api \
googleapis/googleapis \
envoyproxy/protoc-gen-validate \
cncf/udpa
do
git clone git@github.com:$repo /tmp/authorino-grpc-client/$repo
done

brew install grpcurl

grpcurl -import-path /tmp/authorino-grpc-client/envoyproxy/data-plane-api  \
        -import-path /tmp/authorino-grpc-client/googleapis/googleapis \
        -import-path /tmp/authorino-grpc-client/envoyproxy/protoc-gen-validate \
        -import-path /tmp/authorino-grpc-client/cncf/udpa \
        -proto /tmp/authorino-grpc-client/envoyproxy/data-plane-api/envoy/service/auth/v3/external_auth.proto \
        -plaintext -d '{"attributes":{"request":{"http":{"host":"talker-api-authorino.127.0.0.1.nip.io"}}}}' \
        localhost:50051 \
        envoy.service.auth.v3.Authorization.Check
```
The response should look something like this
```
"status": {
    
  },
  "okResponse": {
    "headers": [
      {
        "header": {
          "key": "echo",
          "value": "{\"response\":{\"args\":\"\",\"body\":\"\",\"headers\":{\"CONTENT_TYPE\":\"text/plain\",\"HTTP_ACCEPT_ENCODING\":\"gzip\",\"HTTP_HOST\":\"echo-api.3scale.net\",\"HTTP_TRACEPARENT\":\"00-93b16549c5f367af4478a61dcdfc54e0-2a038657302c4690-01\",\"HTTP_USER_AGENT\":\"Go-http-client/1.1\",\"HTTP_VERSION\":\"HTTP/1.1\",\"HTTP_X_ENVOY_EXPECTED_RQ_TIMEOUT_MS\":\"15000\",\"HTTP_X_ENVOY_EXTERNAL_ADDRESS\":\"103.92.103.133\",\"HTTP_X_FORWARDED_FOR\":\"103.92.103.133\",\"HTTP_X_FORWARDED_PROTO\":\"https\",\"HTTP_X_REQUEST_ID\":\"be1eac9d-d925-4159-97c2-5aa235ee46bc\"},\"method\":\"GET\",\"path\":\"/\",\"uuid\":\"5e60b641-d7cd-496c-a594-ef30d5437467\"}}"
        }
      }
    ]
  },
  "dynamicMetadata": {
    }
} 
```

