### PR TITLE
Handle invalid ext_authz request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ kustomize: ## Installs kustomize in $PROJECT_DIR/bin
 
 ENVTEST = $(PROJECT_DIR)/bin/setup-envtest
 envtest: ## Installs setup-envtest in $PROJECT_DIR/bin
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.16)
 
 MOCKGEN = $(PROJECT_DIR)/bin/mockgen
 mockgen: ## Installs mockgen in $PROJECT_DIR/bin

--- a/pkg/service/auth_test.go
+++ b/pkg/service/auth_test.go
@@ -143,6 +143,16 @@ func TestBuildDynamicEnvoyMetadata(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+func TestInvalidCheckRequest(t *testing.T) {
+	authService := AuthService{Index: index.NewIndex()}
+	resp, err := authService.Check(context.TODO(), &envoy_auth.CheckRequest{})
+	assert.NilError(t, err)
+	assert.Equal(t, resp.Status.Code, int32(rpc.INVALID_ARGUMENT))
+	denied := resp.GetDeniedResponse()
+	assert.Equal(t, denied.Status.Code, envoy_type.StatusCode_BadRequest)
+	assert.Equal(t, getHeader(denied.GetHeaders(), X_EXT_AUTH_REASON_HEADER), "Invalid request")
+}
+
 func TestAuthServiceRawHTTPAuthorization_Post(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()


### PR DESCRIPTION
Improved handler for invalid ext_authz requests errors.

### Verification steps

```sh
make cluster install run
```

In a separate shell: (Requires [grpcurl](https://github.com/fullstorydev/grpcurl))

```sh
grpcurl -plaintext -d @ localhost:50051 envoy.service.auth.v3.Authorization.Check <<EOF
{}
EOF
```

**Before:**

Authorino panics.

**After:**

Authorino handles the error nicely and the returns the following response:

```
{
  "status": {
    "code": 3
  },
  "deniedResponse": {
    "status": {
      "code": "BadRequest"
    },
    "headers": [
      {
        "header": {
          "key": "X-Ext-Auth-Reason",
          "value": "Invalid request"
        }
      }
    ]
  }
}
```
