### PR TITLE
fixup: some broken docs links

### DIFF
--- a/docs/user-guides/anonymous-access.md
+++ b/docs/user-guides/anonymous-access.md
@@ -3,17 +3,12 @@
 Bypass identity verification or fall back to anonymous access when credentials fail to validate
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Identity verification & authentication → <a href="./../features.md#anonymous-access-authenticationanonymous">Anonymous access</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide:</summary>
 
-  For further details about Authorino features in general, check the [docs](./../features.md).
+  - Identity verification & authentication → [Anonymous access](./../features.md#anonymous-access-authenticationanonymous)
+
+    For further details about Authorino features in general, check the [docs](./../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/api-key-authentication.md
+++ b/docs/user-guides/api-key-authentication.md
@@ -3,12 +3,9 @@
 Issue API keys stored in Kubernetes `Secret`s for clients to authenticate with your protected hosts.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Identity verification & authentication → <a href="../features.md#api-key-authenticationapikey">API key</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide:</summary>
+
+  - Identity verification & authentication → [API key](../features.md#api-key-authenticationapikey)
 
   In Authorino, API keys are stored as Kubernetes `Secret`s. Each resource must contain an `api_key` entry with the value of the API key, and labeled to match the selectors specified in `spec.identity.apiKey.selector` of the `AuthConfig`.
 
@@ -16,8 +13,6 @@ Issue API keys stored in Kubernetes `Secret`s for clients to authenticate with y
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
+++ b/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
@@ -3,14 +3,12 @@
 Provide Envoy with dynamic metadata about the external authorization process to be injected into the rate limiting filter.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Dynamic response → Response wrappers → <a href="../features.md#envoy-dynamic-metadata">Envoy Dynamic Metadata</a></li>
-      <li>Dynamic response → <a href="../features.md#json-injection-responsesuccessheadersdynamicmetadatajson">JSON injection</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#api-key-authenticationapikey">API key</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Dynamic response → Response wrappers → [Envoy Dynamic Metadata](../features.md#envoy-dynamic-metadata)
+  - Dynamic response → [JSON injection](../features.md#json-injection-responsesuccessheadersdynamicmetadatajson)
+  - Identity verification & authentication → [API key](../features.md#api-key-authenticationapikey)
+
 
   Dynamic JSON objects built out of static values and values fetched from the [Authorization JSON](../architecture.md#the-authorization-json) can be wrapped to be returned to the reverse-proxy as Envoy Well Known Dynamic Metadata content. Envoy can use those to inject data returned by the external authorization service into the other filters, such as the rate limiting filter.
 

--- a/docs/user-guides/authzed.md
+++ b/docs/user-guides/authzed.md
@@ -3,16 +3,11 @@
 Permission requests sent to a Google Zanzibar-based [Authzed/SpiceDB](https://authzed.com) instance, via gRPC.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Authorization → <a href="../features.md#spicedb-authorizationspicedb">SpiceDB</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#api-key-authenticationapikey">API key</a></li>
-    </ul>
-  </summary>
-</details>
+  <summary>Authorino capabilities featured in this guide</summary>
 
-<br/>
+  - Authorization → [SpiceDB](../features.md#spicedb-authorizationspicedb)
+  - Identity verification & authentication → [API key](../features.md#api-key-authenticationapikey)
+</details>
 
 ## Requirements
 

--- a/docs/user-guides/caching.md
+++ b/docs/user-guides/caching.md
@@ -17,21 +17,16 @@ Cases where one will **NOT** want to enable caching, due to relatively cheap com
 - Anonymous access
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Common feature → <a href="../features.md#common-feature-caching-cache">Caching</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#anonymous-access-authenticationanonymous">Anonymous access</a></li>
-      <li>External auth metadata → <a href="../features.md#http-getget-by-post-metadatahttp">HTTP GET/GET-by-POST</a></li>
-      <li>Authorization → <a href="../features.md#open-policy-agent-opa-rego-policies-authorizationopa">Open Policy Agent (OPA) Rego policies</a></li>
-      <li>Dynamic response → <a href="../features.md#json-injection-responsesuccessheadersdynamicmetadatajson">JSON injection</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Common feature → [Caching](../features.md#common-feature-caching-cache)
+  - Identity verification & authentication → [Anonymous access](../features.md#anonymous-access-authenticationanonymous)
+  - External auth metadata → [HTTP GET/GET-by-POST](../features.md#http-getget-by-post-metadatahttp)
+  - Authorization → [Open Policy Agent (OPA) Rego policies](../features.md#open-policy-agent-opa-rego-policies-authorizationopa)
+  - Dynamic response → [JSON injection](../features.md#json-injection-responsesuccessheadersdynamicmetadatajson)
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/deny-with-redirect-to-login.md
+++ b/docs/user-guides/deny-with-redirect-to-login.md
@@ -3,14 +3,11 @@
 Customize response status code and headers on failed requests to redirect users of a web application protected with Authorino to a login page instead of a `401 Unauthorized`.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Dynamic response → <a href="../features.md#custom-denial-status-responseunauthenticated-and-responseunauthorized">Custom denial status</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#api-key-authenticationapikey">API key</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#jwt-verification-authenticationjwt">JWT verification</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Dynamic response → [Custom denial status](../features.md#custom-denial-status-responseunauthenticated-and-responseunauthorized)
+  - Identity verification & authentication → [API key](../features.md#api-key-authenticationapikey)
+  - Identity verification & authentication → [JWT verification](../features.md#jwt-verification-authenticationjwt)
 
   Authorino's default response status codes, messages and headers for unauthenticated (`401`) and unauthorized (`403`) requests can be customized with static values and values fetched from the [Authorization JSON](../architecture.md#the-authorization-json).
 
@@ -18,8 +15,6 @@ Customize response status code and headers on failed requests to redirect users 
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/edge-authentication-architecture-festival-wristbands.md
+++ b/docs/user-guides/edge-authentication-architecture-festival-wristbands.md
@@ -11,15 +11,12 @@ The very definition of "edge" is subject to discussion, but the underlying idea 
 As a minimum, EAA allows to simplify authentication between applications and microservices inside the network, as well as to reduce authorization to domain-specific rules and policies, rather than having to deal all the complexity to support all types of clients in every node.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Dynamic response → <a href="../features.md#festival-wristband-tokens-responsesuccessheadersdynamicmetadatawristband">Festival Wristband tokens</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#extra-identity-extension-authenticationdefaults-and-authenticationoverrides">Identity extension</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#api-key-authenticationapikey">API key</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#jwt-verification-authenticationjwt">JWT verification</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Dynamic response → [Festival Wristband tokens](../features.md#festival-wristband-tokens-responsesuccessheadersdynamicmetadatawristband)
+  - Identity verification & authentication → [Identity extension](../features.md#extra-identity-extension-authenticationdefaults-and-authenticationoverrides)
+  - Identity verification & authentication → [API key](../features.md#api-key-authenticationapikey)
+  - Identity verification & authentication → [JWT verification](../features.md#jwt-verification-authenticationjwt)
 
   Festival Wristbands are OpenID Connect ID tokens (signed JWTs) issued by Authorino by the end of the Auth Pipeline, for authorized requests. It can be configured to include claims based on static values and values fetched from the [Authorization JSON](../architecture.md#the-authorization-json).
 
@@ -27,8 +24,6 @@ As a minimum, EAA allows to simplify authentication between applications and mic
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/envoy-jwt-authn-and-authorino.md
+++ b/docs/user-guides/envoy-jwt-authn-and-authorino.md
@@ -9,20 +9,15 @@ The policy defines a geo-fence by which only requests originated in Great Britai
 All requests to the Talker API will be authenticated in Envoy. However, requests to `/global` will **not** trigger the external authorization.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Identity verification & authentication → <a href="../features.md#plain-authenticationplain">Plain</a></li>
-      <li>External auth metadata → <a href="../features.md#http-getget-by-post-metadatahttp">HTTP GET/GET-by-POST</a></li>
-      <li>Authorization → <a href="../features.md#pattern-matching-authorization-authorizationpatternmatching">Pattern-matching authorization</a></li>
-      <li>Dynamic response → <a href="../features.md#custom-denial-status-responseunauthenticated-and-responseunauthorized">Custom denial status</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Identity verification & authentication → [Plain](../features.md#plain-authenticationplain)
+  - External auth metadata → [HTTP GET/GET-by-POST](../features.md#http-getget-by-post-metadatahttp)
+  - Authorization → [Pattern-matching authorization](../features.md#pattern-matching-authorization-authorizationpatternmatching)
+  - Dynamic response → [Custom denial status](../features.md#custom-denial-status-responseunauthenticated-and-responseunauthorized)
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/external-metadata.md
+++ b/docs/user-guides/external-metadata.md
@@ -3,14 +3,11 @@
 Get online data from remote HTTP services to enhance authorization rules.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>External auth metadata → <a href="../features.md#http-getget-by-post-metadatahttp">HTTP GET/GET-by-POST</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#api-key-authenticationapikey">API key</a></li>
-      <li>Authorization → <a href="../features.md#open-policy-agent-opa-rego-policies-authorizationopa">Open Policy Agent (OPA) Rego policies</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - External auth metadata → [HTTP GET/GET-by-POST](../features.md#http-getget-by-post-metadatahttp)
+  - Identity verification & authentication → [API key](../features.md#api-key-authenticationapikey)
+  - Authorization → [Open Policy Agent (OPA) Rego policies](../features.md#open-policy-agent-opa-rego-policies-authorizationopa)
 
   You can configure Authorino to fetch additional metadata from external sources in request-time, by sending either GET or POST request to an HTTP service. The service is expected to return a JSON content which is appended to the [Authorization JSON](../architecture.md#the-authorization-json), thus becoming available for usage in other configs of the Auth Pipeline, such as in authorization policies or custom responses.
 
@@ -20,8 +17,6 @@ Get online data from remote HTTP services to enhance authorization rules.
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/http-basic-authentication.md
+++ b/docs/user-guides/http-basic-authentication.md
@@ -3,13 +3,10 @@
 Turn Authorino API key `Secret`s settings into HTTP basic auth.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Identity verification & authentication → <a href="../features.md#api-key-authenticationapikey">API key</a></li>
-        <li>Authorization → <a href="../features.md#pattern-matching-authorization-authorizationpatternmatching">Pattern-matching authorization</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Identity verification & authentication → [API key](../features.md#api-key-authenticationapikey)
+  - Authorization → [Pattern-matching authorization](../features.md#pattern-matching-authorization-authorizationpatternmatching)
 
   HTTP "Basic" Authentication ([RFC 7235](https://datatracker.ietf.org/doc/html/rfc7235)) is not recommended if you can afford other more secure methods such as OpenID Connect. To support legacy nonetheless it is sometimes necessary to implement it.
 
@@ -19,8 +16,6 @@ Turn Authorino API key `Secret`s settings into HTTP basic auth.
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/injecting-data.md
+++ b/docs/user-guides/injecting-data.md
@@ -3,13 +3,10 @@
 Inject HTTP headers with serialized JSON content.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Dynamic response → <a href="../features.md#json-injection-responsesuccessheadersdynamicmetadatajson">JSON injection</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#api-key-authenticationapikey">API key</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Dynamic response → [JSON injection](../features.md#json-injection-responsesuccessheadersdynamicmetadatajson)
+  - Identity verification & authentication → [API key](../features.md#api-key-authenticationapikey)
 
   Inject serialized custom JSON objects as HTTP request headers. Values can be static or fetched from the [Authorization JSON](../architecture.md#the-authorization-json).
 
@@ -17,8 +14,6 @@ Inject HTTP headers with serialized JSON content.
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/json-pattern-matching-authorization.md
+++ b/docs/user-guides/json-pattern-matching-authorization.md
@@ -3,13 +3,10 @@
 Write simple authorization rules based on JSON patterns matched against Authorino's Authorization JSON; check contextual information of the request, validate JWT claims, cross metadata fetched from external sources, etc.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Authorization → <a href="../features.md#pattern-matching-authorization-authorizationpatternmatching">Pattern-matching authorization</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#jwt-verification-authenticationjwt">JWT verification</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Authorization → [Pattern-matching authorization](../features.md#pattern-matching-authorization-authorizationpatternmatching)
+  - Identity verification & authentication → [JWT verification](../features.md#jwt-verification-authenticationjwt)
 
   Authorino provides a built-in authorization module to check simple pattern-matching rules against the [Authorization JSON](../architecture.md#the-authorization-json). This is an alternative to [OPA](../features.md#open-policy-agent-opa-rego-policies-authorizationopa) when all you want is to check for some simple rules, without complex logics, such as match the value of a JWT claim.
 
@@ -17,8 +14,6 @@ Write simple authorization rules based on JSON patterns matched against Authorin
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/keycloak-authorization-services.md
+++ b/docs/user-guides/keycloak-authorization-services.md
@@ -5,18 +5,14 @@ Keycloak provides a powerful set of tools (REST endpoints and administrative UIs
 This user guide is an example of how to use Authorino as an adapter to Keycloak Authorization Services while still relying on the reverse-proxy integration pattern, thus not involving importing an authorization library nor rebuilding the application's code.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Identity verification & authentication → <a href="../features.md#jwt-verification-authenticationjwt">JWT verification</a></li>
-      <li>Authorization → <a href="../features.md#open-policy-agent-opa-rego-policies-authorizationopa">Open Policy Agent (OPA) Rego policies</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Identity verification & authentication → [JWT verification](../features.md#jwt-verification-authenticationjwt)
+  - Authorization → [Open Policy Agent (OPA) Rego policies](../features.md#open-policy-agent-opa-rego-policies-authorizationopa)
+
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/kubernetes-subjectaccessreview.md
+++ b/docs/user-guides/kubernetes-subjectaccessreview.md
@@ -3,13 +3,11 @@
 Manage permissions in the Kubernetes RBAC and let Authorino to check them in request-time with the authorization system of the cluster.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Authorization → <a href="../features.md#kubernetes-subjectaccessreview-authorizationkubernetessubjectaccessreview">Kubernetes SubjectAccessReview</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#kubernetes-tokenreview-authenticationkubernetestokenreview">Kubernetes TokenReview</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Authorization → [Kubernetes SubjectAccessReview](../features.md#kubernetes-subjectaccessreview-authorizationkubernetessubjectaccessreview)
+  - Identity verification & authentication → [Kubernetes TokenReview](../features.md#kubernetes-tokenreview-authenticationkubernetestokenreview)
+
 
   Authorino can delegate authorization decision to the Kubernetes authorization system, allowing permissions to be stored and managed using the Kubernetes Role-Based Access Control (RBAC) for example. The feature is based on the `SubjectAccessReview` API and can be used for `resourceAttributes` (parameters defined in the `AuthConfig`) or `nonResourceAttributes` (inferring HTTP path and verb from the original request).
 
@@ -17,8 +15,6 @@ Manage permissions in the Kubernetes RBAC and let Authorino to check them in req
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/kubernetes-tokenreview.md
+++ b/docs/user-guides/kubernetes-tokenreview.md
@@ -3,12 +3,9 @@
 Validate Kubernetes Service Account tokens to authenticate requests to your protected hosts.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Identity verification & authentication → <a href="../features.md#kubernetes-tokenreview-authenticationkubernetestokenreview">Kubernetes TokenReview</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Identity verification & authentication → [Kubernetes TokenReview](../features.md#kubernetes-tokenreview-authenticationkubernetestokenreview)
 
   Authorino can verify Kubernetes-valid access tokens (using Kubernetes [TokenReview](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1) API).
 
@@ -18,8 +15,6 @@ Validate Kubernetes Service Account tokens to authenticate requests to your prot
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/mtls-authentication.md
+++ b/docs/user-guides/mtls-authentication.md
@@ -3,13 +3,10 @@
 Verify client X.509 certificates against trusted root CAs stored in Kubernetes `Secret`s to authenticate access to APIs protected with Authorino.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Identity verification & authentication → <a href="../features.md#x509-client-certificate-authentication-authenticationx509">X.509 client certificate authentication</a></li>
-      <li>Authorization → <a href="../features.md#pattern-matching-authorization-authorizationpatternmatching">Pattern-matching authorization</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Identity verification & authentication → [X.509 client certificate authentication](../features.md#x509-client-certificate-authentication-authenticationx509)
+  - Authorization → [Pattern-matching authorization](../features.md#pattern-matching-authorization-authorizationpatternmatching)
 
   Authorino can verify x509 certificates presented by clients for authentication on the request to the protected APIs, at application level.
 
@@ -17,8 +14,6 @@ Verify client X.509 certificates against trusted root CAs stored in Kubernetes `
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/oauth2-token-introspection.md
+++ b/docs/user-guides/oauth2-token-introspection.md
@@ -3,13 +3,10 @@
 Introspect OAuth 2.0 access tokens (e.g. opaque tokens) for online user data and token validation in request-time.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Identity verification & authentication → <a href="../features.md#oauth-20-introspection-authenticationoauth2introspection">OAuth 2.0 introspection</a></li>
-      <li>Authorization → <a href="../features.md#pattern-matching-authorization-authorizationpatternmatching">Pattern-matching authorization</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Identity verification & authentication → [OAuth 2.0 introspection](../features.md#oauth-20-introspection-authenticationoauth2introspection)
+  - Authorization → [Pattern-matching authorization](../features.md#pattern-matching-authorization-authorizationpatternmatching)
 
   Authorino can perform OAuth 2.0 token introspection ([RFC 7662](https://tools.ietf.org/html/rfc7662)) on the access tokens supplied in the requests to protected APIs. This is particularly useful when using opaque tokens, for remote checking the token validity and resolving the identity object.
 
@@ -19,8 +16,6 @@ Introspect OAuth 2.0 access tokens (e.g. opaque tokens) for online user data and
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/oidc-jwt-authentication.md
+++ b/docs/user-guides/oidc-jwt-authentication.md
@@ -3,12 +3,9 @@
 Validate JSON Web Tokens (JWT) issued and signed by an OpenID Connect server; leverage OpenID Connect Discovery to automatically fetch JSON Web Key Sets (JWKS).
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Identity verification & authentication → <a href="../features.md#jwt-verification-authenticationjwt">JWT verification</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Identity verification & authentication → [JWT verification](../features.md#jwt-verification-authenticationjwt)
 
   Authorino validates JSON Web Tokens (JWT) issued by an OpenID Connect server that implements OpenID Connect Discovery. Authorino fetches the OpenID Connect configuration and JSON Web Key Set (JWKS) from the issuer endpoint, and verifies the JSON Web Signature (JWS) and time validity of the token.
 
@@ -16,8 +13,6 @@ Validate JSON Web Tokens (JWT) issued and signed by an OpenID Connect server; le
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/oidc-rbac.md
+++ b/docs/user-guides/oidc-rbac.md
@@ -5,20 +5,15 @@ Combine OpenID Connect (OIDC) authentication and Role-Based Access Control (RBAC
 In this user guide, you will learn via example how to implement a simple Role-Based Access Control (RBAC) system to protect endpoints of an API, with roles assigned to users of an Identity Provider (Keycloak) and carried within the access tokens as JSON Web Token (JWT) claims. Users authenticate with the IdP via OAuth2/OIDC flow and get their access tokens verified and validated by Authorino on every request. Moreover, Authorino reads the role bindings of the user and enforces the proper RBAC rules based upon the context.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Identity verification & authentication → <a href="../features.md#jwt-verification-authenticationjwt">JWT verification</a></li>
-      <li>Authorization → <a href="../features.md#pattern-matching-authorization-authorizationpatternmatching">Pattern-matching authorization</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Identity verification & authentication → [JWT verification](../features.md#jwt-verification-authenticationjwt)
+  - Authorization → [Pattern-matching authorization](../features.md#pattern-matching-authorization-authorizationpatternmatching)
 
   Check out as well the user guides about [OpenID Connect Discovery and authentication with JWTs](oidc-jwt-authentication.md) and [Simple pattern-matching authorization policies](json-pattern-matching-authorization.md).
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/oidc-user-info.md
+++ b/docs/user-guides/oidc-user-info.md
@@ -3,14 +3,11 @@
 Fetch user info for OpenID Connect ID tokens in request-time for extra metadata for your policies and online verification of token validity.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>External auth metadata → <a href="../features.md#oidc-userinfo-metadatauserinfo">OIDC UserInfo</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#jwt-verification-authenticationjwt">JWT verification</a></li>
-      <li>Authorization → <a href="../features.md#pattern-matching-authorization-authorizationpatternmatching">Pattern-matching authorization</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - External auth metadata → [OIDC UserInfo](../features.md#oidc-userinfo-metadatauserinfo)
+  - Identity verification & authentication → [JWT verification](../features.md#jwt-verification-authenticationjwt)
+  - Authorization → [Pattern-matching authorization](../features.md#pattern-matching-authorization-authorizationpatternmatching)
 
   Apart from possibly complementing information of the JWT, fetching OpenID Connect UserInfo in request-time can be particularly useful for remote checking the state of the session, as opposed to only verifying the JWT/JWS offline. Implementation requires an OpenID Connect issuer ([`spec.identity.oidc`](#openid-connect-oidc-jwtjose-verification-and-validation-identityoidc)) configured in the same `AuthConfig`.
 
@@ -18,8 +15,6 @@ Fetch user info for OpenID Connect ID tokens in request-time for extra metadata 
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/opa-authorization.md
+++ b/docs/user-guides/opa-authorization.md
@@ -3,13 +3,10 @@
 Leverage the power of Open Policy Agent (OPA) policies, evaluated against Authorino's Authorization JSON in a built-in runtime compiled together with Authorino; pre-cache policies defined in Rego language inline or fetched from an external policy registry.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Authorization → <a href="../features.md#open-policy-agent-opa-rego-policies-authorizationopa">Open Policy Agent (OPA) Rego policies</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#api-key-authenticationapikey">API key</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Authorization → [Open Policy Agent (OPA) Rego policies](../features.md#open-policy-agent-opa-rego-policies-authorizationopa)
+  - Identity verification & authentication → [API key](../features.md#api-key-authenticationapikey)
 
   Authorino supports [Open Policy Agent](https://www.openpolicyagent.org) policies, either inline defined in [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language) as part of the `AuthConfig` or fetched from an external endpoint, such as an OPA Policy Registry.
 
@@ -19,8 +16,6 @@ Leverage the power of Open Policy Agent (OPA) policies, evaluated against Author
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/passing-credentials.md
+++ b/docs/user-guides/passing-credentials.md
@@ -3,13 +3,10 @@
 Customize where credentials are supplied in the request by each trusted source of identity.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Identity verification & authentication → <a href="../features.md#extra-auth-credentials-authenticationcredentials">Auth credentials</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#api-key-authenticationapikey">API key</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Identity verification & authentication →[Auth credentials](../features.md#extra-auth-credentials-authenticationcredentials)
+  - Identity verification & authentication →[API key](../features.md#api-key-authenticationapikey)
 
   Authentication tokens can be supplied in the `Authorization` header, in a custom header, cookie or query string parameter.
 
@@ -17,8 +14,6 @@ Customize where credentials are supplied in the request by each trusted source o
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/resource-level-authorization-uma.md
+++ b/docs/user-guides/resource-level-authorization-uma.md
@@ -3,21 +3,16 @@
 Fetch resource metadata relevant for your authorization policies from Keycloak authorization clients, using User-Managed Access (UMA) protocol.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>External auth metadata → <a href="../features.md#user-managed-access-uma-resource-registry-metadatauma">User-Managed Access (UMA) resource registry</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#jwt-verification-authenticationjwt">JWT verification</a></li>
-      <li>Authorization → <a href="../features.md#open-policy-agent-opa-rego-policies-authorizationopa">Open Policy Agent (OPA) Rego policies</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - External auth metadata → [User-Managed Access (UMA) resource registry](../features.md#user-managed-access-uma-resource-registry-metadatauma)
+  - Identity verification & authentication → [JWT verification](../features.md#jwt-verification-authenticationjwt)
+  - Authorization → [Open Policy Agent (OPA) Rego policies](../features.md#open-policy-agent-opa-rego-policies-authorizationopa)
 
   Check out as well the user guides about [OpenID Connect Discovery and authentication with JWTs](oidc-jwt-authentication.md) and [Open Policy Agent (OPA) Rego policies](opa-authorization.md).
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/sharding.md
+++ b/docs/user-guides/sharding.md
@@ -19,19 +19,15 @@ By default, Authorino will watch events related to all `AuthConfig` custom resou
 </table>
 
 <details markdown="1">
-  <summary markdown="1">
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li><a href="https://docs.kuadrant.io/authorino/docs/architecture#sharding">Sharding</a></li>
-      <li>Identity verification & authentication → <a href="https://docs.kuadrant.io/authorino/docs/features#api-key-authenticationapikey">API key</a></li>
-    </ul>
-  </summary>
+  <summary markdown="1">Authorino capabilities featured in this guide</summary>
+
+  - [Sharding](https://docs.kuadrant.io/authorino/docs/architecture#sharding)
+  - Identity verification & authentication →[API key](https://docs.kuadrant.io/authorino/docs/features#api-key-authenticationapikey)
+
   Check out as well the user guide about [Authentication with API keys](api-key-authentication.md).
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/token-normalization.md
+++ b/docs/user-guides/token-normalization.md
@@ -9,22 +9,17 @@ This user guide focuses on the aspect of mutation of the identity claims resolve
 For not only normalizing the identity claims for purpose of writing simpler authorization checks and policies, but also getting Authorino to issue a new token in a normalized format, check the [Festival Wristband tokens](../features.md#festival-wristband-tokens-responsesuccessheadersdynamicmetadatawristband) feature.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Identity verification & authentication → <a href="../features.md#extra-identity-extension-authenticationdefaults-and-authenticationoverrides">Identity extension</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#api-key-authenticationapikey">API key</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#jwt-verification-authenticationjwt">JWT verification</a></li>
-      <li>Authorization → <a href="../features.md#pattern-matching-authorization-authorizationpatternmatching">Pattern-matching authorization</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Identity verification & authentication → [Identity extension](../features.md#extra-identity-extension-authenticationdefaults-and-authenticationoverrides)
+  - Identity verification & authentication → [API key](../features.md#api-key-authenticationapikey)
+  - Identity verification & authentication → [JWT verification](../features.md#jwt-verification-authenticationjwt)
+  - Authorization → [Pattern-matching authorization](../features.md#pattern-matching-authorization-authorizationpatternmatching)
 
   Check out as well the user guides about [Authentication with API keys](api-key-authentication.md), [OpenID Connect Discovery and authentication with JWTs](oidc-jwt-authentication.md) and [Simple pattern-matching authorization policies](json-pattern-matching-authorization.md).
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 

--- a/docs/user-guides/validating-webhook.md
+++ b/docs/user-guides/validating-webhook.md
@@ -7,25 +7,20 @@ The rules to validate a request to the Kubernetes API – typically a `POST`, `P
 This user guide provides an example of using Authorino as a Kubernetes ValidatingWebhook service that validates requests to `CREATE` and `UPDATE` Authorino `AuthConfig` resources. In other words, we will use Authorino as a validator inside the cluster that decides what is a valid AuthConfig for any application which wants to rely on Authorino to protect itself.
 
 <details markdown="1">
-  <summary>
-    <strong>Authorino capabilities featured in this guide:</strong>
-    <ul>
-      <li>Identity verification & authentication → <a href="../features.md#plain-authenticationplain">Plain</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#kubernetes-tokenreview-authenticationkubernetestokenreview">Kubernetes TokenReview</a></li>
-      <li>Identity verification & authentication → <a href="../features.md#api-key-authenticationapikey">API key</a></li>
-      <li>External auth metadata → <a href="../features.md#http-getget-by-post-metadatahttp">HTTP GET/GET-by-POST</a></li>
-      <li>Authorization → <a href="../features.md#kubernetes-subjectaccessreview-authorizationkubernetessubjectaccessreview">Kubernetes SubjectAccessReview</a></li>
-      <li>Authorization → <a href="../features.md#open-policy-agent-opa-rego-policies-authorizationopa">Open Policy Agent (OPA) Rego policies</a></li>
-      <li>Dynamic response → <a href="../features.md#festival-wristband-tokens-responsesuccessheadersdynamicmetadatawristband">Festival Wristband tokens</a></li>
-      <li>Common feature → <a href="../features.md#common-feature-conditions-when">Conditions</a></li>
-      <li>Common feature → <a href="../features.md#common-feature-priorities">Priorities</a></li>
-    </ul>
-  </summary>
+  <summary>Authorino capabilities featured in this guide</summary>
+
+  - Identity verification & authentication → [Plain](../features.md#plain-authenticationplain)
+  - Identity verification & authentication → [Kubernetes TokenReview](../features.md#kubernetes-tokenreview-authenticationkubernetestokenreview)
+  - Identity verification & authentication → [API key](../features.md#api-key-authenticationapikey)
+  - External auth metadata → [HTTP GET/GET-by-POST](../features.md#http-getget-by-post-metadatahttp)
+  - Authorization → [Kubernetes SubjectAccessReview](../features.md#kubernetes-subjectaccessreview-authorizationkubernetessubjectaccessreview)
+  - Authorization → [Open Policy Agent (OPA) Rego policies](../features.md#open-policy-agent-opa-rego-policies-authorizationopa)
+  - Dynamic response → [Festival Wristband tokens](../features.md#festival-wristband-tokens-responsesuccessheadersdynamicmetadatawristband)
+  - Common feature → [Conditions](../features.md#common-feature-conditions-when)
+  - Common feature → [Priorities](../features.md#common-feature-priorities)
 
   For further details about Authorino features in general, check the [docs](../features.md).
 </details>
-
-<br/>
 
 ## Requirements
 


### PR DESCRIPTION
We've a decent amount of 404'ing content across our docs content.

https://github.com/Kuadrant/docs.kuadrant.io/actions/runs/9807810746/job/27082317585

Some noticed in Authorino's docs have a similar pattern which should be simple/regexable to fix.

Example Broken links: https://docs.kuadrant.io/0.8.0/authorino/docs/user-guides/resource-level-authorization-uma/

External auth metadata → User-Managed Access (UMA) resource registry => 
https://docs.kuadrant.io/0.8.0/authorino/docs/user-guides/features.md#user-managed-access-uma-resource-registry-metadatauma

Should be:

https://docs.kuadrant.io/0.8.0/authorino/docs/features#user-managed-access-uma-resource-registry-metadatauma

With markdown links, the relative link above are resolved and pre-processed before render. HTML is generally passed straight through, untouched, so these relative links end up broken unfortunately. 

This is probably a bit of a PITA to review: sorry!
