### PR TITLE
fix: flaky tests

### DIFF
--- a/api/v1beta2/auth_config_conversion_test.go
+++ b/api/v1beta2/auth_config_conversion_test.go
@@ -41,6 +41,12 @@ func TestConvertTo(t *testing.T) {
 	sort.Slice(converted.Spec.Callbacks, func(i, j int) bool {
 		return converted.Spec.Callbacks[i].Name < converted.Spec.Callbacks[j].Name
 	})
+	sort.Slice(converted.Spec.DenyWith.Unauthenticated.Headers, func(i, j int) bool {
+		return converted.Spec.DenyWith.Unauthenticated.Headers[i].Name < converted.Spec.DenyWith.Unauthenticated.Headers[j].Name
+	})
+	sort.Slice(converted.Spec.DenyWith.Unauthorized.Headers, func(i, j int) bool {
+		return converted.Spec.DenyWith.Unauthorized.Headers[i].Name < converted.Spec.DenyWith.Unauthorized.Headers[j].Name
+	})
 
 	expected := hubAuthConfig()
 	if !reflect.DeepEqual(expected, converted) {

--- a/pkg/evaluators/identity/oidc_test.go
+++ b/pkg/evaluators/identity/oidc_test.go
@@ -111,12 +111,12 @@ func TestOidcProviderRefresh(t *testing.T) {
 
 	authCredMock := mock_auth.NewMockAuthCredentials(ctrl)
 
-	evaluator := NewOIDC(fmt.Sprintf("http://%v", oidcServerHost), authCredMock, 1, context.TODO())
+	evaluator := NewOIDC(fmt.Sprintf("http://%v", oidcServerHost), authCredMock, 3, context.TODO())
 	defer evaluator.Clean(context.Background())
 
 	assert.Check(t, evaluator.refresher != nil)
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 	assert.Equal(t, 2, count)
 	assert.Equal(t, fmt.Sprintf("http://%v/auth?count=2", oidcServerHost), evaluator.provider.Endpoint().AuthURL)
 }


### PR DESCRIPTION
- [x] authconfig conversion tests with random orderring of elements within array
- [x] weak concurrency coordination using sleep directive

Popped up more often after #435.