### PR TITLE
fix: API one-of constraints

### DIFF
--- a/install/crd/patches/oneof_in_authconfigs.yaml
+++ b/install/crd/patches/oneof_in_authconfigs.yaml
@@ -21,7 +21,7 @@
     - properties:
         name: {}
         credentials: {}
-        apiKey: {}
+        mtls: {}
       required: [name, mtls]
     - properties:
         name: {}
@@ -36,7 +36,7 @@
     - properties:
         name: {}
         credentials: {}
-        anonymous: {}
+        plain: {}
       required: [name, plain]
 
 - op: add
@@ -52,7 +52,7 @@
       required: [name, uma]
     - properties:
         name: {}
-        uma: {}
+        http: {}
       required: [name, http]
 
 - op: add
@@ -72,7 +72,7 @@
       required: [name, kubernetes]
     - properties:
         name: {}
-        kubernetes: {}
+        authzed: {}
       required: [name, authzed]
 
 - op: add

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -98,7 +98,7 @@ spec:
                     - name
                     - kubernetes
                   - properties:
-                      kubernetes: {}
+                      authzed: {}
                       name: {}
                     required:
                     - name
@@ -1228,8 +1228,8 @@ spec:
                     - name
                     - apiKey
                   - properties:
-                      apiKey: {}
                       credentials: {}
+                      mtls: {}
                       name: {}
                     required:
                     - name
@@ -1249,9 +1249,9 @@ spec:
                     - name
                     - anonymous
                   - properties:
-                      anonymous: {}
                       credentials: {}
                       name: {}
+                      plain: {}
                     required:
                     - name
                     - plain
@@ -1636,8 +1636,8 @@ spec:
                     - name
                     - uma
                   - properties:
+                      http: {}
                       name: {}
-                      uma: {}
                     required:
                     - name
                     - http

--- a/tests/authconfig-invalid.yaml
+++ b/tests/authconfig-invalid.yaml
@@ -1,0 +1,30 @@
+apiVersion: authorino.kuadrant.io/v1beta1
+kind: AuthConfig
+metadata:
+  name: e2e-test-invalid
+spec:
+  hosts:
+  - talker-api-authorino.127.0.0.1.nip.io
+
+  identity:
+  - name: multiple-identity-methods
+    apiKey:
+      selector:
+        matchLabels:
+          app: talker-api
+    oidc:
+      endpoint: http://keycloak.authorino.svc.cluster.local:8080/auth/realms/kuadrant
+
+  metadata:
+  - name: multiple-metadata-methods
+    http:
+      endpoint: http://metadata-service
+    userInfo:
+      identitySource: keycloak
+
+  authorization:
+  - name: multiple-authorization-methods
+    opa:
+      inlineRego: "allow = true"
+    json:
+      rules: []


### PR DESCRIPTION
- [x] Fix one-of constraints of identity, metadata, authorization and response methods in the AuthConfig API
- [x] Add e2e test for invalid AuthConfigs (one-of violation)

Reported at https://github.com/Kuadrant/authorino/pull/393#discussion_r1202653273