### PR TITLE
docs: move using kuadrant from guides into readme for guides

### DIFF
--- a/docs/user-guides/README.md
+++ b/docs/user-guides/README.md
@@ -15,13 +15,19 @@ to define authentication and authorization rules directly in their network polic
 Rather than defining `AuthConfig` resources directly, users can define an `AuthPolicy`, and Kuadrant will automatically
 generate the corresponding `AuthConfig` for Authorino to consume.
 
-Key details about `AuthPolicy` as an `AuthConfig` Consumer:
+### Key Details About `AuthPolicy` as an `AuthConfig` Consumer
 
 - **Same Specification**: The spec schema of `AuthPolicy` is effectively the same as `AuthConfig`.
 - **Automatic Hostname Handling**: Unlike `AuthConfig`, `AuthPolicy` does not explicitly define `spec.host`. Instead, hostnames are
 inferred from the Kubernetes network object in `spec.targetRef` and the route selectors in the policy.
 - **Authorino Integration**: Kuadrant translates `AuthPolicy` into an `AuthConfig`, which is then processed by Authorino to enforce
 authentication and authorization.
+
+### Authorino Features Not Available via Kuadrant
+Some Authorino-specific features may not be available when using Authorino through Kuadrant:
+
+- [Sharding](./sharding.md)
+- [Host Override via Context Extension](./host-override.md)
 
 For more details on enforcing authentication and authorization with Kuadrant, see the
 [Kuadrant Auth documentation](https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth/).

