### PR TITLE
fix: nil pointer from typed nil of auth.OpenIdConfigStore for UserInfo

### DIFF
--- a/pkg/evaluators/identity.go
+++ b/pkg/evaluators/identity.go
@@ -206,7 +206,10 @@ func (config *IdentityConfig) ResolveExtendedProperties(pipeline auth.AuthPipeli
 }
 
 func (config *IdentityConfig) GetOpenIdConfig() auth.OpenIdConfigStore {
-	return config.JWTAuthentication
+	if config.JWTAuthentication != nil {
+		return config.JWTAuthentication
+	}
+	return nil
 }
 
 // impl:K8sSecretBasedIdentityConfigEvaluator


### PR DESCRIPTION
# Description
[e2e is failing](https://github.com/Kuadrant/authorino/actions/runs/15439930133/job/43455108934) with the error:

```sh
clusterrolebinding.rbac.authorization.k8s.io/talker-api-admins created
waiting authconfig ready. condition met
sending multiple requests

Test failed [#1]:
  GET   http://talker-api.127.0.0.1.nip.io:8000/
  Authorization: Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6InFxSE9fa0NHWmdNZEZ0ZXJTSFFucURlbml2Z29aSGlNR2hkTll3WnJmNU0ifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiXSwiZXhwIjoxNzQ5MTI3NjkxLCJpYXQiOjE3NDkxMjcwOTEsImlzcyI6Imh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJhdXRob3Jpbm8iLCJzZXJ2aWNlYWNjb3VudCI6eyJuYW1lIjoiYXBwLTEtc2EiLCJ1aWQiOiI3YTgxYjNlNC0wMzE4LTQwMGUtODA2NC0xYmI1Y2IyYjJlZjIifX0sIm5iZiI6MTc0OTEyNzA5MSwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmF1dGhvcmlubzphcHAtMS1zYSJ9.E8UNlbHWXWQ9tcwTktYztOgNIfYlZjTAczpQ1xUtxXFPHnRj_FhZCXQi4DkopNrFZeYs2jvoaXdtWP3-Mnw7H9dLDqdyO8R9ZNBFa-lMMk37Wc0TnSmj_H-qVEVq3wJlYiH5fvq08nRK8UL071cGMByUuElbbzzkoEh8N_SNq1MIZ6BQYEjoakVzarIh39lB91Mg9OqJUW4RL6_D3-gO8UzmbNzqgo58zibIsv6IiHfCJpPVcT6DgmxnHO8gcZVSE_g0QTMTMDr7Myif6ba0aDStBtYu9d1jjc6PLjN9L9Jv4iNonB02Z-9GsJ11Vmysp2mo_Iqwq6LZhKhmLyVrfw
  X-Forwarded-For: 109.69.200.56

  Expected: 200
  Actual: 403


FAIL

```

With Authorino crashing with a `nil` pointer with the following logs:
```sh
2025-06-05T12:38:12Z	DEBUG	authorino.service.auth.authpipeline.identity	identity validated	{"request id": "665170cb-b06b-4bb9-955a-3c4e99d96615", "config": {"Name":"k8s-auth","Priority":0,"Conditions":{"Left":null,"Right":null},"Metrics":false,"Cache":null,"OAuth2":null,"JWTAuthentication":null,"MTLS":null,"HMAC":null,"APIKey":null,"KubernetesAuth":{"AuthCredentials":{"KeySelector":"Bearer","In":"authorization_header"}},"Plain":null,"Noop":null,"ExtendedProperties":[{"Name":"username","Value":{},"Overwrite":false},{"Name":"kubernetes-rbac","Value":{"Static":true,"Pattern":""},"Overwrite":false}]}, "object": {"audiences":["https://kubernetes.default.svc.cluster.local"],"authenticated":true,"kubernetes-rbac":true,"user":{"groups":["system:serviceaccounts","system:serviceaccounts:authorino","system:authenticated"],"uid":"7a81b3e4-0318-400e-8064-1bb5cb2b2ef2","username":"system:serviceaccount:authorino:app-1-sa"},"username":"system:serviceaccount:authorino:app-1-sa"}}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x168b0f4]

goroutine 280 [running]:
github.com/kuadrant/authorino/pkg/evaluators/identity.(*JWTAuthentication).GetOpenIdUrl(0x367f2b0?, {0x22c56c8?, 0x40024b64b0?}, {0x1e76538?, 0x6?})
	/usr/src/authorino/pkg/evaluators/identity/jwt.go:81 +0x24
github.com/kuadrant/authorino/pkg/evaluators/metadata.(*UserInfo).Call(0x4002640940, {0x22cc9f0, 0x4002298e00}, {0x22c56c8, 0x40024b6420})
	/usr/src/authorino/pkg/evaluators/metadata/user_info.go:46 +0x194
github.com/kuadrant/authorino/pkg/evaluators.(*MetadataConfig).Call(0x4000ba2060, {0x22cc9f0, 0x4002298e00}, {0x22c5700, 0x4002ba9680})
	/usr/src/authorino/pkg/evaluators/metadata.go:66 +0x448
github.com/kuadrant/authorino/pkg/service.(*AuthPipeline).evaluateAuthConfig.func1()
	/usr/src/authorino/pkg/service/auth_pipeline.go:128 +0x78
github.com/kuadrant/authorino/pkg/metrics.ReportTimedMetricWithObject(0x40004ce1a8, 0x400226de60, {0xffff436103c8?, 0x4000ba2060?}, {0x400226de40?, 0x0?, 0x0?})
	/usr/src/authorino/pkg/metrics/metrics.go:76 +0x54
github.com/kuadrant/authorino/pkg/service.(*AuthPipeline).evaluateAuthConfig(0x4002298e00, {0x229dbe0, 0x4000ba2060}, {0x22c5700, 0x4002ba9680}, 0x4000d2cd78, 0x0, 0x0)
	/usr/src/authorino/pkg/service/auth_pipeline.go:145 +0x3d4
github.com/kuadrant/authorino/pkg/service.(*AuthPipeline).evaluateMetadataConfigs.func1.(*AuthPipeline).evaluateAnyAuthConfig.1({0x229dbe0?, 0x4000ba2060?}, {0x22c5700?, 0x4002ba9680?}, 0x0?, 0x0?)
	/usr/src/authorino/pkg/service/auth_pipeline.go:180 +0x50
github.com/kuadrant/authorino/pkg/service.(*AuthPipeline).evaluateAuthConfigs.func1()
	/usr/src/authorino/pkg/service/auth_pipeline.go:159 +0x6c
created by github.com/kuadrant/authorino/pkg/service.(*AuthPipeline).evaluateAuthConfigs in goroutine 277
	/usr/src/authorino/pkg/service/auth_pipeline.go:157 +0x98
```

A _**typed nil**_ interface can be created from assigning `idConfig.GetOpenIdConfig()` to `var openIdConfigStore auth.OpenIdConfigStore` at: 
https://github.com/Kuadrant/authorino/blob/390081929a260f20441c606f1fea1675fbe5adf5/controllers/auth_config_controller.go#L368-L375
Due to this, it passes the `nil` check at the following but causes a `nil` pointer when accessing `resolvedIdentityOidc.GetOpenIdUrl(ctx, "issuer")`
https://github.com/Kuadrant/authorino/blob/390081929a260f20441c606f1fea1675fbe5adf5/pkg/evaluators/metadata/user_info.go#L45-L52

# Verification
* See successful e2e run at https://github.com/Kuadrant/authorino/actions/runs/15467571889/job/43543212336
* Or run `make e2e` if you want to run the e2e tests locally