### PR TITLE
Check 'client auth' key usage on mtls identity

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -203,6 +203,8 @@ Trusted root Certificate Authorities (CA) are stored in Kubernetes Secrets label
 
 Trusted root CA secrets must be created in the same namespace of the `AuthConfig` (default) or `spec.authentication.x509.allNamespaces` must be set to `true` (only works with [cluster-wide Authorino instances](./architecture.md#cluster-wide-vs-namespaced-instances)).
 
+Client certificates must include x509 v3 extension specifying 'Client Authentication' extended key usage.
+
 The identity object resolved out of a client x509 certificate is equal to the subject field of the certificate, and it serializes as JSON within the Authorization JSON usually as follows:
 
 ```jsonc

--- a/pkg/evaluators/identity/mtls.go
+++ b/pkg/evaluators/identity/mtls.go
@@ -91,7 +91,7 @@ func (m *MTLS) Call(pipeline auth.AuthPipeline, ctx context.Context) (interface{
 		certs.AddCert(cert)
 	}
 
-	if _, err := cert.Verify(x509.VerifyOptions{Roots: certs}); err != nil {
+	if _, err := cert.Verify(x509.VerifyOptions{Roots: certs, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}}); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Make the mTLS identity verification method to check for 'Client authentication' extended key usage, instead of default 'Server authentication' ([ref](https://access.redhat.com/documentation/en-us/red_hat_certificate_system/9/html/administration_guide/standard_x.509_v3_certificate_extensions#Standard_X.509_v3_Certificate_Extensions-extKeyUsage)).