### PR TITLE
dep: upgrade to jwt/v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.0.5
 	github.com/go-logr/logr v1.4.2
 	github.com/gogo/googleapis v1.4.0
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/cel-go v0.21.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.2.1 h1:OptwRhECazUx5ix5TTWC3EZhsZEHWcYWY4FQHTIubm4=
 github.com/golang/glog v1.2.1/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=

--- a/pkg/evaluators/response/wristband.go
+++ b/pkg/evaluators/response/wristband.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kuadrant/authorino/pkg/json"
 
 	jose "github.com/go-jose/go-jose/v4"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 const DEFAULT_WRISTBAND_DURATION = int64(300)
@@ -51,12 +51,6 @@ func NewSigningKey(name string, algorithm string, singingKey []byte) (*jose.JSON
 	}
 
 	return signingKey, nil
-}
-
-type Claims map[string]interface{}
-
-func (c *Claims) Valid() error {
-	return nil
 }
 
 func NewWristbandConfig(issuer string, claims []json.JSONProperty, tokenDuration *int64, signingKeys []jose.JSONWebKey) (*Wristband, error) {
@@ -115,7 +109,7 @@ func (w *Wristband) Call(pipeline auth.AuthPipeline, ctx context.Context) (inter
 	exp := iat + int64(w.TokenDuration)
 
 	// claims
-	claims := Claims{
+	claims := jwt.MapClaims{
 		"iss": w.GetIssuer(),
 		"iat": iat,
 		"exp": exp,


### PR DESCRIPTION
# Description
Upgrade to jwt/v5 to potentially fix dependabot alert

# Verification
Passing e2e should be enough as there's tests that use JWT auth
- https://github.com/Kuadrant/authorino/actions/runs/15826543810