--- a/docs/user-guides/README.md
+++ b/docs/user-guides/README.md
@@ -1,0 +1,27 @@
+# AuthConfig Consumers
+Authorino's `AuthConfig` is a custom resource that defines authentication and authorization policies. Many tools and frameworks act
+as consumers of `AuthConfig` by automatically generating and managing these resources on behalf of users. Since these consumers
+follow the same specification, the general concepts and steps outlined in the user guides are applicable.
+However, some details—such as resource names and specific API fields—may differ based on the consuming framework.
+
+This section provides guidance for users working with tools that act as consumers of `AuthConfig`, allowing them to leverage the
+same principles outlined in the user guides, regardless of the framework they are using.
+
+## Kuadrant
+[Kuadrant](https://kuadrant.io/) provides API security and access control capabilities through its own custom resource: `AuthPolicy`.
+`AuthPolicy` is designed specifically for use with the Kubernetes [Gateway API](https://gateway-api.sigs.k8s.io/), allowing users
+to define authentication and authorization rules directly in their network policy configurations.
+
+Rather than defining `AuthConfig` resources directly, users can define an `AuthPolicy`, and Kuadrant will automatically
+generate the corresponding `AuthConfig` for Authorino to consume.
+
+Key details about `AuthPolicy` as an `AuthConfig` Consumer:
+
+- **Same Specification**: The spec schema of `AuthPolicy` is effectively the same as `AuthConfig`.
+- **Automatic Hostname Handling**: Unlike `AuthConfig`, `AuthPolicy` does not explicitly define `spec.host`. Instead, hostnames are
+inferred from the Kubernetes network object in `spec.targetRef` and the route selectors in the policy.
+- **Authorino Integration**: Kuadrant translates `AuthPolicy` into an `AuthConfig`, which is then processed by Authorino to enforce
+authentication and authorization.
+
+For more details on enforcing authentication and authorization with Kuadrant, see the
+[Kuadrant Auth documentation](https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth/).

--- a/docs/user-guides/anonymous-access.md
+++ b/docs/user-guides/anonymous-access.md
@@ -29,23 +29,6 @@ kind create cluster --name authorino-tutorial
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/anonymous-access.md
+++ b/docs/user-guides/anonymous-access.md
@@ -91,18 +91,6 @@ kubectl port-forward deployment/envoy 8000:8000 2>&1 >/dev/null &
 
 Create an Authorino `AuthConfig` custom resource declaring the auth rules to be enforced:
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/api-key-authentication.md
+++ b/docs/user-guides/api-key-authentication.md
@@ -33,23 +33,6 @@ kind create cluster --name authorino-tutorial
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/api-key-authentication.md
+++ b/docs/user-guides/api-key-authentication.md
@@ -95,18 +95,6 @@ kubectl port-forward deployment/envoy 8000:8000 2>&1 >/dev/null &
 
 Create an Authorino `AuthConfig` custom resource declaring the auth rules to be enforced:
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
+++ b/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
@@ -35,23 +35,6 @@ kind create cluster --name authorino-tutorial
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❻.</p>
-        <p>At step ❻, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
+++ b/docs/user-guides/authenticated-rate-limiting-envoy-dynamic-metadata.md
@@ -109,18 +109,6 @@ Create an Authorino `AuthConfig` custom resource declaring the auth rules to be 
 
 An annotation `auth-data/username` will be read from the Kubernetes API Key secret and passed as dynamic metadata `{ "ext_auth_data": { "username": «annotations.auth-data/username» } }`.
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/authzed.md
+++ b/docs/user-guides/authzed.md
@@ -28,23 +28,6 @@ kind create cluster --name authorino-tutorial
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❻.</p>
-        <p>At step ❻, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/authzed.md
+++ b/docs/user-guides/authzed.md
@@ -215,18 +215,6 @@ EOF
 
 Create an Authorino `AuthConfig` custom resource declaring the auth rules to be enforced.
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 Store the shared token for Authorino to authenticate with the SpiceDB instance in a Service:
 
 ```sh

--- a/docs/user-guides/caching.md
+++ b/docs/user-guides/caching.md
@@ -47,23 +47,6 @@ kind create cluster --name authorino-tutorial
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/caching.md
+++ b/docs/user-guides/caching.md
@@ -117,18 +117,6 @@ In both cases, the path of the HTTP request is used as cache key. I.e., whenever
 
 The cached values will be visible in the response returned by the Talker API in `x-authz-data` header injected by Authorino. This way, we can tell when an existing value in the cache was used and when a new one was generated and stored.
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/deny-with-redirect-to-login.md
+++ b/docs/user-guides/deny-with-redirect-to-login.md
@@ -35,23 +35,6 @@ kind create cluster --name authorino-tutorial
 
 The next steps walk you through installing Authorino, deploying and configuring a sample web application called **Matrix Quotes** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/deny-with-redirect-to-login.md
+++ b/docs/user-guides/deny-with-redirect-to-login.md
@@ -97,18 +97,6 @@ kubectl port-forward deployment/envoy 8000:8000 2>&1 >/dev/null &
 
 Create an Authorino `AuthConfig` custom resource declaring the auth rules to be enforced:
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/edge-authentication-architecture-festival-wristbands.md
+++ b/docs/user-guides/edge-authentication-architecture-festival-wristbands.md
@@ -142,18 +142,6 @@ EOF
 
 Create the config:
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl -n edge apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3
@@ -223,18 +211,6 @@ kubectl -n internal port-forward deployment/envoy 8000:8000 2>&1 >/dev/null &
 ```
 
 ### Create the `AuthConfig`
-
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
 
 ```sh
 kubectl -n internal apply -f -<<EOF

--- a/docs/user-guides/edge-authentication-architecture-festival-wristbands.md
+++ b/docs/user-guides/edge-authentication-architecture-festival-wristbands.md
@@ -56,23 +56,6 @@ The next steps walk you through installing Authorino and configuring 2 environme
 
 The first environment is a facade for handling the first layer of authentication and exchanging any valid presented authentication token for a Festival Wristband token. In the second, we will deploy a sample service called **Talker API** that the authorization service will ensure to receive only authenticated traffic presented with a valid Festival Wristband.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❹.</p>
-        <p>At steps ❹ and ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/envoy-jwt-authn-and-authorino.md
+++ b/docs/user-guides/envoy-jwt-authn-and-authorino.md
@@ -47,23 +47,6 @@ kubectl -n keycloak apply -f https://raw.githubusercontent.com/kuadrant/authorin
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❻.</p>
-        <p>At step ❻, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/envoy-jwt-authn-and-authorino.md
+++ b/docs/user-guides/envoy-jwt-authn-and-authorino.md
@@ -310,18 +310,6 @@ kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-examples/m
 
 Create an Authorino `AuthConfig` custom resource declaring the auth rules to be enforced:
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/external-metadata.md
+++ b/docs/user-guides/external-metadata.md
@@ -37,23 +37,6 @@ kind create cluster --name authorino-tutorial
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/external-metadata.md
+++ b/docs/user-guides/external-metadata.md
@@ -103,18 +103,6 @@ In this example, we will implement a geofence policy for the API, using OPA and 
 
 The implementation relies on the [`X-Forwarded-For`](https://datatracker.ietf.org/doc/html/rfc7239) HTTP header to read the client's IP address.
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/hello-world.md
+++ b/docs/user-guides/hello-world.md
@@ -12,23 +12,6 @@ kind create cluster --name authorino-tutorial
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a>, you can skip step ❸. You may already have Authorino installed and running as well. In this case, skip also step ❺. If you even have your workload cluster configured, with sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, go straight to step ❼.</p>
-        <p>At step ❼, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ## ❶ Create the namespace
 
 ```sh

--- a/docs/user-guides/hello-world.md
+++ b/docs/user-guides/hello-world.md
@@ -91,18 +91,6 @@ Authorino does not know about the `talker-api.127.0.0.1.nip.io` host, hence the 
 
 Create an Authorino `AuthConfig` custom resource declaring the auth rules to be enforced:
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl -n hello-world apply -f https://raw.githubusercontent.com/kuadrant/authorino-examples/main/hello-world/authconfig.yaml
 # authconfig.authorino.kuadrant.io/talker-api-protection created

--- a/docs/user-guides/host-override.md
+++ b/docs/user-guides/host-override.md
@@ -4,17 +4,6 @@ By default, Authorino uses the host information of the HTTP request ([`Attribute
 
 Overriding the host attribute of the HTTP request can be useful to support use cases such as of **path prefix-based lookup** and **wildcard subdomains lookup**.
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b>⚠️ <i>Important:</i></b>
-        This feature may not be available to users of Authorino via <a href="https://kuadrant.io">Kuadrant</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 In this guide:

--- a/docs/user-guides/http-basic-authentication.md
+++ b/docs/user-guides/http-basic-authentication.md
@@ -100,18 +100,6 @@ Create an Authorino `AuthConfig` custom resource declaring the auth rules to be 
 
 The config uses API Key secrets to store base64-encoded `username:password` HTTP "Basic" authentication credentials. The config also specifies an Access Control List (ACL) by which only user `john` is authorized to consume the `/bye` endpoint of the API.
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/http-basic-authentication.md
+++ b/docs/user-guides/http-basic-authentication.md
@@ -36,23 +36,6 @@ kind create cluster --name authorino-tutorial
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/injecting-data.md
+++ b/docs/user-guides/injecting-data.md
@@ -34,23 +34,6 @@ kind create cluster --name authorino-tutorial
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/injecting-data.md
+++ b/docs/user-guides/injecting-data.md
@@ -101,18 +101,6 @@ The following defines a JSON object to be injected as an added HTTP header into 
 2. a dynamic value `request-time`, from Envoy-supplied contextual data present in the Authorization JSON; and
 3. a greeting message `geeting-message` that interpolates a dynamic value read from an annotation of the Kubernetes `Secret` resource that represents the API key used to authenticate into a static string.
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/json-pattern-matching-authorization.md
+++ b/docs/user-guides/json-pattern-matching-authorization.md
@@ -43,23 +43,6 @@ kubectl -n keycloak apply -f https://raw.githubusercontent.com/kuadrant/authorin
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/json-pattern-matching-authorization.md
+++ b/docs/user-guides/json-pattern-matching-authorization.md
@@ -111,18 +111,6 @@ The `email_verified` claim is a property of the identity added to the JWT by the
 
 The implementation relies on the [`X-Forwarded-For`](https://datatracker.ietf.org/doc/html/rfc7239) HTTP header to read the client's IP address.
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/keycloak-authorization-services.md
+++ b/docs/user-guides/keycloak-authorization-services.md
@@ -119,18 +119,6 @@ In cases of asynchronous user-managed permission control, the first request to t
 
 Whenever an RPT with proper permissions is obtained by Authorino, the RPT is supplied back to the API consumer, so it can be used in subsequent requests thus skipping new negotiations of UMA tickets.
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/keycloak-authorization-services.md
+++ b/docs/user-guides/keycloak-authorization-services.md
@@ -47,23 +47,6 @@ kubectl -n keycloak port-forward deployment/keycloak 8080:8080 2>&1 >/dev/null &
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/kubernetes-subjectaccessreview.md
+++ b/docs/user-guides/kubernetes-subjectaccessreview.md
@@ -99,18 +99,6 @@ Create an Authorino `AuthConfig` custom resource declaring the auth rules to be 
 
 The `AuthConfig` below sets all Kubernetes service accounts as trusted users of the API, and relies on the Kubernetes RBAC to enforce authorization using Kubernetes SubjectAccessReview API for non-resource endpoints:
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/kubernetes-subjectaccessreview.md
+++ b/docs/user-guides/kubernetes-subjectaccessreview.md
@@ -35,23 +35,6 @@ kind create cluster --name authorino-tutorial
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/kubernetes-tokenreview.md
+++ b/docs/user-guides/kubernetes-tokenreview.md
@@ -36,23 +36,6 @@ kind create cluster --name authorino-tutorial
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/kubernetes-tokenreview.md
+++ b/docs/user-guides/kubernetes-tokenreview.md
@@ -98,18 +98,6 @@ kubectl port-forward deployment/envoy 8000:8000 2>&1 >/dev/null &
 
 Create an Authorino `AuthConfig` custom resource declaring the auth rules to be enforced:
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/mtls-authentication.md
+++ b/docs/user-guides/mtls-authentication.md
@@ -34,23 +34,6 @@ kind create cluster --name authorino-tutorial
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❻.</p>
-        <p>At step ❻, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/mtls-authentication.md
+++ b/docs/user-guides/mtls-authentication.md
@@ -319,18 +319,6 @@ kubectl port-forward deployment/envoy 8443:8443 2>&1 >/dev/null &
 
 Create an Authorino `AuthConfig` custom resource declaring the auth rules to be enforced:
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/oauth2-token-introspection.md
+++ b/docs/user-guides/oauth2-token-introspection.md
@@ -138,18 +138,6 @@ EOF
 
 Create the Authorino `AuthConfig` custom resource declaring the auth rules to be enforced:
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/oauth2-token-introspection.md
+++ b/docs/user-guides/oauth2-token-introspection.md
@@ -52,23 +52,6 @@ kubectl -n a12n-server apply -f https://raw.githubusercontent.com/kuadrant/autho
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/oidc-jwt-authentication.md
+++ b/docs/user-guides/oidc-jwt-authentication.md
@@ -42,23 +42,6 @@ kubectl -n keycloak apply -f https://raw.githubusercontent.com/kuadrant/authorin
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/oidc-jwt-authentication.md
+++ b/docs/user-guides/oidc-jwt-authentication.md
@@ -104,18 +104,6 @@ kubectl port-forward deployment/envoy 8000:8000 2>&1 >/dev/null &
 
 Create an Authorino `AuthConfig` custom resource declaring the auth rules to be enforced:
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/oidc-rbac.md
+++ b/docs/user-guides/oidc-rbac.md
@@ -43,23 +43,6 @@ kubectl -n keycloak apply -f https://raw.githubusercontent.com/kuadrant/authorin
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/oidc-rbac.md
+++ b/docs/user-guides/oidc-rbac.md
@@ -113,18 +113,6 @@ In this example, the Keycloak realm defines a few users and 2 realm roles: 'memb
 | /resources/{id} | DELETE           | admin  |
 | /admin[/*]      | *                | admin  |
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 Apply the AuthConfig:
 
 ```sh

--- a/docs/user-guides/oidc-user-info.md
+++ b/docs/user-guides/oidc-user-info.md
@@ -44,23 +44,6 @@ kubectl -n keycloak apply -f https://raw.githubusercontent.com/kuadrant/authorin
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/oidc-user-info.md
+++ b/docs/user-guides/oidc-user-info.md
@@ -106,18 +106,6 @@ kubectl port-forward deployment/envoy 8000:8000 2>&1 >/dev/null &
 
 Create an Authorino `AuthConfig` custom resource declaring the auth rules to be enforced:
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/opa-authorization.md
+++ b/docs/user-guides/opa-authorization.md
@@ -104,18 +104,6 @@ The implementation relies on the [`X-Forwarded-For`](https://datatracker.ietf.or
 
 [^5]: You can also set [`use_remote_address: true`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-use-remote-address) in the Envoy route configuration, so the proxy will append its IP address instead of run in transparent mode. This setting will also ensure real remote address of the client connection passed in the [`x-envoy-external-address`](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#config-http-conn-man-headers-x-envoy-external-address) HTTP header, which can be used to simplify the read-only policy in remote environment.
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/opa-authorization.md
+++ b/docs/user-guides/opa-authorization.md
@@ -36,23 +36,6 @@ kind create cluster --name authorino-tutorial
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/passing-credentials.md
+++ b/docs/user-guides/passing-credentials.md
@@ -104,18 +104,6 @@ In this example, `member` users can authenticate supplying the API key in any of
 
 `admin` API keys are only accepted in the (default) HTTP header `Authorization: Bearer <api-key>`.
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/passing-credentials.md
+++ b/docs/user-guides/passing-credentials.md
@@ -34,23 +34,6 @@ kind create cluster --name authorino-tutorial
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/resource-level-authorization-uma.md
+++ b/docs/user-guides/resource-level-authorization-uma.md
@@ -42,23 +42,6 @@ kubectl -n keycloak apply -f https://raw.githubusercontent.com/kuadrant/authorin
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/resource-level-authorization-uma.md
+++ b/docs/user-guides/resource-level-authorization-uma.md
@@ -108,18 +108,6 @@ This example of resource-level authorization leverages part of Keycloak's User-M
 
 The Keycloak server also provides the identities. The `sub` claim of the Keycloak-issued ID tokens must match the owner of the requested resource, identified by the URI of the request.
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 Create a required secret that will be used by Authorino to initiate the authentication with the UMA registry.
 
 ```sh

--- a/docs/user-guides/sharding.md
+++ b/docs/user-guides/sharding.md
@@ -7,17 +7,6 @@ By default, Authorino will watch events related to all `AuthConfig` custom resou
 - multiple environments (e.g. staging, production) inside of a same cluster/namespace;
 - providing managed instances of Authorino that all watch CRs cluster-wide, yet dedicated to organizations allowed to create and operate their own `AuthConfig`s across multiple namespaces.
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b>⚠️ <i>Important:</i></b>
-        This feature may not be available to users of Authorino via <a href="https://kuadrant.io">Kuadrant</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <details markdown="1">
   <summary markdown="1">
     <strong>Authorino capabilities featured in this guide:</strong>

--- a/docs/user-guides/token-normalization.md
+++ b/docs/user-guides/token-normalization.md
@@ -49,23 +49,6 @@ kubectl -n keycloak apply -f https://raw.githubusercontent.com/kuadrant/authorin
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> and already have your workload cluster configured and sample service application deployed, as well as your Gateway API network resources applied to route traffic to your service, skip straight to step ❺.</p>
-        <p>At step ❺, instead of creating an <code>AuthConfig</code> custom resource, create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)

--- a/docs/user-guides/token-normalization.md
+++ b/docs/user-guides/token-normalization.md
@@ -117,18 +117,6 @@ The config trusts access tokens issued by a Keycloak realm as well as API keys l
 
 Without normalizing identity claims from these two different sources, the policy would have to handle the differences of data formats with additional ifs-and-elses. Instead, the config here uses the `identity.extendedProperties` option to ensure a custom `roles` (Array) claim is always present in the identity object. In the case of Keycloak ID tokens, the value is extracted from the `realm_access.roles` claim; for API key-resolved objects, the custom claim is set to the static value `["admin"]`.
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        Remember to create an <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead of an AuthConfig.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/validating-webhook.md
+++ b/docs/user-guides/validating-webhook.md
@@ -242,18 +242,6 @@ kubectl create namespace myapp
 
 ### With a valid `AuthConfig`
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <b><i>Kuadrant users –</i></b>
-        For this and other example AuthConfigs below, if you create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> instead, the output of the commands shall differ. The requested AuthPolicy may be initially accepted, but its state will turn ready or not ready depending on whether the corresponding AuthConfig requested by Kuadrant is accepted or rejected, according to the validating webhook rules. Check the state of the resources to confirm.
-        For more, see <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ```sh
 kubectl -n myapp apply -f -<<EOF
 apiVersion: authorino.kuadrant.io/v1beta3

--- a/docs/user-guides/validating-webhook.md
+++ b/docs/user-guides/validating-webhook.md
@@ -51,23 +51,6 @@ kubectl -n keycloak apply -f https://raw.githubusercontent.com/kuadrant/authorin
 
 The next steps walk you through installing Authorino, deploying and configuring a sample service called **Talker API** to be protected by the authorization service.
 
-<table>
-  <thead>
-    <tr>
-      <th>Using Kuadrant</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>If you are a user of <a href="https://kuadrant.io">Kuadrant</a> you may already have Authorino installed and running. In this case, skip straight to step ❸.</p>
-        <p>At step ❺, alternatively to creating an <code>AuthConfig</code> custom resource, you may create a Kuadrant <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy"><code>AuthPolicy</code></a> one. The schema of the AuthConfig's <code>spec</code> matches the one of the AuthPolicy's, except <code>spec.host</code>, which is not available in the Kuadrant AuthPolicy. Host names in a Kuadrant AuthPolicy are inferred automatically from the Kubernetes network object referred in <code>spec.targetRef</code> and route selectors declared in the policy.</p>
-        <p>For more about using Kuadrant to enforce authorization, check out <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/overviews/auth">Kuadrant auth</a>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <br/>
 
 ## ❶ Install the Authorino Operator (cluster admin required)


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/authorino/issues/519

Move out the "Using Kuadrant" from the user guides to keep the user guides focused on `AuthConfig`. Instead a `README.md` is introduced describing Kuadrant `AuthPolicy` as a consumer of the `AuthConfig`

