### PR TITLE
fixup: use v1beta3 for smoke tests

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Run e2e tests
         env:
           NAMESPACE: authorino
-          AUTHCONFIG: https://raw.githubusercontent.com/Kuadrant/authorino/main/tests/v1beta2/authconfig.yaml
-          AUTHCONFIG_INVALID: https://raw.githubusercontent.com/Kuadrant/authorino/main/tests/v1beta2/authconfig-invalid.yaml
+          AUTHCONFIG: https://raw.githubusercontent.com/Kuadrant/authorino/main/tests/v1beta3/authconfig.yaml
+          AUTHCONFIG_INVALID: https://raw.githubusercontent.com/Kuadrant/authorino/main/tests/v1beta3/authconfig-invalid.yaml
         run: |
           curl -sSL https://raw.githubusercontent.com/Kuadrant/authorino/main/tests/e2e-test.sh | bash


### PR DESCRIPTION
# Description
Related  https://github.com/Kuadrant/authorino-operator/pull/218

Missed updating to use v1beta3 of AuthConfig in smoke tests in the initial introduction of v1beta3 in https://github.com/Kuadrant/authorino/pull/493