### PR TITLE
Add log for when authconfig is de-indexed

### DIFF
--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -99,6 +99,7 @@ func (r *AuthConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		r.Index.Delete(resourceId)
 		r.StatusReport.Clear(resourceId)
 		reportReconciled = false
+		logger.Info("resource de-indexed")
 	} else {
 		// resource found and it is to be watched by this controller
 		// we need to either create it or update it in the index

--- a/docs/user-guides/sharding.md
+++ b/docs/user-guides/sharding.md
@@ -201,11 +201,11 @@ kubectl -n myapp label authconfig/auth-config-2 disabled=true
 # authconfig.authorino.kuadrant.io/auth-config-2 labeled
 ```
 
-Verify in the logs that only the `authorino-production` instance adds the resources to the index:
+Verify in the logs that the `authorino-production` instance removes the authconfig from the index:
 
 ```sh
 kubectl logs $(kubectl get pods -l authorino-resource=authorino-production -o name)
-# {"level":"info","ts":1638383515.6428752,"logger":"authorino.controller-runtime.manager.controller.authconfig","msg":"resource reconciled","authconfig":"myapp/auth-config-2"}
+# {"level":"info","ts":1638383515.6428752,"logger":"authorino.controller-runtime.manager.controller.authconfig","msg":"resource de-indexed","authconfig":"myapp/auth-config-2"}
 ```
 
 ## Cleanup


### PR DESCRIPTION
## Verification

Follow the [user-guide](https://github.com/Kuadrant/authorino/blob/main/docs/user-guides/sharding.md) up to step 9. to verify that there are no logs present when adding the disabled label.

Remove the disabled label from the `AuthConfig`:

```
kubectl -n myapp label authconfig/auth-config-2 disabled-
```

Update the authorino-production deployment to use an image built from this branch:
```
kubectl patch authorino/authorino-production --type=merge -p '{"spec":{"image":"quay.io/acatterm/authorino:log-deindex"}}'
kubectl rollout restart deployment authorino-production
```
Watch the logs:
```
kubectl logs -f $(kubectl get pods -l authorino-resource=authorino-production -o name)
```

Re-label the `AuthConfig` as disabled:
```
kubectl -n myapp label authconfig/auth-config-2 disabled=true
```

See a log stating the resource is de-indexed:
```
{"level":"info","ts":1695213540.451739,"logger":"authorino.controller-runtime.manager.controller.authconfig","msg":"resource de-indexed","authconfig":"myapp/auth-config-2"}
```

Resolves #423 