### PR TITLE
#kuadrant channel on kubernetes.slack.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,4 +456,4 @@ geomean     569.0        2.000       -99.65%
 
 If you are interested in contributing to Authorino, please refer to the [Developer's guide](./docs/contributing.md) for info about the stack and requirements, workflow, policies and Code of Conduct.
 
-Join us on [kuadrant.slack.com](https://kuadrant.slack.com) for live discussions about the roadmap and more.
+Join us on the [#kuadrant](https://kubernetes.slack.com/archives/C05J0D0V525) channel in the Kubernetes Slack workspace, for live discussions about the roadmap and more.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -264,4 +264,4 @@ Other repos:
 
 ## Reach out
 
-[kuadrant.slack.com](https://kuadrant.slack.com)
+[#kuadrant](https://kubernetes.slack.com/archives/C05J0D0V525) channel on kubernetes.slack.com.


### PR DESCRIPTION
Point people interested to reach out to the [#kuadrant](https://kubernetes.slack.com/archives/C05J0D0V525) channel in the Kubernetes Slack workspace.