### PR TITLE
V1beta2

### DIFF
--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -571,9 +571,9 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 
 	interfacedCallbackConfigs := make([]auth.AuthConfigEvaluator, 0)
 
-	for name, callback := range authConfig.Spec.Callbacks {
+	for callbackName, callback := range authConfig.Spec.Callbacks {
 		translatedCallback := &evaluators.CallbackConfig{
-			Name:       name,
+			Name:       callbackName,
 			Priority:   callback.Priority,
 			Conditions: buildJSONExpression(authConfig, callback.Conditions, jsonexp.All),
 			Metrics:    callback.Metrics,
@@ -606,9 +606,11 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 	}
 
 	// denyWith
-	if denyWith := authConfig.Spec.DenyWith; denyWith != nil {
-		translatedAuthConfig.Unauthenticated = buildAuthorinoDenyWithValues(denyWith.Unauthenticated)
-		translatedAuthConfig.Unauthorized = buildAuthorinoDenyWithValues(denyWith.Unauthorized)
+	if denyWith := authConfig.Spec.Response.Unauthenticated; denyWith != nil {
+		translatedAuthConfig.Unauthenticated = buildAuthorinoDenyWithValues(denyWith)
+	}
+	if denyWith := authConfig.Spec.Response.Unauthorized; denyWith != nil {
+		translatedAuthConfig.Unauthorized = buildAuthorinoDenyWithValues(denyWith)
 	}
 
 	return translatedAuthConfig, nil

--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -22,7 +22,6 @@ import (
 	"sort"
 	"sync"
 
-	old "github.com/kuadrant/authorino/api/v1beta1"
 	api "github.com/kuadrant/authorino/api/v1beta2"
 	"github.com/kuadrant/authorino/pkg/auth"
 	"github.com/kuadrant/authorino/pkg/evaluators"
@@ -202,7 +201,7 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 		if identity.Cache != nil {
 			ttl := identity.Cache.TTL
 			if ttl == 0 {
-				ttl = old.EvaluatorDefaultCacheTTL
+				ttl = api.EvaluatorDefaultCacheTTL
 			}
 			translatedIdentity.Cache = evaluators.NewEvaluatorCache(
 				*getJsonFromStaticDynamic(&identity.Cache.Key),
@@ -296,7 +295,7 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 		if metadata.Cache != nil {
 			ttl := metadata.Cache.TTL
 			if ttl == 0 {
-				ttl = old.EvaluatorDefaultCacheTTL
+				ttl = api.EvaluatorDefaultCacheTTL
 			}
 			translatedMetadata.Cache = evaluators.NewEvaluatorCache(
 				*getJsonFromStaticDynamic(&metadata.Cache.Key),
@@ -365,7 +364,7 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 		if authorization.Cache != nil {
 			ttl := authorization.Cache.TTL
 			if ttl == 0 {
-				ttl = old.EvaluatorDefaultCacheTTL
+				ttl = api.EvaluatorDefaultCacheTTL
 			}
 			translatedAuthorization.Cache = evaluators.NewEvaluatorCache(
 				*getJsonFromStaticDynamic(&authorization.Cache.Key),
@@ -480,7 +479,7 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 		if headerResponse.Cache != nil {
 			ttl := headerResponse.Cache.TTL
 			if ttl == 0 {
-				ttl = old.EvaluatorDefaultCacheTTL
+				ttl = api.EvaluatorDefaultCacheTTL
 			}
 			translatedResponse.Cache = evaluators.NewEvaluatorCache(
 				*getJsonFromStaticDynamic(&headerResponse.Cache.Key),
@@ -503,7 +502,7 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 		if response.Cache != nil {
 			ttl := response.Cache.TTL
 			if ttl == 0 {
-				ttl = old.EvaluatorDefaultCacheTTL
+				ttl = api.EvaluatorDefaultCacheTTL
 			}
 			translatedResponse.Cache = evaluators.NewEvaluatorCache(
 				*getJsonFromStaticDynamic(&response.Cache.Key),
@@ -680,7 +679,7 @@ func (r *AuthConfigReconciler) bootstrapIndex(ctx context.Context) error {
 		return nil
 	}
 
-	authConfigList := old.AuthConfigList{}
+	authConfigList := api.AuthConfigList{}
 	listOptions := []client.ListOption{}
 	if r.LabelSelector != nil {
 		listOptions = append(listOptions, client.MatchingLabelsSelector{Selector: r.LabelSelector})
@@ -735,7 +734,7 @@ func (r *AuthConfigReconciler) ClusterWide() bool {
 
 func (r *AuthConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&old.AuthConfig{}, builder.WithPredicates(LabelSelectorPredicate(r.LabelSelector))).
+		For(&api.AuthConfig{}, builder.WithPredicates(LabelSelectorPredicate(r.LabelSelector))).
 		Complete(r)
 }
 
@@ -746,7 +745,7 @@ func (r *AuthConfigReconciler) Ready(includes, _ []string, _ bool) error {
 
 	for id, status := range r.StatusReport.ReadAll() {
 		switch status.Reason {
-		case old.StatusReasonReconciled:
+		case api.StatusReasonReconciled:
 			continue
 		default:
 			return fmt.Errorf("authconfig is not ready: %s (reason: %s)", id, status.Reason)

--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -22,7 +22,7 @@ import (
 	"sort"
 	"sync"
 
-	api "github.com/kuadrant/authorino/api/v1beta1"
+	api "github.com/kuadrant/authorino/api/v1beta2"
 	"github.com/kuadrant/authorino/pkg/auth"
 	"github.com/kuadrant/authorino/pkg/evaluators"
 	authorization_evaluators "github.com/kuadrant/authorino/pkg/evaluators/authorization"
@@ -163,13 +163,16 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 	interfacedIdentityConfigs := make([]auth.AuthConfigEvaluator, 0)
 	ctxWithLogger = log.IntoContext(ctx, log.FromContext(ctx).WithName("identity"))
 
-	authConfigIdentityConfigs := authConfig.Spec.Identity
+	authConfigIdentityConfigs := authConfig.Spec.Authentication
 
 	if len(authConfigIdentityConfigs) == 0 {
-		authConfigIdentityConfigs = append(authConfigIdentityConfigs, &api.Identity{
-			Name:      "anonymous",
-			Anonymous: &api.Identity_Anonymous{},
-		})
+		authConfigIdentityConfigs["anonymous"] = api.AuthenticationSpec{
+			CommonEvaluatorSpec: api.CommonEvaluatorSpec{},
+			Credentials:         api.Credentials{},
+			AuthenticationMethodSpec: api.AuthenticationMethodSpec{
+				AnonymousAccess: &api.AnonymousAccessSpec{},
+			},
+		}
 	}
 
 	for _, identity := range authConfigIdentityConfigs {

--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -451,8 +451,8 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 				SharedSecret: sharedSecret,
 				Permission:   *getJsonFromStaticDynamic(&authzed.Permission),
 			}
-			translatedAuthzed.Subject, translatedAuthzed.SubjectKind = authzedObjectToJsonValues(authzed.Subject)
-			translatedAuthzed.Resource, translatedAuthzed.ResourceKind = authzedObjectToJsonValues(authzed.Resource)
+			translatedAuthzed.Subject, translatedAuthzed.SubjectKind = spiceDBObjectToJsonValues(authzed.Subject)
+			translatedAuthzed.Resource, translatedAuthzed.ResourceKind = spiceDBObjectToJsonValues(authzed.Resource)
 
 			translatedAuthorization.Authzed = translatedAuthzed
 
@@ -860,14 +860,14 @@ func buildJSONExpressionPattern(expression api.PatternExpression) jsonexp.Expres
 	}
 }
 
-func buildAuthorinoDenyWithValues(denyWithSpec *old.DenyWithSpec) *evaluators.DenyWithValues {
+func buildAuthorinoDenyWithValues(denyWithSpec *api.DenyWithSpec) *evaluators.DenyWithValues {
 	if denyWithSpec == nil {
 		return nil
 	}
 
 	headers := make([]json.JSONProperty, 0, len(denyWithSpec.Headers))
-	for _, header := range denyWithSpec.Headers {
-		headers = append(headers, json.JSONProperty{Name: header.Name, Value: json.JSONValue{Static: header.Value, Pattern: header.ValueFrom.AuthJSON}})
+	for name, header := range denyWithSpec.Headers {
+		headers = append(headers, json.JSONProperty{Name: name, Value: json.JSONValue{Static: header.Value, Pattern: header.Selector}})
 	}
 
 	return &evaluators.DenyWithValues{
@@ -889,7 +889,7 @@ func getJsonFromStaticDynamic(value *api.ValueOrSelector) *json.JSONValue {
 	}
 }
 
-func authzedObjectToJsonValues(obj *old.AuthzedObject) (name json.JSONValue, kind json.JSONValue) {
+func spiceDBObjectToJsonValues(obj *api.SpiceDBObject) (name json.JSONValue, kind json.JSONValue) {
 	if obj == nil {
 		return
 	}

--- a/controllers/auth_config_controller_test.go
+++ b/controllers/auth_config_controller_test.go
@@ -170,7 +170,7 @@ func TestReconcileAuthConfigOk(t *testing.T) {
 	config := authConfigIndex.Get("echo-api")
 	assert.Check(t, config != nil)
 	idConfig, _ := config.IdentityConfigs[0].(*evaluators.IdentityConfig)
-	assert.Equal(t, idConfig.ExtendedProperties[0].Name, "source")
+	assert.Equal(t, idConfig.ExtendedProperties[1].Name, "source")
 	// TODO(@guicassolato): assert other fields of the AuthConfig
 }
 
@@ -390,6 +390,10 @@ func TestBootstrapIndex(t *testing.T) {
 	indexMock := mock_index.NewMockIndex(mockController)
 
 	authConfig := newTestAuthConfig(map[string]string{"scope": "in"})
+	expectedNumResponseItems := 0
+	if authConfig.Spec.Response != nil {
+		expectedNumResponseItems = len(authConfig.Spec.Response.Success.DynamicMetadata) + len(authConfig.Spec.Response.Success.Headers)
+	}
 	authConfig.Status.Summary = api.AuthConfigStatusSummary{
 		Ready:                    true,
 		HostsReady:               authConfig.Spec.Hosts,
@@ -397,7 +401,7 @@ func TestBootstrapIndex(t *testing.T) {
 		NumIdentitySources:       int64(len(authConfig.Spec.Authentication)),
 		NumMetadataSources:       int64(len(authConfig.Spec.Metadata)),
 		NumAuthorizationPolicies: int64(len(authConfig.Spec.Authorization)),
-		NumResponseItems:         int64(len(authConfig.Spec.Response.Success.DynamicMetadata) + len(authConfig.Spec.Response.Success.Headers)),
+		NumResponseItems:         int64(expectedNumResponseItems),
 		FestivalWristbandEnabled: false,
 	}
 
@@ -409,7 +413,7 @@ func TestBootstrapIndex(t *testing.T) {
 		NumIdentitySources:       int64(len(authConfig.Spec.Authentication)),
 		NumMetadataSources:       int64(len(authConfig.Spec.Metadata)),
 		NumAuthorizationPolicies: int64(len(authConfig.Spec.Authorization)),
-		NumResponseItems:         int64(len(authConfig.Spec.Response.Success.DynamicMetadata) + len(authConfig.Spec.Response.Success.Headers)),
+		NumResponseItems:         int64(expectedNumResponseItems),
 		FestivalWristbandEnabled: false,
 	}
 

--- a/controllers/auth_config_status_updater.go
+++ b/controllers/auth_config_status_updater.go
@@ -218,6 +218,11 @@ func updateStatusSummary(authConfig *api.AuthConfig, newLinkedHosts []string) (c
 
 func issuingWristbands(authConfig *api.AuthConfig) bool {
 	if authConfig.Spec.Response != nil {
+		for _, responseConfig := range authConfig.Spec.Response.Success.Headers {
+			if responseConfig.GetMethod() == api.WristbandAuthResponse {
+				return true
+			}
+		}
 		for _, responseConfig := range authConfig.Spec.Response.Success.DynamicMetadata {
 			if responseConfig.GetMethod() == api.WristbandAuthResponse {
 				return true

--- a/controllers/auth_config_status_updater.go
+++ b/controllers/auth_config_status_updater.go
@@ -181,6 +181,10 @@ func updateStatusSummary(authConfig *api.AuthConfig, newLinkedHosts []string) (c
 		newLinkedHosts = []string{}
 	}
 
+	numResponseItems := 0
+	if authConfig.Spec.Response != nil {
+		numResponseItems = len(authConfig.Spec.Response.Success.DynamicMetadata) + len(authConfig.Spec.Response.Success.Headers)
+	}
 	new := api.AuthConfigStatusSummary{
 		Ready:                    authConfig.Status.Ready(),
 		HostsReady:               newLinkedHosts,
@@ -188,7 +192,7 @@ func updateStatusSummary(authConfig *api.AuthConfig, newLinkedHosts []string) (c
 		NumIdentitySources:       int64(len(authConfig.Spec.Authentication)),
 		NumMetadataSources:       int64(len(authConfig.Spec.Metadata)),
 		NumAuthorizationPolicies: int64(len(authConfig.Spec.Authorization)),
-		NumResponseItems:         int64(len(authConfig.Spec.Response.Success.DynamicMetadata) + len(authConfig.Spec.Response.Success.Headers)),
+		NumResponseItems:         int64(numResponseItems),
 		FestivalWristbandEnabled: issuingWristbands(authConfig),
 	}
 
@@ -213,9 +217,11 @@ func updateStatusSummary(authConfig *api.AuthConfig, newLinkedHosts []string) (c
 }
 
 func issuingWristbands(authConfig *api.AuthConfig) bool {
-	for _, responseConfig := range authConfig.Spec.Response.Success.DynamicMetadata {
-		if responseConfig.GetMethod() == api.WristbandAuthResponse {
-			return true
+	if authConfig.Spec.Response != nil {
+		for _, responseConfig := range authConfig.Spec.Response.Success.DynamicMetadata {
+			if responseConfig.GetMethod() == api.WristbandAuthResponse {
+				return true
+			}
 		}
 	}
 	return false

--- a/controllers/auth_config_status_updater.go
+++ b/controllers/auth_config_status_updater.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	api "github.com/kuadrant/authorino/api/v1beta1"
+	api "github.com/kuadrant/authorino/api/v1beta2"
 	"github.com/kuadrant/authorino/pkg/log"
 	"github.com/kuadrant/authorino/pkg/utils"
 
@@ -105,11 +105,11 @@ func (u *AuthConfigStatusUpdater) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(u)
 }
 
-func updateStatusConditions(currentConditions []api.Condition, newCondition api.Condition) ([]api.Condition, bool) {
+func updateStatusConditions(currentConditions []api.AuthConfigStatusCondition, newCondition api.AuthConfigStatusCondition) ([]api.AuthConfigStatusCondition, bool) {
 	newCondition.LastTransitionTime = metav1.Now()
 
 	if currentConditions == nil {
-		return []api.Condition{newCondition}, true
+		return []api.AuthConfigStatusCondition{newCondition}, true
 	}
 
 	for i, condition := range currentConditions {
@@ -122,7 +122,7 @@ func updateStatusConditions(currentConditions []api.Condition, newCondition api.
 				newCondition.LastTransitionTime = condition.LastTransitionTime
 			}
 
-			res := make([]api.Condition, len(currentConditions))
+			res := make([]api.AuthConfigStatusCondition, len(currentConditions))
 			copy(res, currentConditions)
 			res[i] = newCondition
 			return res, true
@@ -143,7 +143,7 @@ func updateStatusAvailable(authConfig *api.AuthConfig, available bool) (changed 
 		message = ""
 	}
 
-	authConfig.Status.Conditions, changed = updateStatusConditions(authConfig.Status.Conditions, api.Condition{
+	authConfig.Status.Conditions, changed = updateStatusConditions(authConfig.Status.Conditions, api.AuthConfigStatusCondition{
 		Type:    api.StatusConditionAvailable,
 		Status:  status,
 		Reason:  reason,
@@ -164,7 +164,7 @@ func updateStatusReady(authConfig *api.AuthConfig, ready bool, reason, message s
 		reason = api.StatusReasonUnknown
 	}
 
-	authConfig.Status.Conditions, changed = updateStatusConditions(authConfig.Status.Conditions, api.Condition{
+	authConfig.Status.Conditions, changed = updateStatusConditions(authConfig.Status.Conditions, api.AuthConfigStatusCondition{
 		Type:    api.StatusConditionReady,
 		Status:  status,
 		Reason:  reason,
@@ -181,14 +181,14 @@ func updateStatusSummary(authConfig *api.AuthConfig, newLinkedHosts []string) (c
 		newLinkedHosts = []string{}
 	}
 
-	new := api.Summary{
+	new := api.AuthConfigStatusSummary{
 		Ready:                    authConfig.Status.Ready(),
 		HostsReady:               newLinkedHosts,
 		NumHostsReady:            fmt.Sprintf("%d/%d", len(newLinkedHosts), len(authConfig.Spec.Hosts)),
-		NumIdentitySources:       int64(len(authConfig.Spec.Identity)),
+		NumIdentitySources:       int64(len(authConfig.Spec.Authentication)),
 		NumMetadataSources:       int64(len(authConfig.Spec.Metadata)),
 		NumAuthorizationPolicies: int64(len(authConfig.Spec.Authorization)),
-		NumResponseItems:         int64(len(authConfig.Spec.Response)),
+		NumResponseItems:         int64(len(authConfig.Spec.Response.Success.DynamicMetadata) + len(authConfig.Spec.Response.Success.Headers)),
 		FestivalWristbandEnabled: issuingWristbands(authConfig),
 	}
 
@@ -213,8 +213,8 @@ func updateStatusSummary(authConfig *api.AuthConfig, newLinkedHosts []string) (c
 }
 
 func issuingWristbands(authConfig *api.AuthConfig) bool {
-	for _, responseConfig := range authConfig.Spec.Response {
-		if responseConfig.GetType() == api.ResponseWristband {
+	for _, responseConfig := range authConfig.Spec.Response.Success.DynamicMetadata {
+		if responseConfig.GetMethod() == api.WristbandAuthResponse {
 			return true
 		}
 	}

--- a/controllers/auth_config_status_updater_test.go
+++ b/controllers/auth_config_status_updater_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	api "github.com/kuadrant/authorino/api/v1beta1"
+	api "github.com/kuadrant/authorino/api/v1beta2"
 	"github.com/kuadrant/authorino/pkg/log"
 
 	"github.com/golang/mock/gomock"
@@ -176,7 +176,7 @@ func mockStatusUpdateAuthConfigWithLabelsAndHosts(labels map[string]string, host
 	return api.AuthConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AuthConfig",
-			APIVersion: "authorino.kuadrant.io/v1beta1",
+			APIVersion: "authorino.kuadrant.io/v1beta2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "auth-config-1",


### PR DESCRIPTION
This should get us rid off all `v1beta1` usages in the code base (other than conversion obviously)
Fixes #484 