### PR TITLE
[docs] avoid false positive openssl-related security flagging

### DIFF
--- a/pkg/evaluators/identity/mtls_test.go
+++ b/pkg/evaluators/identity/mtls_test.go
@@ -336,7 +336,7 @@ func issueCertificate(subject pkix.Name, ca map[string][]byte, days int, extKeyU
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: isCA,
 	}
-	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	key, _ := rsa.GenerateKey(rand.Reader, 4096)
 	privKey := key
 	parent := cert
 	if !isCA {


### PR DESCRIPTION
Generate 4096-bit cert keys and use sha512 algorithms for certificate requests in the `openssl` examples in the docs and mtls test cases, to avoid false-positive security flagging.