### PR TITLE
fix: Escape base64-decoded strings

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -79,6 +79,7 @@ Examples below provided for the following Authorization JSON:
         "path": "/pets/123",
         "headers": {
           "authorization": "Basic amFuZTpzZWNyZXQK" // jane:secret
+          "baggage": "eyJrZXkxIjoidmFsdWUxIn0=" // {"key1":"value1"}
         }
       }
     }

--- a/pkg/json/json.go
+++ b/pkg/json/json.go
@@ -283,7 +283,7 @@ var base64JSONStr = func(json, arg string) string {
 			encoding = base64.RawStdEncoding
 		}
 		decoded, _ := encoding.DecodeString(str)
-		return fmt.Sprintf("\"%s\"", decoded)
+		return fmt.Sprintf("\"%s\"", strings.ReplaceAll(string(decoded), `"`, `\"`))
 	default:
 		return json
 	}

--- a/pkg/json/json.go
+++ b/pkg/json/json.go
@@ -275,10 +275,14 @@ var base64JSONStr = func(json, arg string) string {
 
 	switch arg {
 	case "encode":
-		encoded := base64.URLEncoding.EncodeToString([]byte(str))
+		encoded := base64.StdEncoding.EncodeToString([]byte(str))
 		return fmt.Sprintf("\"%s\"", encoded)
 	case "decode":
-		decoded, _ := base64.URLEncoding.DecodeString(str)
+		encoding := base64.StdEncoding
+		if !strings.HasSuffix(str, "=") {
+			encoding = base64.RawStdEncoding
+		}
+		decoded, _ := encoding.DecodeString(str)
 		return fmt.Sprintf("\"%s\"", decoded)
 	default:
 		return json

--- a/pkg/json/json_test.go
+++ b/pkg/json/json_test.go
@@ -228,10 +228,19 @@ func TestCaseJSONStr(t *testing.T) {
 }
 
 func TestBase64JSONStr(t *testing.T) {
-	const jsonData = `{"auth":{"identity":{"username":{"encoded":"am9obg==","decoded":"john"}}}}`
-
+	jsonData := `{"auth":{"identity":{"username":{"encoded":"am9obg","decoded":"john"}}}}`
 	assert.Equal(t, gjson.Get(jsonData, `auth.identity.username.encoded.@base64:decode`).String(), "john")
 	assert.Equal(t, gjson.Get(jsonData, `auth.identity.username.decoded.@base64:encode`).String(), "am9obg==")
+
+	jsonData = `{"auth":{"identity":{"username":{"encoded":"am9obg==","decoded":"john"}}}}`
+	assert.Equal(t, gjson.Get(jsonData, `auth.identity.username.encoded.@base64:decode`).String(), "john")
+	assert.Equal(t, gjson.Get(jsonData, `auth.identity.username.decoded.@base64:encode`).String(), "am9obg==")
+}
+
+func TestParseJWTFromAuthzHeader(t *testing.T) {
+	// JWT: {"alg":"RS256","kid":"Ruk8dcoOv7kJqmchIJPtks7sHirl27ErFhfOVpBClHE"}{"aud":["https://kubernetes.default.svc.cluster.local"],"exp":1685557675,"iat":1685554075,"iss":"https://kubernetes.default.svc.cluster.local","kubernetes.io":{"namespace":"default","serviceaccount":{"name":"default","uid":"1edfd768-d05a-445f-a03a-0a834b45688e"}},"nbf":1685554075,"sub":"system:serviceaccount:default:default"}
+	jsonData := `{"access_token":"Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IlJ1azhkY29PdjdrSnFtY2hJSlB0a3M3c0hpcmwyN0VyRmhmT1ZwQkNsSEUifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiXSwiZXhwIjoxNjg1NTU3Njc1LCJpYXQiOjE2ODU1NTQwNzUsImlzcyI6Imh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJkZWZhdWx0Iiwic2VydmljZWFjY291bnQiOnsibmFtZSI6ImRlZmF1bHQiLCJ1aWQiOiIxZWRmZDc2OC1kMDVhLTQ0NWYtYTAzYS0wYTgzNGI0NTY4OGUifX0sIm5iZiI6MTY4NTU1NDA3NSwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmRlZmF1bHQ6ZGVmYXVsdCJ9.0KxjmGyzOaUdFdCWiGC9Y5BilCr-K8cuP3rI51ayu_rV91EC93c-HzojWbOI-Z9qKK4wt7Kd1NE_9IzDO53ZC_IBRBjPUaDXvw2Bt06pwRYlqfFsK6q9hr4h3VceWerCxq2wVdiBZaDa_eagpJMmz0JwOiQ3uxfI4aefnjl3KJaPke9nH0rzBfWGtYo1oOHMjqxIPmKAaJhzJqX1RmQKPdxncsl_gRQXCD9UdsJE6Gnlt2R01bJVaLYQQ-Y8w-wzvXFeSz0FBgSXla5KSqeMYFVkjT5pSvT7bxATmGVNfmmNR2rseS405cSqvDyU64FZ0oZEZTsiCGGXQdLO6-6hOA"}`
+	assert.Equal(t, gjson.Get(jsonData, `access_token.@extract:{"pos":1}|@extract:{"sep":".","pos":1}|@base64:decode|exp`).Num, float64(1685557675))
 }
 
 func TestStripJSONStr(t *testing.T) {

--- a/pkg/json/json_test.go
+++ b/pkg/json/json_test.go
@@ -228,19 +228,32 @@ func TestCaseJSONStr(t *testing.T) {
 }
 
 func TestBase64JSONStr(t *testing.T) {
+	// unpadded
 	jsonData := `{"auth":{"identity":{"username":{"encoded":"am9obg","decoded":"john"}}}}`
 	assert.Equal(t, gjson.Get(jsonData, `auth.identity.username.encoded.@base64:decode`).String(), "john")
 	assert.Equal(t, gjson.Get(jsonData, `auth.identity.username.decoded.@base64:encode`).String(), "am9obg==")
 
+	// padded
 	jsonData = `{"auth":{"identity":{"username":{"encoded":"am9obg==","decoded":"john"}}}}`
 	assert.Equal(t, gjson.Get(jsonData, `auth.identity.username.encoded.@base64:decode`).String(), "john")
 	assert.Equal(t, gjson.Get(jsonData, `auth.identity.username.decoded.@base64:encode`).String(), "am9obg==")
+
+	// with quotes
+	jsonData = `{"auth":{"identity":{"username":{"encoded":"bXkgbmFtZSBpcyAiam9obiI=","decoded":"my name is \"john\""}}}}`
+	assert.Equal(t, gjson.Get(jsonData, `auth.identity.username.encoded.@base64:decode`).String(), `my name is "john"`)
+	assert.Equal(t, gjson.Get(jsonData, `auth.identity.username.decoded.@base64:encode`).String(), "bXkgbmFtZSBpcyAiam9obiI=")
 }
 
 func TestParseJWTFromAuthzHeader(t *testing.T) {
 	// JWT: {"alg":"RS256","kid":"Ruk8dcoOv7kJqmchIJPtks7sHirl27ErFhfOVpBClHE"}{"aud":["https://kubernetes.default.svc.cluster.local"],"exp":1685557675,"iat":1685554075,"iss":"https://kubernetes.default.svc.cluster.local","kubernetes.io":{"namespace":"default","serviceaccount":{"name":"default","uid":"1edfd768-d05a-445f-a03a-0a834b45688e"}},"nbf":1685554075,"sub":"system:serviceaccount:default:default"}
 	jsonData := `{"access_token":"Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IlJ1azhkY29PdjdrSnFtY2hJSlB0a3M3c0hpcmwyN0VyRmhmT1ZwQkNsSEUifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiXSwiZXhwIjoxNjg1NTU3Njc1LCJpYXQiOjE2ODU1NTQwNzUsImlzcyI6Imh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJkZWZhdWx0Iiwic2VydmljZWFjY291bnQiOnsibmFtZSI6ImRlZmF1bHQiLCJ1aWQiOiIxZWRmZDc2OC1kMDVhLTQ0NWYtYTAzYS0wYTgzNGI0NTY4OGUifX0sIm5iZiI6MTY4NTU1NDA3NSwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmRlZmF1bHQ6ZGVmYXVsdCJ9.0KxjmGyzOaUdFdCWiGC9Y5BilCr-K8cuP3rI51ayu_rV91EC93c-HzojWbOI-Z9qKK4wt7Kd1NE_9IzDO53ZC_IBRBjPUaDXvw2Bt06pwRYlqfFsK6q9hr4h3VceWerCxq2wVdiBZaDa_eagpJMmz0JwOiQ3uxfI4aefnjl3KJaPke9nH0rzBfWGtYo1oOHMjqxIPmKAaJhzJqX1RmQKPdxncsl_gRQXCD9UdsJE6Gnlt2R01bJVaLYQQ-Y8w-wzvXFeSz0FBgSXla5KSqeMYFVkjT5pSvT7bxATmGVNfmmNR2rseS405cSqvDyU64FZ0oZEZTsiCGGXQdLO6-6hOA"}`
-	assert.Equal(t, gjson.Get(jsonData, `access_token.@extract:{"pos":1}|@extract:{"sep":".","pos":1}|@base64:decode|exp`).Num, float64(1685557675))
+
+	value := gjson.Get(jsonData, `access_token.@extract:{"pos":1}|@extract:{"sep":".","pos":1}|@base64:decode|@fromstr`)
+	assert.Equal(t, value.Type, gjson.JSON)
+
+	value = gjson.Get(jsonData, `access_token.@extract:{"pos":1}|@extract:{"sep":".","pos":1}|@base64:decode|@fromstr.exp`)
+	assert.Equal(t, value.Type, gjson.Number)
+	assert.Equal(t, value.Num, float64(1685557675))
 }
 
 func TestStripJSONStr(t *testing.T) {


### PR DESCRIPTION
Automatically escaping of double quotes within strings extracted from the Authorization JSON and decoded with the `@base64` custom modifier.

**Description of the problem:**
Values decoded using the `@base64` custom modifier for JSON paths can be truncated due to the presence of unescaped double quotes in the string.

This also causes the conversion of values to other JSON types (e.g. objects and arrays) using the built-in `@fromstr` modifier to fail if the value contains unescaped double quotes. Users have to explicitly escape the double quotes in the source before encoding the string, which is not always possible, such as in the case of stringified JSON baggage automatically injected.

**Use case:**
To be able to parse base64 encoded strings that represent valid JSON types other than strings (e.g. objects and arrays) and navigate those structures with normal JSON paths. E.g.:
- Parsing of JWTs straight from the Authorization header
- Parsing of base64-encoded baggage data passed in custom headers and query string parameters

**Explanation:**
Any raw string handled to [gjson](https://github.com/tidwall/gjson) will be attempted to be parsed into a valid JSON. The library detects the JSON type to which it will cast the parsed string based on the first byte character of the raw string. When it detects a double quote (`“`), it parses the value as a literal JSON string; left curly brace (`{`) or square bracket (`[`) signal a JSON object and JSON array respectively, and similarly to other JSON types.

Currently, with the `@base64` custom modifier, when Authorino decodes a base64-encoded value that contains a double quote (`“`) in it, the double quote is **not** automatically escaped, i.e. it will not be preceded by a back slash (`\`) that would make the double quote to be parsed as just another character within the literal JSON string. Nevertheless, we still wrap the decoded value within doubles quotes so the output, which is handled back to gjson, can be detected and parsed as a JSON string.

Not wrapping the output of the base64 decoding to be parsed as a JSON string in the first place, on one hand, would make possible to base64 decode any JSON type “on the wire”, including objects, arrays, etc; therefore not being limited to strings only. On the other hand, this would create 2 problems:
1. Values that are meant to be decoded and parsed as string would require to be wrapped between quotes upfront, by the user, in the source, i.e. before base64 encoding. This would hardly work in cases where the user has little control over the encoding procedure, such as in the case of HTTP Basic authentication, where `user:passwd` is base64-encoded before passed in the Authorization header.
2. It would open a security vulnerability related to the decoding of malicious characters in the middle of the string that could cause the truncation of the JSON parsing and potential subsequent unpredictable behaviours.

Wrapping the output of the base64 decoding for string detection causes a source such as `{"key1":"value1"}` (base64-encoded as `eyJrZXkxIjoidmFsdWUxIn0=`) to be decoded and wrapped as the following raw value: `"{"key1":"value1"}"`. Detected as a JSON string, gjson still tries to extract the value from this invalid JSON sequence, effectively generating in the output a JSON result typed as JSON string but with value equal to `"{"`. 

**Alternatives considered:**
One solution for the problem described would be to pipe the output of the base64 decoding to another modifier that unwraps the handled raw JSON, removing the double quote delimiters. The user would control when to employ this `@unwrap` modifier depending whether the decoded value is meant to be treated as a string (no need to use the modifier) or as raw JSON (using the modifier). However, the abuse of this feature could reopen the vulnerability described before.

Another approach to address the problem of decoding base64 encoded sequences as JSON types other than strings is to automatically escape any double quotes in the output value that will be wrapped. Consequently, a raw value such as `{"key1":"value1"}`, that represents a JSON object and is base64-encoded as `eyJrZXkxIjoidmFsdWUxIn0=`, will be decoded, escaped and wrapped as the fully valid JSON string `"{\"key1\":\"value1\"}"`. Users that wants to navigate the output as the JSON object the string represents can rely on the built-in `@fromstr` modifier which handles will properly handle the parsing.

## Verification steps

Setup:

```sh
make local-setup FF=1
kubectl port-forward deployment/envoy 8000:8000 2>&1 >/dev/null &
```

Create the AuthConfig:

```sh
kubectl apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta1
kind: AuthConfig
metadata:
  name: talker-api-protection
spec:
  hosts:
  - talker-api-authorino.127.0.0.1.nip.io
  response:
  - name: x-auth-data
    json:
      properties:
      - name: jwt
        valueFrom:
          authJSON: context.request.http.headers.authorization|@extract:{"pos":1}|@extract:{"sep":".","pos":1}|@base64:decode|@fromstr
      - name: username
        valueFrom:
          authJSON: context.request.http.headers.authorization|@extract:{"pos":1}|@extract:{"sep":".","pos":1}|@base64:decode|@fromstr.sub
      - name: v
        valueFrom:
          authJSON: context.request.http.path.@extract:{"sep":"?v=","pos":1}|@base64:decode

  - name: x-auth-jwt
    plain:
      valueFrom:
        authJSON: context.request.http.headers.authorization|@extract:{"pos":1}|@extract:{"sep":".","pos":1}|@base64:decode|@fromstr.@tostr

  - name: x-auth-username
    plain:
      valueFrom:
        authJSON: context.request.http.headers.authorization|@extract:{"pos":1}|@extract:{"sep":".","pos":1}|@base64:decode|@fromstr.sub

  - name: x-auth-v
    plain:
      valueFrom:
        authJSON: context.request.http.path.@extract:{"sep":"?v=","pos":1}|@base64:decode
EOF
```

Obtain a token:

```sh
ACCESS_TOKEN=$(kubectl create --raw /api/v1/namespaces/default/serviceaccounts/default/token -f -<<EOF | jq -r .status.token
{ "apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest", "spec": { "audiences": ["talker-api-authorino.127.0.0.1.nip.io"] } }
EOF
)
```

Send a request:

```sh
echo -n 'my name is "john"' | base64
# bXkgbmFtZSBpcyAiam9obiI=

echo -n 'bXkgbmFtZSBpcyAiam9obiI=' | base64 -d
# my name is "john"%
```

```sh
curl -H 'Host: talker-api-authorino.127.0.0.1.nip.io' \
     -H "Authorization: Bearer $ACCESS_TOKEN" \
     'http://localhost:8000?v=bXkgbmFtZSBpcyAiam9obiI' -i
```