### PR TITLE
feat: Simple Kubernetes TokenReview identity object

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -207,7 +207,7 @@ spec:
           - bar
 ```
 
-The resolved identity object, added to the authorization JSON following a Kubernetes authentication identity source evaluation, is the decoded JWT when the Kubernetes token is a valid JWT, or the value of `status.user` in the response to the TokenReview request (see Kubernetes [UserInfo](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#userinfo-v1-authentication-k8s-io) for details).
+The resolved identity object added to the authorization JSON following a successful Kubernetes authentication identity evaluation is the `status` field of TokenReview response (see [TokenReviewStatus](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/#TokenReviewStatus) for reference).
 
 ### OpenID Connect (OIDC) JWT/JOSE verification and validation ([`identity.oidc`](https://pkg.go.dev/github.com/kuadrant/authorino/api/v1beta1?utm_source=gopls#Identity_OidcConfig))
 

--- a/pkg/evaluators/identity/kubernetes_auth.go
+++ b/pkg/evaluators/identity/kubernetes_auth.go
@@ -8,7 +8,6 @@ import (
 	"github.com/kuadrant/authorino/pkg/context"
 	"github.com/kuadrant/authorino/pkg/log"
 
-	"github.com/golang-jwt/jwt"
 	authv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -89,22 +88,8 @@ func (kubeAuth *KubernetesAuth) audiencesWithDefault(defaultAudience string) []s
 func parseTokenReviewResult(tokenReview *authv1.TokenReview) (interface{}, error) {
 	tokenReviewStatus := tokenReview.Status
 	if tokenReviewStatus.Authenticated {
-		// returns the jwt claims (if the token is in fact a jwt); otherwise, returns the "user" in the TokenReview status
-		if claims, err := decodeTrustedJWT(tokenReview.Spec.Token); err == nil {
-			return claims, nil
-		} else {
-			return tokenReviewStatus.User, nil
-		}
+		return tokenReviewStatus, nil
 	} else {
 		return nil, fmt.Errorf("Not authenticated")
-	}
-}
-
-func decodeTrustedJWT(rawToken string) (jwt.Claims, error) {
-	claims := jwt.MapClaims{}
-	if token, _, err := new(jwt.Parser).ParseUnverified(rawToken, claims); err != nil { // we don't care about verifying the jwt because it has been authenticated ("reviewed") already
-		return nil, err
-	} else {
-		return token.Claims, nil
 	}
 }

--- a/pkg/evaluators/identity/kubernetes_auth_test.go
+++ b/pkg/evaluators/identity/kubernetes_auth_test.go
@@ -15,25 +15,25 @@ import (
 	authenticationv1 "k8s.io/client-go/kubernetes/typed/authentication/v1"
 )
 
-type tokenReviewData struct {
+type kubernetesTokenReviewDataMock struct {
 	requestToken  string
 	authenticated bool
 	audiences     []string
 }
 
-type tokenReviews struct {
-	tokenReviewData
+type kubernetesTokenReviewsMock struct {
+	kubernetesTokenReviewDataMock
 }
 
-func (t *tokenReviews) Create(ctx context.Context, tokenReview *authv1.TokenReview, opts metav1.CreateOptions) (*authv1.TokenReview, error) {
+func (t *kubernetesTokenReviewsMock) Create(ctx context.Context, tokenReview *authv1.TokenReview, opts metav1.CreateOptions) (*authv1.TokenReview, error) {
 	if t.authenticated {
 		return &authv1.TokenReview{
 			Spec: tokenReview.Spec,
 			Status: authv1.TokenReviewStatus{
 				Authenticated: true,
 				User: authv1.UserInfo{
-					Username: "system:serviceaccount:authorino:api-consumer-sa",
-					UID:      "0632367e-2455-44fb-bd01-3cf5b5f4a34b",
+					Username: "system:serviceaccount:authorino:api-consumer",
+					UID:      "eb5bcf55-6bdb-4b5b-a7ae-fbb8ad1119cb",
 					Groups: []string{
 						"system:serviceaccounts",
 						"system:serviceaccounts:authorino",
@@ -55,13 +55,13 @@ func (t *tokenReviews) Create(ctx context.Context, tokenReview *authv1.TokenRevi
 	}
 }
 
-type k8sAuthenticationClientMock struct {
-	tokenReviewData
+type kubernetesAuthenticationClientMock struct {
+	kubernetesTokenReviewDataMock
 }
 
-func (client *k8sAuthenticationClientMock) TokenReviews() authenticationv1.TokenReviewInterface {
-	return &tokenReviews{
-		tokenReviewData{
+func (client *kubernetesAuthenticationClientMock) TokenReviews() authenticationv1.TokenReviewInterface {
+	return &kubernetesTokenReviewsMock{
+		kubernetesTokenReviewDataMock{
 			client.requestToken,
 			client.authenticated,
 			client.audiences,
@@ -69,8 +69,8 @@ func (client *k8sAuthenticationClientMock) TokenReviews() authenticationv1.Token
 	}
 }
 
-func newKubernetesAuth(authCreds *mock_auth.MockAuthCredentials, audiences []string, token tokenReviewData) *KubernetesAuth {
-	authenticator := &k8sAuthenticationClientMock{token}
+func newKubernetesAuthMock(authCreds *mock_auth.MockAuthCredentials, audiences []string, token kubernetesTokenReviewDataMock) *KubernetesAuth {
+	authenticator := &kubernetesAuthenticationClientMock{token}
 
 	return &KubernetesAuth{
 		authCreds,
@@ -82,9 +82,9 @@ func newKubernetesAuth(authCreds *mock_auth.MockAuthCredentials, audiences []str
 	}
 }
 
-func TestAuthenticatedToken(t *testing.T) {
-	const requestToken string = `eyJhbGciOiJSUzI1NiIsImtpZCI6IjdXY3BwMVY1cTBPOFF6aFc0U3Ywb1NtaVh4T09qTnpKV2lKN21WVXJObmcifQ.eyJhdWQiOlsiZWNoby1hcGkiXSwiZXhwIjoxNjE2NTkyMDkxLCJpYXQiOjE2MTY1OTE0OTEsImlzcyI6Imt1YmVybmV0ZXMuZGVmYXVsdC5zdmMiLCJrdWJlcm5ldGVzLmlvIjp7Im5hbWVzcGFjZSI6ImF1dGhvcmlubyIsInNlcnZpY2VhY2NvdW50Ijp7Im5hbWUiOiJhcGktY29uc3VtZXIiLCJ1aWQiOiJlYjViY2Y1NS02YmRiLTRiNWItYTdhZS1mYmI4YWQxMTE5Y2IifX0sIm5iZiI6MTYxNjU5MTQ5MSwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmF1dGhvcmlubzphcGktY29uc3VtZXIifQ.Kp8pkOqFQoriumJTxtpRGJB3F26jpYVpxzXZBLbCSJKYi1CvgwdzsbVwlbbSOl5qCS62xlQCcPAyr3M56jjOjw-3_fHmQ8O8K7BcN6oDdRFRZgu5f0z6jVyi-aAEH0tieexRsPNJotenwSJn-eoCytLcIF70LNWhhmFbHNjZffFl5-Tl7blqfG60ztXmeo-N0ISoXXPnEwgV5CxWyTKDagmp0bYeCaiSszUe4YSOGmUeU9xLuM3wBHg93GFWFs3ZSQ_-mnaBnNoLBytd_nS_IOehIDdu1jPmNCJVFNpwOYxrvxisTPa--IjV_zIS5D9WR2dR6h8w8CFkdMlSFssANw`
-	const expectedIdObj string = `{"aud":["echo-api"],"exp":1616592091,"iat":1616591491,"iss":"kubernetes.default.svc","kubernetes.io":{"namespace":"authorino","serviceaccount":{"name":"api-consumer","uid":"eb5bcf55-6bdb-4b5b-a7ae-fbb8ad1119cb"}},"nbf":1616591491,"sub":"system:serviceaccount:authorino:api-consumer"}`
+func TestKubernetesTokenReviewWithOpaqueToken(t *testing.T) {
+	const requestToken string = `some-opaque-token`
+	const expectedIdObj string = `{"authenticated":true,"user":{"username":"system:serviceaccount:authorino:api-consumer","uid":"eb5bcf55-6bdb-4b5b-a7ae-fbb8ad1119cb","groups":["system:serviceaccounts","system:serviceaccounts:authorino","system:authenticated"]},"audiences":["echo-api"]}`
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -96,7 +96,7 @@ func TestAuthenticatedToken(t *testing.T) {
 	pipelineMock.EXPECT().GetHttp().Return(request).AnyTimes()
 	authCredsMock.EXPECT().GetCredentialsFromReq(request).Return(requestToken, nil)
 
-	kubernetesAuth := newKubernetesAuth(authCredsMock, []string{}, tokenReviewData{requestToken, true, []string{"echo-api"}})
+	kubernetesAuth := newKubernetesAuthMock(authCredsMock, []string{}, kubernetesTokenReviewDataMock{requestToken, true, []string{"echo-api"}})
 	ret, err := kubernetesAuth.Call(pipelineMock, context.TODO())
 
 	assert.NilError(t, err)
@@ -105,7 +105,30 @@ func TestAuthenticatedToken(t *testing.T) {
 	assert.Equal(t, expectedIdObj, string(claims))
 }
 
-func TestUnauthenticatedToken(t *testing.T) {
+func TestKubernetesTokenReviewWithJWT(t *testing.T) {
+	const requestToken string = `eyJhbGciOiJSUzI1NiIsImtpZCI6IjdXY3BwMVY1cTBPOFF6aFc0U3Ywb1NtaVh4T09qTnpKV2lKN21WVXJObmcifQ.eyJhdWQiOlsiZWNoby1hcGkiXSwiZXhwIjoxNjE2NTkyMDkxLCJpYXQiOjE2MTY1OTE0OTEsImlzcyI6Imt1YmVybmV0ZXMuZGVmYXVsdC5zdmMiLCJrdWJlcm5ldGVzLmlvIjp7Im5hbWVzcGFjZSI6ImF1dGhvcmlubyIsInNlcnZpY2VhY2NvdW50Ijp7Im5hbWUiOiJhcGktY29uc3VtZXIiLCJ1aWQiOiJlYjViY2Y1NS02YmRiLTRiNWItYTdhZS1mYmI4YWQxMTE5Y2IifX0sIm5iZiI6MTYxNjU5MTQ5MSwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmF1dGhvcmlubzphcGktY29uc3VtZXIifQ.Kp8pkOqFQoriumJTxtpRGJB3F26jpYVpxzXZBLbCSJKYi1CvgwdzsbVwlbbSOl5qCS62xlQCcPAyr3M56jjOjw-3_fHmQ8O8K7BcN6oDdRFRZgu5f0z6jVyi-aAEH0tieexRsPNJotenwSJn-eoCytLcIF70LNWhhmFbHNjZffFl5-Tl7blqfG60ztXmeo-N0ISoXXPnEwgV5CxWyTKDagmp0bYeCaiSszUe4YSOGmUeU9xLuM3wBHg93GFWFs3ZSQ_-mnaBnNoLBytd_nS_IOehIDdu1jPmNCJVFNpwOYxrvxisTPa--IjV_zIS5D9WR2dR6h8w8CFkdMlSFssANw`
+	const expectedIdObj string = `{"authenticated":true,"user":{"username":"system:serviceaccount:authorino:api-consumer","uid":"eb5bcf55-6bdb-4b5b-a7ae-fbb8ad1119cb","groups":["system:serviceaccounts","system:serviceaccounts:authorino","system:authenticated"]},"audiences":["echo-api"]}`
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	authCredsMock := mock_auth.NewMockAuthCredentials(ctrl)
+	pipelineMock := mock_auth.NewMockAuthPipeline(ctrl)
+
+	request := &envoy_auth.AttributeContext_HttpRequest{Host: "echo-api"}
+	pipelineMock.EXPECT().GetHttp().Return(request).AnyTimes()
+	authCredsMock.EXPECT().GetCredentialsFromReq(request).Return(requestToken, nil)
+
+	kubernetesAuth := newKubernetesAuthMock(authCredsMock, []string{}, kubernetesTokenReviewDataMock{requestToken, true, []string{"echo-api"}})
+	ret, err := kubernetesAuth.Call(pipelineMock, context.TODO())
+
+	assert.NilError(t, err)
+
+	claims, _ := json.Marshal(ret)
+	assert.Equal(t, expectedIdObj, string(claims))
+}
+
+func TestKubernetesTokenReviewUnauthenticatedToken(t *testing.T) {
 	const requestToken string = `eyJhbGciOiJSUzI1NiIsImtpZCI6IjdXY3BwMVY1cTBPOFF6aFc0U3Ywb1NtaVh4T09qTnpKV2lKN21WVXJObmcifQ.eyJhdWQiOlsiZWNoby1hcGkiXSwiZXhwIjoxNjE2NTkyMDkxLCJpYXQiOjE2MTY1OTE0OTEsImlzcyI6Imt1YmVybmV0ZXMuZGVmYXVsdC5zdmMiLCJrdWJlcm5ldGVzLmlvIjp7Im5hbWVzcGFjZSI6ImF1dGhvcmlubyIsInNlcnZpY2VhY2NvdW50Ijp7Im5hbWUiOiJhcGktY29uc3VtZXIiLCJ1aWQiOiJlYjViY2Y1NS02YmRiLTRiNWItYTdhZS1mYmI4YWQxMTE5Y2IifX0sIm5iZiI6MTYxNjU5MTQ5MSwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmF1dGhvcmlubzphcGktY29uc3VtZXIifQ.Kp8pkOqFQoriumJTxtpRGJB3F26jpYVpxzXZBLbCSJKYi1CvgwdzsbVwlbbSOl5qCS62xlQCcPAyr3M56jjOjw-3_fHmQ8O8K7BcN6oDdRFRZgu5f0z6jVyi-aAEH0tieexRsPNJotenwSJn-eoCytLcIF70LNWhhmFbHNjZffFl5-Tl7blqfG60ztXmeo-N0ISoXXPnEwgV5CxWyTKDagmp0bYeCaiSszUe4YSOGmUeU9xLuM3wBHg93GFWFs3ZSQ_-mnaBnNoLBytd_nS_IOehIDdu1jPmNCJVFNpwOYxrvxisTPa--IjV_zIS5D9WR2dR6h8w8CFkdMlSFssANw`
 
 	ctrl := gomock.NewController(t)
@@ -118,39 +141,16 @@ func TestUnauthenticatedToken(t *testing.T) {
 	pipelineMock.EXPECT().GetHttp().Return(request).AnyTimes()
 	authCredsMock.EXPECT().GetCredentialsFromReq(request).Return(requestToken, nil)
 
-	kubernetesAuth := newKubernetesAuth(authCredsMock, []string{}, tokenReviewData{requestToken, false, []string{"echo-api"}})
+	kubernetesAuth := newKubernetesAuthMock(authCredsMock, []string{}, kubernetesTokenReviewDataMock{requestToken, false, []string{"echo-api"}})
 	ret, err := kubernetesAuth.Call(pipelineMock, context.TODO())
 
 	assert.Check(t, ret == nil)
 	assert.Error(t, err, "Not authenticated")
 }
 
-func TestOpaqueToken(t *testing.T) {
-	const requestToken string = `some-opaque-token`
-	const expectedIdObj string = `{"username":"system:serviceaccount:authorino:api-consumer-sa","uid":"0632367e-2455-44fb-bd01-3cf5b5f4a34b","groups":["system:serviceaccounts","system:serviceaccounts:authorino","system:authenticated"]}`
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	authCredsMock := mock_auth.NewMockAuthCredentials(ctrl)
-	pipelineMock := mock_auth.NewMockAuthPipeline(ctrl)
-
-	request := &envoy_auth.AttributeContext_HttpRequest{Host: "echo-api"}
-	pipelineMock.EXPECT().GetHttp().Return(request).AnyTimes()
-	authCredsMock.EXPECT().GetCredentialsFromReq(request).Return(requestToken, nil)
-
-	kubernetesAuth := newKubernetesAuth(authCredsMock, []string{}, tokenReviewData{requestToken, true, []string{"echo-api"}})
-	ret, err := kubernetesAuth.Call(pipelineMock, context.TODO())
-
-	assert.NilError(t, err)
-
-	claims, _ := json.Marshal(ret)
-	assert.Equal(t, expectedIdObj, string(claims))
-}
-
-func TestCustomAudiences(t *testing.T) {
+func TestKubernetesTokenReviewAudiencesMatch(t *testing.T) {
 	const requestToken string = `eyJhbGciOiJSUzI1NiIsImtpZCI6Ik1vQmRRVjBhVGJ2elZOVGVEQ3JEQ1dUb1J4cGJnUzRES0JZNk1zX0M2c3cifQ.eyJhdWQiOlsiY3VzdG9tLWF1ZGllbmNlIl0sImV4cCI6MTYxNjY4NDA5OCwiaWF0IjoxNjE2NjgzNDk4LCJpc3MiOiJrdWJlcm5ldGVzLmRlZmF1bHQuc3ZjIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJhdXRob3Jpbm8iLCJzZXJ2aWNlYWNjb3VudCI6eyJuYW1lIjoiYXBpLWNvbnN1bWVyIiwidWlkIjoiMWE0MTI0NjUtZWJjMi00MzcyLWE2NzMtYzIwNDBjMWQ3YmI3In19LCJuYmYiOjE2MTY2ODM0OTgsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDphdXRob3Jpbm86YXBpLWNvbnN1bWVyIn0.hXPwycVZnmcqtYUjRXCvUChFlPIk5FQpMO9-kbX6UgP2vdEftuWKZhR1FxfT6BkMzk-mfCmjBaS171i4hwl0TErnu8YDYlA4wy-L3dGSAi-ys1PAk1oEu7XaKMA7J2Amv-Xm6GdeAL5LAyTEXuvCV0kzauxqc_XX2eTqxk_54fpbQH79EHVCr1gm1R2CTvQLNitZ8k-YyHCGU4J8UxUNWQvgu-HFYHNUCIuRUbYqsCYwDgIzxXl8_3qeywK8pp316PiWFcXzJ5cOV2aeMy_xpKO-9i08R4ezT2KeHc3JlgX6BBOnh1ft60CNgPd7xk81CKEDnSMnCmc072rJslv89Q`
-	const expectedIdObj string = `{"aud":["custom-audience"],"exp":1616684098,"iat":1616683498,"iss":"kubernetes.default.svc","kubernetes.io":{"namespace":"authorino","serviceaccount":{"name":"api-consumer","uid":"1a412465-ebc2-4372-a673-c2040c1d7bb7"}},"nbf":1616683498,"sub":"system:serviceaccount:authorino:api-consumer"}`
+	const expectedIdObj string = `{"authenticated":true,"user":{"username":"system:serviceaccount:authorino:api-consumer","uid":"eb5bcf55-6bdb-4b5b-a7ae-fbb8ad1119cb","groups":["system:serviceaccounts","system:serviceaccounts:authorino","system:authenticated"]},"audiences":["custom-audience"]}`
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -162,7 +162,7 @@ func TestCustomAudiences(t *testing.T) {
 	pipelineMock.EXPECT().GetHttp().Return(request).AnyTimes()
 	authCredsMock.EXPECT().GetCredentialsFromReq(request).Return(requestToken, nil)
 
-	kubernetesAuth := newKubernetesAuth(authCredsMock, []string{"custom-audience"}, tokenReviewData{requestToken, true, []string{"custom-audience"}})
+	kubernetesAuth := newKubernetesAuthMock(authCredsMock, []string{"custom-audience"}, kubernetesTokenReviewDataMock{requestToken, true, []string{"custom-audience"}})
 	ret, err := kubernetesAuth.Call(pipelineMock, context.TODO())
 
 	assert.NilError(t, err)
@@ -171,7 +171,7 @@ func TestCustomAudiences(t *testing.T) {
 	assert.Equal(t, expectedIdObj, string(claims))
 }
 
-func TestCustomAudiencesUnmatch(t *testing.T) {
+func TestKubernetesTokenReviewAudiencesUnmatch(t *testing.T) {
 	const requestToken string = `eyJhbGciOiJSUzI1NiIsImtpZCI6Ik1vQmRRVjBhVGJ2elZOVGVEQ3JEQ1dUb1J4cGJnUzRES0JZNk1zX0M2c3cifQ.eyJhdWQiOlsiY3VzdG9tLWF1ZGllbmNlIl0sImV4cCI6MTYxNjY4NDA5OCwiaWF0IjoxNjE2NjgzNDk4LCJpc3MiOiJrdWJlcm5ldGVzLmRlZmF1bHQuc3ZjIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJhdXRob3Jpbm8iLCJzZXJ2aWNlYWNjb3VudCI6eyJuYW1lIjoiYXBpLWNvbnN1bWVyIiwidWlkIjoiMWE0MTI0NjUtZWJjMi00MzcyLWE2NzMtYzIwNDBjMWQ3YmI3In19LCJuYmYiOjE2MTY2ODM0OTgsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDphdXRob3Jpbm86YXBpLWNvbnN1bWVyIn0.hXPwycVZnmcqtYUjRXCvUChFlPIk5FQpMO9-kbX6UgP2vdEftuWKZhR1FxfT6BkMzk-mfCmjBaS171i4hwl0TErnu8YDYlA4wy-L3dGSAi-ys1PAk1oEu7XaKMA7J2Amv-Xm6GdeAL5LAyTEXuvCV0kzauxqc_XX2eTqxk_54fpbQH79EHVCr1gm1R2CTvQLNitZ8k-YyHCGU4J8UxUNWQvgu-HFYHNUCIuRUbYqsCYwDgIzxXl8_3qeywK8pp316PiWFcXzJ5cOV2aeMy_xpKO-9i08R4ezT2KeHc3JlgX6BBOnh1ft60CNgPd7xk81CKEDnSMnCmc072rJslv89Q`
 
 	ctrl := gomock.NewController(t)
@@ -184,7 +184,7 @@ func TestCustomAudiencesUnmatch(t *testing.T) {
 	pipelineMock.EXPECT().GetHttp().Return(request).AnyTimes()
 	authCredsMock.EXPECT().GetCredentialsFromReq(request).Return(requestToken, nil)
 
-	kubernetesAuth := newKubernetesAuth(authCredsMock, []string{"expected-audience"}, tokenReviewData{requestToken, false, []string{"custom-audience"}})
+	kubernetesAuth := newKubernetesAuthMock(authCredsMock, []string{"expected-audience"}, kubernetesTokenReviewDataMock{requestToken, false, []string{"custom-audience"}})
 	ret, err := kubernetesAuth.Call(pipelineMock, context.TODO())
 
 	assert.Check(t, ret == nil)


### PR DESCRIPTION
Makes the Kubernetes TokenReview-based identity method to always fill the identity object from the [status](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/#TokenReviewStatus) field of the TokenReview response, as opposed to the current hybrid behaviour of trying to detect whether the verified access token is a JWT or an opaque token.

Closes #394.

---

**_Warning!_** This is a breaking change and users of Authorino Kubernetes identity verification method must consider its impact to existing AuthConfigs before upgrading to a new version.

Users relying on JWT detection can still extract, decode and parse the JWT directly from the Authorization header. Here’s an example extending the identity object<sup>*</sup>:

```yaml
spec:
  identity:
  - name: k8s-tokenreview
    kubernetes:
      extendedProperties:
      - name: jwt
        valueFrom:
          authJSON: context.request.http.headers.authorization|@extract:{"pos":1}|@extract:{"sep":".","pos":1}|@base64:decode|@fromstr
```

<sup>* Requires <a href="https://github.com/Kuadrant/authorino/pull/401">#401</a>.</sup>

## Verification steps

①  Deploy

```sh
make local-setup FF=1
kubectl port-forward deployment/envoy 8000:8000 2>&1 >/dev/null &
```

②  Follow the steps of the [Authentication with Kubernetes tokens (TokenReview API)](https://github.com/Kuadrant/authorino/blob/main/docs/user-guides/kubernetes-tokenreview.md#5-create-the-authconfig) user guide from step 5