### PR TITLE
fix: extra metrics handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -416,13 +416,13 @@ func setupTelemetryServices(opts telemetryOptions) {
 }
 
 func setupManager(options ctrl.Options) (ctrl.Manager, error) {
+	if options.Metrics.BindAddress != "0" {
+		options.Metrics.ExtraHandlers = map[string]http.Handler{"/server-metrics": promhttp.Handler()}
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {
 		return nil, err
-	}
-
-	if options.Metrics.BindAddress != "0" {
-		options.Metrics.ExtraHandlers = map[string]http.Handler{"/server-metrics": promhttp.Handler()}
 	}
 
 	if options.HealthProbeBindAddress != "0" {


### PR DESCRIPTION
Options for the extra metrics handler of the controller manager need to be set before creating the manager.
Otherwise, the `/server-metrics` endpoint will not be included and return a 404.

### Verification steps

```sh
make local-setup FF=1
kubectl port-forward service/authorino-controller-metrics 8080:8080 2>&1 >/dev/null &
curl http://localhost:8080/server-metrics
```

You should see the server metrics and not a `404 Not Found`.