### PR TITLE
Tighten up the permissions over Authorino files within the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,20 +11,18 @@ RUN CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags "-X main.version=${version
 # https://catalog.redhat.com/software/containers/ubi9-minimal
 FROM registry.access.redhat.com/ubi9-minimal:latest
 
-WORKDIR /home/authorino/bin
-ENV PATH=/home/authorino/bin:$PATH
-COPY --from=builder /usr/bin/authorino ./authorino
-
-# shadow-utils is required for `groupadd`, etc.
+# shadow-utils is required for `useradd`
 RUN PKGS="shadow-utils" \
     && microdnf --assumeyes install --nodocs $PKGS \
     && rpm --verify --nogroup --nouser $PKGS \
     && microdnf -y clean all
-RUN groupadd -g 1000 authorino \
-    && useradd -u 1000 -g authorino -s /bin/sh -m -d /home/authorino authorino
-# Group members must be able to r-x in the directory due to OpenShift SCC constraints (https://docs.openshift.com/container-platform/4.12/authentication/managing-security-context-constraints.html)
-# Make sure to set supplementalGroups: [1000] in the security context of the pod when running on OpenShift (https://docs.openshift.com/container-platform/4.12/storage/persistent_storage/persistent-storage-nfs.html#storage-persistent-storage-nfs-group-ids_persistent-storage-nfs)
-RUN chown -R authorino:authorino /home/authorino \
+RUN useradd -u 1000 -s /bin/sh -m -d /home/authorino authorino
+
+WORKDIR /home/authorino/bin
+ENV PATH=/home/authorino/bin:$PATH
+COPY --from=builder /usr/bin/authorino ./authorino
+
+RUN chown -R authorino:root /home/authorino \
     && chmod -R 750 /home/authorino
 USER authorino
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,30 @@
 # https://catalog.redhat.com/software/containers/ubi9/go-toolset
 FROM registry.access.redhat.com/ubi9/go-toolset:1.18 AS builder
 USER root
-WORKDIR /workspace
+WORKDIR /usr/src/authorino
 COPY ./ ./
 ARG version=latest
-RUN CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags "-X main.version=${version}" -o authorino main.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags "-X main.version=${version}" -o /usr/bin/authorino main.go
 
 # Use Red Hat minimal base image to package the binary
 # https://catalog.redhat.com/software/containers/ubi9-minimal
 FROM registry.access.redhat.com/ubi9-minimal:latest
-WORKDIR /
-COPY --from=builder /workspace/authorino .
-USER 1001
 
-ENTRYPOINT ["/authorino", "server"]
+WORKDIR /home/authorino/bin
+ENV PATH=/home/authorino/bin:$PATH
+COPY --from=builder /usr/bin/authorino ./authorino
+
+# shadow-utils is required for `groupadd`, etc.
+RUN PKGS="shadow-utils" \
+    && microdnf --assumeyes install --nodocs $PKGS \
+    && rpm --verify --nogroup --nouser $PKGS \
+    && microdnf -y clean all
+RUN groupadd -g 1000 authorino \
+    && useradd -u 1000 -g authorino -s /bin/sh -m -d /home/authorino authorino
+# Group members must be able to r-x in the directory due to OpenShift SCC constraints (https://docs.openshift.com/container-platform/4.12/authentication/managing-security-context-constraints.html)
+# Make sure to set supplementalGroups: [1000] in the security context of the pod when running on OpenShift (https://docs.openshift.com/container-platform/4.12/storage/persistent_storage/persistent-storage-nfs.html#storage-persistent-storage-nfs-group-ids_persistent-storage-nfs)
+RUN chown -R authorino:authorino /home/authorino \
+    && chmod -R 750 /home/authorino
+USER authorino
+
+ENTRYPOINT ["authorino", "server"]


### PR DESCRIPTION
Adds new dedicated home path in the FS within the container for the binary and any other future Authorino files. The directory is owned by a new `authorino` Linux user and `root` Linux group.

This allows running Authorino on OpenShift with the default unprivileged user on standard `restricted` security context strategy, without the files having to be owned by root. As for other environments, users can choose to run the container as root or as the less privileged `authorino` user.

Implements **OPTION 4** proposed for [kuadrant/limitador](https://github.com/kuadrant/limitador) in https://github.com/Kuadrant/limitador/issues/175#issuecomment-1542578528.
