### PR TITLE
fix: RawExtension to string conversion

### DIFF
--- a/pkg/evaluators/authorization/authzed.go
+++ b/pkg/evaluators/authorization/authzed.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kuadrant/authorino/pkg/auth"
 	"github.com/kuadrant/authorino/pkg/expressions"
+	"github.com/kuadrant/authorino/pkg/json"
 	"google.golang.org/grpc"
 	insecuregrpc "google.golang.org/grpc/credentials/insecure"
 
@@ -60,10 +61,11 @@ func (a *Authzed) Call(pipeline auth.AuthPipeline, ctx gocontext.Context) (inter
 	if err != nil {
 		return nil, err
 	}
+	permissionStr, err := json.StringifyJSON(permission)
 	resp, err := client.CheckPermission(ctx, &authzedpb.CheckPermissionRequest{
 		Resource:   resource,
 		Subject:    &authzedpb.SubjectReference{Object: object},
-		Permission: fmt.Sprintf("%s", permission),
+		Permission: permissionStr,
 	})
 	if err != nil {
 		return nil, err
@@ -91,12 +93,20 @@ func authzedObjectFor(name, kind expressions.Value, authJSON string) (*authzedpb
 	if err != nil {
 		return nil, err
 	}
+	objectIdStr, err := json.StringifyJSON(objectId)
+	if err != nil {
+		return nil, err
+	}
 	objectType, err := kind.ResolveFor(authJSON)
 	if err != nil {
 		return nil, err
 	}
+	objectTypeStr, err := json.StringifyJSON(objectType)
+	if err != nil {
+		return nil, err
+	}
 	return &authzedpb.ObjectReference{
-		ObjectId:   fmt.Sprintf("%s", objectId),
-		ObjectType: fmt.Sprintf("%s", objectType),
+		ObjectId:   objectIdStr,
+		ObjectType: objectTypeStr,
 	}, nil
 }

--- a/pkg/evaluators/authorization/authzed.go
+++ b/pkg/evaluators/authorization/authzed.go
@@ -62,6 +62,9 @@ func (a *Authzed) Call(pipeline auth.AuthPipeline, ctx gocontext.Context) (inter
 		return nil, err
 	}
 	permissionStr, err := json.StringifyJSON(permission)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := client.CheckPermission(ctx, &authzedpb.CheckPermissionRequest{
 		Resource:   resource,
 		Subject:    &authzedpb.SubjectReference{Object: object},

--- a/pkg/evaluators/authorization/kubernetes_authz.go
+++ b/pkg/evaluators/authorization/kubernetes_authz.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kuadrant/authorino/pkg/auth"
 	"github.com/kuadrant/authorino/pkg/context"
 	"github.com/kuadrant/authorino/pkg/expressions"
+	"github.com/kuadrant/authorino/pkg/json"
 	"github.com/kuadrant/authorino/pkg/log"
 
 	kubeAuthz "k8s.io/api/authorization/v1"
@@ -71,7 +72,7 @@ func (k *KubernetesAuthz) Call(pipeline auth.AuthPipeline, ctx gocontext.Context
 		if err != nil {
 			return "", err
 		}
-		return fmt.Sprintf("%s", resolved), nil
+		return json.StringifyJSON(resolved)
 	}
 
 	user, err := jsonValueToStr(k.User)

--- a/pkg/evaluators/metadata/generic_http.go
+++ b/pkg/evaluators/metadata/generic_http.go
@@ -142,7 +142,11 @@ func (h *GenericHttp) buildRequest(ctx gocontext.Context, endpoint, authJSON str
 		if err != nil {
 			return nil, err
 		}
-		req.Header.Set(header.Name, fmt.Sprintf("%s", headerValue))
+		headerValueStr, err := json.StringifyJSON(headerValue)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set(header.Name, headerValueStr)
 	}
 
 	req.Header.Set("Content-Type", contentType)

--- a/pkg/json/json.go
+++ b/pkg/json/json.go
@@ -157,6 +157,10 @@ func ReplaceJSONPlaceholders(source string, jsonData string) string {
 }
 
 func StringifyJSON(data interface{}) (string, error) {
+	_, ok := data.(string)
+	if ok {
+		return data.(string), nil
+	}
 	if dataAsJSON, err := json.Marshal(data); err != nil {
 		return "", err
 	} else {


### PR DESCRIPTION
Fixes conversion of `ValueOrSelector.Value` (based on [`runtime.RawExtension`](https://pkg.go.dev/k8s.io/apimachinery@v0.28.3/pkg/runtime#RawExtension)) to string, used at the following configs:
- SubjectAccessReview authorization
- External HTTP requests (metadata, external Rego policies, etc)
- SpiceDB check permissions

This bug was introduced in [v0.18.0](https://github.com/Kuadrant/authorino/releases/tag/v0.18.0), when the AuthConfig controller was updated to work with `v1beta2` type (previously (`v1beta1`), thus activating the option to set static values to JSON/YAML types other than strings. The conversion functions used in the features listed above were overlooked in the process and remain naively treating static values (stored in Golang `interface{}` variables) as if they were always strings.

## Verification steps

```sh
make local-setup FF=1
```

```sh
kubectl port-forward deployment/envoy 8000:8000 2>&1 >/dev/null &
```

```sh
kubectl apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta3
kind: AuthConfig
metadata:
  name: talker-api-protection
spec:
  hosts:
  - talker-api.127.0.0.1.nip.io
  authorization:
    "sar":
      kubernetesSubjectAccessReview:
        user:
          value: john
        resourceAttributes:
          resource:
            value: secrets
          name:
            selector: request.path.@extract:{"sep":"/","pos":1}
          verb:
            expression: request.method
  response:
    unauthorized:
      message:
        value: Access denied by the Kubernetes RBAC
EOF
```

```sh
curl http://talker-api.127.0.0.1.nip.io:8000/my-secret -i
```

Check the Authorino logs. You should spot en entry like the following:

```sj
{
  "level": "debug",
  "ts": "2024-11-04T11:06:44Z",
  "logger": "authorino.service.auth.authpipeline.authorization.kubernetesauthz",
  "msg": "calling kubernetes subject access review api",
  "request id": "b6471552-9154-41fb-87e4-843f5db9255a",
  "subjectaccessreview": {
    "metadata": {
      "creationTimestamp": null
    },
    "spec": {
      "resourceAttributes": {
        "verb": "GET",
        "resource": "secrets",
        "name": "my-secret"
      },
      "user": "john"
    },
    "status": {
      "allowed": false
    }
  }
}
```

Before the fix, attributes such as `subjectaccessreview.spec.user` were being stringified as `"{\"john\" <nil>}"`, which is the direct print out of the `RawExtension` type in Golang as string.