### PR TITLE
refactor: remove needing to use ROOT user in dockerfile

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -56,7 +56,7 @@ jobs:
         if: ${{ matrix.importpath != '' }}
         run: |
           cd $(mktemp -d)
-          GO111MODULE=on go install ${{ matrix.importpath }}
+          go install ${{ matrix.importpath }}
 
       - name: ${{ matrix.tool }} ${{ matrix.options }}
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG TARGETVARIANT
 ENV GOOS=${TARGETOS:-linux}
 ENV GOARCH=${TARGETARCH:-amd64}
 ENV GOARM=${TARGETVARIANT}
-RUN CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags "-X main.version=${version} -X main.gitSHA=${git_sha} -X main.dirty=${dirty}" -o /tmp/authorino main.go
+RUN CGO_ENABLED=0 go build -a -ldflags "-X main.version=${version} -X main.gitSHA=${git_sha} -X main.dirty=${dirty}" -o /tmp/authorino main.go
 
 # Use Red Hat minimal base image to package the binary
 # https://catalog.redhat.com/software/containers/ubi9-minimal

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 # Build the authorino binary
 # https://catalog.redhat.com/software/containers/ubi9/go-toolset
 FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.23 AS builder
-USER root
 WORKDIR /usr/src/authorino
 COPY ./ ./
 ARG version
@@ -16,7 +15,7 @@ ARG TARGETVARIANT
 ENV GOOS=${TARGETOS:-linux}
 ENV GOARCH=${TARGETARCH:-amd64}
 ENV GOARM=${TARGETVARIANT}
-RUN CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags "-X main.version=${version} -X main.gitSHA=${git_sha} -X main.dirty=${dirty}" -o /usr/bin/authorino main.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags "-X main.version=${version} -X main.gitSHA=${git_sha} -X main.dirty=${dirty}" -o /tmp/authorino main.go
 
 # Use Red Hat minimal base image to package the binary
 # https://catalog.redhat.com/software/containers/ubi9-minimal
@@ -31,7 +30,7 @@ RUN PKGS="shadow-utils" \
 
 WORKDIR /home/authorino/bin
 ENV PATH=/home/authorino/bin:$PATH
-COPY --from=builder /usr/bin/authorino ./authorino
+COPY --from=builder /tmp/authorino ./authorino
 
 # Set permissions and prepare for non-root user in one layer
 RUN chown -R authorino:root /home/authorino \

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ run: generate manifests ## Runs the application against the Kubernetes cluster c
 build:git_sha=$(shell git rev-parse HEAD)
 build:dirty=$(shell $(PROJECT_DIR)/hack/check-git-dirty.sh || echo "unknown")
 build: generate ## Builds the manager binary
-	CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags "-X main.version=$(VERSION) -X main.gitSHA=${git_sha} -X main.dirty=${dirty}" -o bin/authorino main.go
+	CGO_ENABLED=0 go build -a -ldflags "-X main.version=$(VERSION) -X main.gitSHA=${git_sha} -X main.dirty=${dirty}" -o bin/authorino main.go
 
 docker-build:git_sha=$(shell git rev-parse HEAD)
 docker-build:dirty=$(shell $(PROJECT_DIR)/hack/check-git-dirty.sh || echo "unknown")


### PR DESCRIPTION
# Description
- Remove needing to use ROOT user in Dockerfile builder layer as it's not strictly necessary.
  - It was previously needed due to building the binary to `/usr/bin` which is protected from the default user.
- Remove setting GO111MODULE 
  - default is on from go v1.17 

# Verification
* Passing image build should be sufficient
  * https://github.com/Kuadrant/authorino/actions/runs/16467329104