### PR TITLE
refactor: cross compile and distribute build image

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -15,17 +15,13 @@ env:
 
 jobs:
   prepare:
-    name: Prepare build metadata
+    name: Prepare build info
     runs-on: ubuntu-latest
     outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-      labels: ${{ steps.meta.outputs.labels }}
       version: ${{ steps.build-info.outputs.version }}
       git_sha: ${{ steps.build-info.outputs.git_sha }}
       dirty: ${{ steps.build-info.outputs.dirty }}
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
       - name: Set Authorino build info
         id: build-info
         run: |
@@ -39,16 +35,6 @@ jobs:
           fi
           echo "git_sha=${{ github.sha }}" >> $GITHUB_OUTPUT
           echo "dirty=false" >> $GITHUB_OUTPUT
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha,prefix={{branch}}-
-            type=raw,value=latest,enable={{is_default_branch}}
 
   build:
     name: Build ${{ matrix.platform }}
@@ -86,7 +72,7 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          labels: ${{ needs.prepare.outputs.labels }}
+
           build-args: |
             version=${{ needs.prepare.outputs.version }}
             git_sha=${{ needs.prepare.outputs.git_sha }}
@@ -118,6 +104,16 @@ jobs:
           merge-multiple: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
       - name: Login to registry
         if: ${{ !env.ACT }}
         uses: docker/login-action@v3
@@ -129,7 +125,7 @@ jobs:
         if: ${{ !env.ACT }}
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create $(echo '${{ needs.prepare.outputs.tags }}' | tr '\n' ' ' | sed 's/^/-t /' | sed 's/ / -t /g') \
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino@sha256:%s ' *)
       - name: Inspect image
         if: ${{ !env.ACT }}

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -57,8 +57,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Extract metadata for build
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -14,58 +14,124 @@ env:
   MAIN_BRANCH_NAME: main
 
 jobs:
-  build:
-    name: Build and push image
+  prepare:
+    name: Prepare build metadata
     runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+      labels: ${{ steps.meta.outputs.labels }}
