### PR TITLE
Fix documentation wrong metric type

### DIFF
--- a/docs/user-guides/observability.md
+++ b/docs/user-guides/observability.md
@@ -163,7 +163,7 @@ The [Authorino Operator](https://github.com/kuadrant/authorino-operator) creates
       <td>auth_server_authconfig_duration_seconds</td>
       <td>Response latency of authconfig enforced by the auth server (in seconds).</td>
       <td><code>namespace</code>, <code>authconfig</code></td>
-      <td>counter</td>
+      <td>histogram</td>
     </tr>
     <tr>
       <td>auth_server_response_status</td>


### PR DESCRIPTION
```
# HELP auth_server_authconfig_duration_seconds Response latency of authconfig enforced by the auth server (in seconds).
# TYPE auth_server_authconfig_duration_seconds histogram
auth_server_authconfig_duration_seconds_bucket{authconfig="test",namespace="test-ns",le="0.001"} 0
auth_server_authconfig_duration_seconds_bucket{authconfig="test",namespace="test-ns",le="0.051000000000000004"} 1
auth_server_authconfig_duration_seconds_bucket{authconfig="test",namespace="test-ns",le="0.101"} 1
auth_server_authconfig_duration_seconds_bucket{authconfig="test",namespace="test-ns",le="0.15100000000000002"} 1
auth_server_authconfig_duration_seconds_bucket{authconfig="test",namespace="test-ns",le="0.201"} 1
auth_server_authconfig_duration_seconds_bucket{authconfig="test",namespace="test-ns",le="0.251"} 1
```