### PR TITLE
Enable/disable host name collision prevention for strict host subsets

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -238,6 +238,8 @@ Authorino tries to prevent host name collision between `AuthConfig`s by rejectin
 
 When wildcards are involved, a host name that matches a host wildcard already linked in the index to another `AuthConfig` will be considered taken, and therefore the newest `AuthConfig` will be rejected to be linked to that host.
 
+This behavior can be disabled to allow `AuthConfig`s to partially supersede each others' host names (limited to strict host subsets), by supplying the `--allow-superseding-host-subsets` command-line flag when running the Authorino instance.
+
 ## The Authorization JSON
 
 On every Auth Pipeline, Authorino builds the **Authorization JSON**, a "working-memory" data structure composed of `context` (information about the request, as supplied by the Envoy proxy to Authorino) and `auth` (objects resolved in phases (i) to (v) of the pipeline). The evaluators of each phase can read from the Authorization JSON and implement dynamic properties and decisions based on its values.


### PR DESCRIPTION
Adds a new command-line flag `--allow-superseding-host-subsets` that disables the [host name collision prevention](https://github.com/Kuadrant/authorino/blob/main/docs/architecture.md#avoiding-host-name-collision) for strict subsets of hosts attempted to be linked after a superset already taken.

Closes #433 under a more conservative approach where the switch for the host name collision mechanism does not come in levels, but as a simple ON/OFF switch, whose semantics is limited to strict subsets. I reckon this is a reasonable compromise as there are only few use cases I can think of for fully superseding the auth scheme a given host is linked to, based only on the order of creation of the resources.

Moreover, this approach exempts the reconciler from having to update the status of the (partially) superseded AuthConfigs, consistently with the current behaviour, when the order of creation goes: more specific first, then more generic host. The status of the more generic (wider) AuthConfig has never reflected that a subset of its hosts was actually under another auth scheme declared first.

### Verification steps

①  Setup

```sh
make local-setup FF=1
```

②  Activate the switch

Avoid the Authorino Operator to reconcile the changes back:

```sh
kubectl scale --replicas=0 deployment/authorino-operator -n authorino-operator
```

Modify the Authorino deployment activating the switch:

```sh
kubectl edit deployment/authorino
```

Add the `--allow-superseding-host-subsets` command-line flag to the list of `args` of the pod.

③  Create AuthConfigs in an order that otherwise would result in one of them being rejected

More generic:

```sh
kubectl apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta2
kind: AuthConfig
metadata:
  name: deny-all
spec:
  hosts:
  - "*.127.0.0.1.nip.io"
  authorization:
    deny-all:
      opa:
        rego: "allow = false"
EOF
```

More specific:

```sh
kubectl apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta2
kind: AuthConfig
metadata:
  name: talker-api
spec:
  hosts:
  - talker-api.127.0.0.1.nip.io
  authentication:
    friends:
      apiKey:
        selector:
          matchLabels:
            app: friends
        allNamespaces: true
      credentials:
        authorizationHeader:
          prefix: APIKEY
EOF
```

Verify both AuthConfigs have been accepted:

```sh
kubectl get authconfigs
# NAME         READY   HOSTS
# deny-all     true    1/1
# talker-api   true    1/1
```

④  Create another AuthConfig that tries to fully supersede a hostname already taken

```sh
kubectl apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta2
kind: AuthConfig
metadata:
  name: allow-all
spec:
  hosts:
  - "*.127.0.0.1.nip.io"
EOF
```

Verify all the right AuthConfigs are accepted and rejected:

```sh
kubectl get authconfigs
# NAME         READY   HOSTS
# allow-all    false   0/1
# deny-all     true    1/1
# talker-api   true    1/1
```

⑤  Send requests to the sample API and confirm the right AuthConfigs are being enforced

Expose the proxy:

```sh
kubectl port-forward deployment/envoy 8000:8000 2>&1 >/dev/null &
```

More specific auth scheme:

```sh
curl http://talker-api.127.0.0.1.nip.io:8000 -i
# HTTP/1.1 401 Unauthorized
```

More generic auth scheme:

```sh
curl http://other.127.0.0.1.nip.io:8000 -i
# HTTP/1.1 403 Forbidden
```

⑥  (Optional) Verify that bootstrapping the index with preexisting resources keeps the state consistsent

```sh
kubectl rollout restart deployment/authorino
```

```sh
kubectl get authconfigs
# NAME         READY   HOSTS
# allow-all    false   0/1
# deny-all     true    1/1
# talker-api   true    1/1
```