### PR TITLE
Upgrade Go version to 1.22

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -40,10 +40,10 @@ jobs:
           importpath: golang.org/x/tools/cmd/goimports@latest
 
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
 
       - name: Check out code
@@ -88,10 +88,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
 
       - name: Check out code

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -13,7 +13,7 @@ jobs:
     name: End-to-end Tests
     strategy:
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.22.x]
         platform: [ubuntu-latest]
         authconfig_version: [v1beta2, v1beta3]
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.22.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     defaults:

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Smoke Tests
     strategy:
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.22.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     if: ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build the authorino binary
 # https://catalog.redhat.com/software/containers/ubi9/go-toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22 AS builder
 USER root
 WORKDIR /usr/src/authorino
 COPY ./ ./

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,7 +4,7 @@
 
 Minimum requirements to contribute to Authorino are:
 
-- [Golang v1.21+](https://golang.org)
+- [Golang v1.22+](https://golang.org)
 - [Docker](https://docker.com)
 
 Authorino's code was originally bundled using the [Operator SDK](https://sdk.operatorframework.io/) (v1.9.0).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino
 
-go 1.21
+go 1.22
 
 require (
 	github.com/authzed/authzed-go v0.7.0


### PR DESCRIPTION
This also fixes [CVE-2025-22866](https://access.redhat.com/security/cve/CVE-2025-22866) (ppc64le arch)