### PR TITLE
makefile: refactor dependency tooling install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,18 +68,18 @@ MOCKGEN ?= $(LOCALBIN)/mockgen
 BENCHSTAT ?= $(LOCALBIN)/benchstat
 
 ## Tool Versions
-KIND_VERSION ?= v0.21.0
+KIND_VERSION ?= v0.20.0
 KUSTOMIZE_VERSION ?= v5.5.0
 CONTROLLER_GEN_VERSION ?= v0.15.0
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
-MOCKGEN_VERSION ?= v1.6.0
+MOCKGEN_VERSION ?= v0.5.2
 BENCHSTAT_VERSION ?= latest
 
 ## Versioned Binaries (the actual files that 'make' will check for)
 KIND_V_BINARY := $(LOCALBIN)/kind-$(KIND_VERSION)
 KUSTOMIZE_V_BINARY := $(LOCALBIN)/kustomize-$(KUSTOMIZE_VERSION)
-CONTROLLER_GEN_V_BINARY := $(LOCALBIN)/controller-gen-$(CONTROLLER_TOOLS_VERSION)
+CONTROLLER_GEN_V_BINARY := $(LOCALBIN)/controller-gen-$(CONTROLLER_GEN_VERSION)
 ENVTEST_V_BINARY := $(LOCALBIN)/setup-envtest-$(ENVTEST_VERSION)
 MOCKGEN_V_BINARY := $(LOCALBIN)/mockgen-$(MOCKGEN_VERSION)
 BENCHSTAT_V_BINARY := $(LOCALBIN)/benchstat-$(BENCHSTAT_VERSION)
@@ -102,7 +102,7 @@ $(ENVTEST_V_BINARY): $(LOCALBIN)
 .PHONY: mockgen
 mockgen: $(MOCKGEN_V_BINARY)
 $(MOCKGEN_V_BINARY): $(LOCALBIN) ## Installs mockgen in $PROJECT_DIR/bin
-	$(call go-install-tool,$(MOCKGEN),github.com/golang/mock/mockgen,$(MOCKGEN_VERSION))
+	$(call go-install-tool,$(MOCKGEN),go.uber.org/mock/mockgen,$(MOCKGEN_VERSION))
 
 .PHONY: benchstat
 benchstat: $(BENCHSTAT_V_BINARY)


### PR DESCRIPTION
# Description
* Refactor makefile dependency tools using [Kubebuilder v4 project makefile as template](https://github.com/kubernetes-sigs/kubebuilder/blob/012e741d07a34da23451b9d0c946f89dddd43609/testdata/project-v4/Makefile#L168-L232)
* Bind tool version to "X-V_BINARY" that will be checked instead by `make`. This will ensure that should the version of the tool is changed/updated, `make` will download this new version and update the symlink
* Minor consistency update to download uber mockgen which was missed when mockgen was changed as part of https://github.com/Kuadrant/authorino/pull/536

# Verification
* Passing github workflow
* Test tool binary is downloaded if version has changed
```
make kind
./bin/kind version
KIND_VERSION=v0.23.0 make kind
./bin/kind version
```
![image](https://github.com/user-attachments/assets/9c20d54e-61c6-4e8f-8a19-8b9b9d9d086d)
![image](https://github.com/user-attachments/assets/2f879a23-cc84-4005-9038-5b0c07ebb815)
