### PR TITLE
fix: missing one-of constraint of top-level when conditions

### DIFF
--- a/install/crd/patches/oneof_in_authconfigs.yaml
+++ b/install/crd/patches/oneof_in_authconfigs.yaml
@@ -121,6 +121,12 @@
         selector: {}
         value: {}
       required: [operator, selector]
+    - properties:
+        all: {}
+      required: [all]
+    - properties:
+        any: {}
+      required: [any]
 
 - op: add
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/identity/items/properties/when/items/oneOf

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -2474,6 +2474,14 @@ spec:
                     required:
                     - operator
                     - selector
+                  - properties:
+                      all: {}
+                    required:
+                    - all
+                  - properties:
+                      any: {}
+                    required:
+                    - any
                   properties:
                     all:
                       description: A list of pattern expressions to be evaluated as


### PR DESCRIPTION
Add missing top-level `when` conditions one-of constraints. Should have been in https://github.com/Kuadrant/authorino/pull/427.

### Verification steps

① Setup:

```sh
make local-setup FF=1
```

② Create an AuthConfig otherwise invalid

```sh
kubectl apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta2
kind: AuthConfig
metadata:
  name: toystore
spec:
  hosts:
  - api.toystore.com
  when:
  - any:
    - any:
      - all:
        - operator: eq
          selector: context.request.http.method
          value: GET
        - operator: matches
          selector: context.request.http.path.@extract:{"sep":"?"}
          value: /cars.*
      - all:
        - operator: eq
          selector: context.request.http.method
          value: GET
        - operator: matches
          selector: context.request.http.path.@extract:{"sep":"?"}
          value: /dolls.*
    - any:
      - all:
        - operator: matches
          selector: context.request.http.path.@extract:{"sep":"?"}
          value: /admin.*
EOF
```

③ Verify the AuthConfig is ready:

```sh
kubectl get authconfig/toystore
# NAME       READY   HOSTS
# toystore   true    1/1
```