### PR TITLE
kustomize: use patches instead of patchesJson6902

### DIFF
--- a/install/crd/kustomization.yaml
+++ b/install/crd/kustomization.yaml
@@ -9,10 +9,10 @@ resources:
 #- patches/webhook_in_authconfigs.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
-patchesJson6902:
+patches:
 - path: patches/oneof_in_authconfigs.yaml
   target:
     group: apiextensions.k8s.io
-    version: v1
     kind: CustomResourceDefinition
     name: authconfigs.authorino.kuadrant.io
+    version: v1


### PR DESCRIPTION
# Description
Kustomize `patchesJson6902` is deprecated in favour of `patches` as runnng `make manifests` previously had the following warning:

<img width="1162" alt="image" src="https://github.com/user-attachments/assets/ed8fd24a-2ef4-4125-870d-1902f857b971" />

# Verification
* Passing CI jobs
* Running `make manifests` should no longer display the above warning