### PR TITLE
Google proto timestamps support

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -80,7 +80,7 @@ Similar to [JSON Paths](#common-feature-json-paths-selector), Authorino supports
 
 [String extension functions](https://pkg.go.dev/github.com/google/cel-go/ext#readme-strings), such as `split`, `substring`, `indexOf`, etc, are also supported.
 
-Use the `expression` field for selecting values from the [Authorization JSON](./architecture.md#the-authorization-json). The type of the selected value will be converted to a JSON-compatible equivalent. Complex types without a direct JSON equivalent may be converted to objects (e.g. `google.golang.org/protobuf/types/known/timestamppb.Timestamp` gets converted to `{ "seconds": Number, "nanos": Number }`)
+Use the `expression` field for selecting values from the [Authorization JSON](./architecture.md#the-authorization-json). The type of the selected value will be converted to a JSON-compatible equivalent. Complex types without a direct JSON equivalent may be converted to the raw abstract objects used to represent the type. JSON objects that match [`google.golang.org/protobuf/types/known/timestamppb.Timestamp`](https://pkg.go.dev/google.golang.org/protobuf/types/known/timestamppb#Timestamp) type (i.e. `{ "seconds": Number, "nanos": Number }`) are converted to their corresponding timestamp string representation in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) format.
 
 The most common applications of `expression` are for building dynamic URLs and request parameters when fetching metadata from external sources, extending properties of identity objects, and dynamic authorization response attributes (e.g. injected HTTP headers, etc).
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/open-policy-agent/opa v0.68.0
 	github.com/prometheus/client_golang v1.20.2
+	github.com/samber/lo v1.47.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/tidwall/gjson v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -483,6 +483,8 @@ github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/samber/lo v1.47.0 h1:z7RynLwP5nbyRscyvcD043DWYoOcYRv3mV8lBeqOCLc=
+github.com/samber/lo v1.47.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/pkg/expressions/cel/expressions.go
+++ b/pkg/expressions/cel/expressions.go
@@ -14,6 +14,8 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	authorinojson "github.com/kuadrant/authorino/pkg/json"
 )
 
 const RootMetadataBinding = "metadata"
@@ -80,7 +82,7 @@ func (e *Expression) ResolveFor(json string) (interface{}, error) {
 	if jsonLiteral, err := ValueToJSON(result); err != nil {
 		return nil, err
 	} else {
-		return gjson.Parse(jsonLiteral).Value(), nil
+		return authorinojson.TryTimestamp(gjson.Parse(jsonLiteral)), nil
 	}
 }
 

--- a/pkg/expressions/cel/expressions_test.go
+++ b/pkg/expressions/cel/expressions_test.go
@@ -3,10 +3,11 @@ package cel
 import (
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	mock_auth "github.com/kuadrant/authorino/pkg/auth/mocks"
 	"gotest.tools/assert"
 
-	"github.com/golang/mock/gomock"
+	authorinojson "github.com/kuadrant/authorino/pkg/json"
 )
 
 func TestPredicate(t *testing.T) {
@@ -47,4 +48,23 @@ func TestPredicate(t *testing.T) {
 	response, err = predicate.Matches("{}")
 	assert.NilError(t, err)
 	assert.Equal(t, response, true)
+}
+
+func TestTimestamp(t *testing.T) {
+	expression, _ := NewExpression(`request.time`)
+
+	val, err := expression.ResolveFor(`{"request":{"time":{"seconds":1732721739,"nanos":123456}}}`)
+	s, _ := authorinojson.StringifyJSON(val)
+	assert.NilError(t, err)
+	assert.Equal(t, s, "2024-11-27T15:35:39.000123456Z")
+
+	val, err = expression.ResolveFor(`{"request":{"time":"2024-11-27T15:35:39Z"}}`)
+	s, _ = authorinojson.StringifyJSON(val)
+	assert.NilError(t, err)
+	assert.Equal(t, s, "2024-11-27T15:35:39Z")
+
+	val, err = expression.ResolveFor(`{"request":{"time":{"custom":"11 Nov 2024 03:35:39pm UTC"}}}`)
+	s, _ = authorinojson.StringifyJSON(val)
+	assert.NilError(t, err)
+	assert.Equal(t, s, `{"custom":"11 Nov 2024 03:35:39pm UTC"}`)
 }

--- a/pkg/json/json_test.go
+++ b/pkg/json/json_test.go
@@ -346,3 +346,21 @@ func TestStringifyJSON(t *testing.T) {
 	assert.Equal(t, str, `{"prop_str":"str","prop_num":123,"prop_bool":false,"prop_null":null,"prop_arr":["a","b","c"],"prop_obj":{"a_prop":"a_value"}}`)
 	assert.NilError(t, err)
 }
+
+func TestTryTimestamp(t *testing.T) {
+	val := TryTimestamp(gjson.Parse(`{"seconds":1732721739}`))
+	s, _ := StringifyJSON(val)
+	assert.Equal(t, s, "2024-11-27T15:35:39Z")
+
+	val = TryTimestamp(gjson.Parse(`{"seconds":1732721739,"nanos":123456}`))
+	s, _ = StringifyJSON(val)
+	assert.Equal(t, s, "2024-11-27T15:35:39.000123456Z")
+
+	val = TryTimestamp(gjson.Parse(`"2024-11-27T15:35:39Z"`))
+	s, _ = StringifyJSON(val)
+	assert.Equal(t, s, "2024-11-27T15:35:39Z")
+
+	val = TryTimestamp(gjson.Parse(`{"foo":"bar"}`))
+	s, _ = StringifyJSON(val)
+	assert.Equal(t, s, `{"foo":"bar"}`)
+}


### PR DESCRIPTION
Adds support for selecting values that match [`google.golang.org/protobuf/types/known/timestamppb.Timestamp`](https://pkg.go.dev/google.golang.org/protobuf/types/known/timestamppb#Timestamp) type (i.e. `{ "seconds": Number, "nanos": Number }`) from the Authorization JSON. The source values are converted to their corresponding timestamp string representation in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) format.

**_Breaking change:_**<br/>
Users that previously trusted on selectors/CEL expressions such as `request.time` to resolve to `{ "seconds": Number, "nanos": Number }` shall now expect RFC3339 instead.

Users can still dig into the details of a timestamp value in the middle of an expression or for extracting only one of the parts of the timestamp (e.g. `request.time.seconds`). However, RFC3339 will be used whenever extracting a value known to be a perfect representation of a timestamp in Google's protobuf format, for example, when building dynamic URLs and request parameters for fetching metadata from external sources, when extending properties of identity objects, and dynamic authorization response attributes (e.g. injected HTTP headers, etc) from these values.

Although `google.golang.org/protobuf/types/known/timestamppb.Timestamp` declares both `seconds` and `nanos` as optional. For the conversion to RFC3339 to trigger, at least one of these properties must be present in the source value, and no other property other than these two.