### PR TITLE
fix: bump OpenTelemetry Schema URL to 1.21.0

### DIFF
--- a/pkg/trace/exporter.go
+++ b/pkg/trace/exporter.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 )
 
 type Config struct {


### PR DESCRIPTION
Fixes an error in the initialization of Authorino when tracing services are enabled.

Error message:

```
cannot merge resource due to conflicting Schema URL
```

Stacktrace:

```
main.setupTelemetryServices
	/usr/src/authorino/main.go:409
main.setup
	/usr/src/authorino/main.go:387
main.runAuthorizationServer
	/usr/src/authorino/main.go:225
github.com/spf13/cobra.(*Command).execute
	/opt/app-root/src/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944
github.com/spf13/cobra.(*Command).ExecuteC
	/opt/app-root/src/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068
github.com/spf13/cobra.(*Command).Execute
	/opt/app-root/src/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/spf13/cobra.(*Command).ExecuteContext
	/opt/app-root/src/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:985
main.main
	/usr/src/authorino/main.go:149
runtime.main
	/usr/lib/golang/src/runtime/proc.go:250
```

This was likely caused after upgrading otel deps to v0.46.x (#448) and it's a known issue of otel's Resource API: https://github.com/open-telemetry/opentelemetry-go/issues/2341.