### PR TITLE
Explicitly state Z stream go version in go.mod, version set to 1.22.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino
 
-go 1.22
+go 1.22.5
 
 require (
 	github.com/authzed/authzed-go v0.7.0


### PR DESCRIPTION
Same as https://github.com/Kuadrant/authorino-operator/pull/249