### PR TITLE
Fix e2e tests for Authorino OIDC endpoint with TLS disabled

### DIFF
--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -13,6 +13,7 @@ authconfig=${AUTHCONFIG:-"$(dirname $(realpath $0))/${authconfig_version}/authco
 authconfig_invalid=${AUTHCONFIG_INVALID:-"$(dirname $(realpath $0))/${authconfig_version}/authconfig-invalid.yaml"}
 verbose=${VERBOSE}
 timeout=${TIMEOUT:-"600"}
+tls_enabled=${TLS_ENABLED:-"true"}
 
 HOSTNAME="talker-api.127.0.0.1.nip.io"
 IP_IN="109.69.200.56" # IT
@@ -275,7 +276,11 @@ send_anonymous_requests $IP_OUT "
     GET / => 403"
 
 # Test #43 done
-send_requests "https" "authorino-authorino-oidc" "8083" $IP_IN "" "
+protocol="http"
+if [[ "$tls_enabled" == "true" ]]; then
+  protocol="https"
+fi
+send_requests $protocol "authorino-authorino-oidc" "8083" $IP_IN "" "
     GET /authorino/e2e-test/wristband/.well-known/openid-configuration => 200
     GET /authorino/e2e-test/wristband/.well-known/openid-connect/certs => 200
     GET /authorino/e2e-test/invalid/.well-known/openid-configuration => 404


### PR DESCRIPTION
Verification steps:

```sh
make e2e TLS_ENABLED=false
```

Before:

```
sending multiple requests
...........................................E0527 17:52:02.562019   53220 portforward.go:404] "Unhandled Error" err="error copying from local connection to remote stream: writeto tcp6 [::1]:8083->[::1]:54783: read tcp6 [::1]:8083->[::1]:54783: read: connection reset by peer"

Test failed [#44]:
  GET	https://authorino-authorino-oidc:8083/authorino/e2e-test/wristband/.well-known/openid-configuration
  X-Forwarded-For: 109.69.200.56

  Expected: 200
  Actual: 000


FAIL
```

After:

```
sending multiple requests
.................................................


SUCCESS
```