+      version: ${{ steps.build-info.outputs.version }}
+      git_sha: ${{ steps.build-info.outputs.git_sha }}
+      dirty: ${{ steps.build-info.outputs.dirty }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
-      - name: Add latest tag
-        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
-        id: add-latest-tag
-        run: |
-          echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
-      - name: Add branch tag
-        if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
-        id: add-branch-tag
-        run: |
-          echo "IMG_TAGS=${GITHUB_REF_NAME/\//-} ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+        uses: actions/checkout@v4
       - name: Set Authorino build info
-        id: authorino-build-info
+        id: build-info
         run: |
           if [[ ${GITHUB_REF_NAME/\//-} =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
             tag=${GITHUB_REF_NAME/\//-}
-            echo "version=${tag#v}" >> $GITHUB_ENV
+            echo "version=${tag#v}" >> $GITHUB_OUTPUT
           elif [[ ${GITHUB_REF_NAME/\//-} == "main" ]]; then
-            echo "version=latest" >> $GITHUB_ENV
+            echo "version=latest" >> $GITHUB_OUTPUT
           else
-            echo "version=${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           fi
-          echo "git_sha=${{ github.sha }}" >> $GITHUB_ENV
+          echo "git_sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "dirty=false" >> $GITHUB_OUTPUT
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-latest
+          - platform: linux/s390x
+            runner: ubuntu-latest
+          - platform: linux/ppc64le
+            runner: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      - name: Build Image
-        id: build-image
-        uses: redhat-actions/buildah-build@v2
-        with:
-          image: authorino
-          tags: ${{ env.IMG_TAGS }}
-          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
-          build-args: |
-            git_sha=${{ env.git_sha }}
-            version=${{ env.version }}
-            dirty=${{ env.dirty }}
-          containerfiles: |
-            ./Dockerfile
-      - name: Push Image
+      - name: Login to registry
         if: ${{ !env.ACT }}
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
+        uses: docker/login-action@v3
         with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
+          registry: ${{ env.IMG_REGISTRY_HOST }}
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
-      - name: Print Image URL
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ needs.prepare.outputs.labels }}
+          build-args: |
+            version=${{ needs.prepare.outputs.version }}
+            git_sha=${{ needs.prepare.outputs.git_sha }}
+            dirty=${{ needs.prepare.outputs.dirty }}
+          outputs: type=image,name=${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino,push-by-digest=true,name-canonical=true,push=${{ !env.ACT }}
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ strategy.job-index }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Create multi-platform manifest
+    runs-on: ubuntu-latest
+    needs: [prepare, build]
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to registry
+        if: ${{ !env.ACT }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.IMG_REGISTRY_HOST }}
+          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
+          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
+      - name: Create manifest list and push
+        if: ${{ !env.ACT }}
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(echo '${{ needs.prepare.outputs.tags }}' | tr '\n' ' ' | sed 's/^/-t /' | sed 's/ / -t /g') \
+            $(printf '${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino@sha256:%s ' *)
+      - name: Inspect image
+        if: ${{ !env.ACT }}
+        run: |
+          docker buildx imagetools inspect ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino:${{ needs.prepare.outputs.version }}

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
       - 'master'
-  workflow_dispatch: {}
+  workflow_dispatch: { }
 
 env:
   IMG_TAGS: ${{ github.sha }}
@@ -57,15 +57,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Extract metadata for build
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino
-          tags: |
-            type=ref,event=branch
-            type=raw,value=${{ github.sha }}
-            type=raw,value=latest,enable={{is_default_branch}}
       - name: Login to registry
         if: ${{ !env.ACT }}
         uses: docker/login-action@v3
@@ -79,7 +70,6 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             version=${{ needs.prepare.outputs.version }}
             git_sha=${{ needs.prepare.outputs.git_sha }}
@@ -102,7 +92,7 @@ jobs:
   merge:
     name: Create multi-platform manifest
     runs-on: ubuntu-latest
-    needs: [prepare, build]
+    needs: [ prepare, build ]
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -119,8 +109,7 @@ jobs:
           images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
-            type=sha
+            type=raw,value=${{ github.sha }}
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Login to registry
         if: ${{ !env.ACT }}

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -59,6 +59,16 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+      - name: Extract metadata for build
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
       - name: Login to registry
         if: ${{ !env.ACT }}
         uses: docker/login-action@v3
@@ -72,7 +82,7 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             version=${{ needs.prepare.outputs.version }}
             git_sha=${{ needs.prepare.outputs.git_sha }}
@@ -112,7 +122,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Login to registry
         if: ${{ !env.ACT }}

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -66,8 +66,7 @@ jobs:
           images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=raw,value=${{ github.sha }}
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Login to registry
         if: ${{ !env.ACT }}
@@ -88,6 +87,7 @@ jobs:
             git_sha=${{ needs.prepare.outputs.git_sha }}
             dirty=${{ needs.prepare.outputs.dirty }}
           outputs: type=image,name=${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino,push-by-digest=true,name-canonical=true,push=${{ !env.ACT }}
+          provenance: false
       - name: Export digest
         run: |
           mkdir -p /tmp/digests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build the authorino binary
 # https://catalog.redhat.com/software/containers/ubi9/go-toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.23 AS builder
 USER root
 WORKDIR /usr/src/authorino
 COPY ./ ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,12 @@ ARG git_sha
 ENV git_sha=${git_sha:-unknown}
 ARG dirty
 ENV dirty=${dirty:-unknown}
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ENV GOOS=${TARGETOS:-linux}
+ENV GOARCH=${TARGETARCH:-amd64}
+ENV GOARM=${TARGETVARIANT}
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags "-X main.version=${version} -X main.gitSHA=${git_sha} -X main.dirty=${dirty}" -o /usr/bin/authorino main.go
 
 # Use Red Hat minimal base image to package the binary


### PR DESCRIPTION
# Description
Image building is slow due to using QEMU and building the various platforms sequentially, taking about [54 mins](https://github.com/Kuadrant/authorino/actions/runs/15826379972) to complete the image build workflow.

This PR refactors the image build by:
1. Cross compiling instead of using emulating the targetted architecture 
2. Distribute the image build per architecture to individual github runners and merging the manifests at the end

This approach decreases the image build time to approximately **[3 mins](https://github.com/Kuadrant/authorino/actions/runs/15997307660)**, an **18** fold decrease.

This will allow quicker releases and potentially testings where users may not waiting/depend of the build images