### PR TITLE
gRPC server reflection

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -329,6 +330,7 @@ func startExtAuthServerGRPC(authConfigIndex index.Index) {
 	}
 
 	grpcServer := grpc.NewServer(grpcServerOpts...)
+	reflection.Register(grpcServer)
 
 	envoy_auth.RegisterAuthorizationServer(grpcServer, &service.AuthService{Index: authConfigIndex, Timeout: timeoutMs()})
 	healthpb.RegisterHealthServer(grpcServer, &service.HealthService{})


### PR DESCRIPTION
Add [gRPC server reflection](https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md#enable-server-reflection).

### Verification steps

Requires:
- [gRPCurl](https://github.com/fullstorydev/grpcurl)

Build and run:

```sh
make cluster install build
bin/authorino server
```

In a separate shell:

```sh
grpcurl -plaintext localhost:50051 list
# envoy.service.auth.v3.Authorization
# grpc.health.v1.Health
# grpc.reflection.v1alpha.ServerReflection
```

```sh
grpcurl -plaintext localhost:50051 list envoy.service.auth.v3.Authorization
# envoy.service.auth.v3.Authorization.Check
```

```sh
grpcurl -plaintext localhost:50051 describe envoy.service.auth.v3.Authorization
# envoy.service.auth.v3.Authorization is a service:
# service Authorization {
#   rpc Check ( .envoy.service.auth.v3.CheckRequest ) returns ( .envoy.service.auth.v3.CheckResponse );
# } 
```

```sh
grpcurl -plaintext localhost:50051 describe envoy.service.auth.v3.CheckRequest
# envoy.service.auth.v3.CheckRequest is a message:
# message CheckRequest {
#   option (.udpa.annotations.versioning) = { previous_message_type:"envoy.service.auth.v2.CheckRequest" };
#   .envoy.service.auth.v3.AttributeContext attributes = 1;
# }
```