### PR TITLE
gha: use go version from go.mod

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -37,20 +37,20 @@ jobs:
           - gofmt
 
         include:
-        - tool: gofmt
-          options: -s
-        - tool: goimports
-          importpath: golang.org/x/tools/cmd/goimports@latest
+          - tool: gofmt
+            options: -s
+          - tool: goimports
+            importpath: golang.org/x/tools/cmd/goimports@latest
 
     steps:
-      - name: Set up Go 1.23.x
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.23.x
+          go-version-file: go.mod
         id: go
-
-      - name: Check out code
-        uses: actions/checkout@v3
 
       - name: Install Dependencies
         if: ${{ matrix.importpath != '' }}
@@ -91,14 +91,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.23.x
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.23.x
+          go-version-file: go.mod
         id: go
-
-      - name: Check out code
-        uses: actions/checkout@v3
 
       - name: Install Tools
         env:

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -13,25 +13,24 @@ jobs:
     name: End-to-end Tests
     strategy:
       matrix:
-        go-version: [1.23.x]
-        platform: [ubuntu-latest]
-        authconfig_version: [v1beta2, v1beta3]
+        platform: [ ubuntu-latest ]
+        authconfig_version: [ v1beta2, v1beta3 ]
     runs-on: ${{ matrix.platform }}
     defaults:
       run:
         shell: bash
     steps:
-      - name: Set up Go ${{ matrix.go-version }}
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
         id: go
       - name: Install jq
         run: sudo apt-get install jq
-      - name: Check out code
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.sha }}
       - name: Run make e2e
         env:
           OPERATOR_VERSION: ${{ github.event.inputs.operatorVersion }}

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -15,20 +15,19 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: [1.23.x]
-        platform: [ubuntu-latest]
+        platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
     defaults:
       run:
         shell: bash
     steps:
-      - name: Set up Go ${{ matrix.go-version }}
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
         id: go
-      - name: Check out code
-        uses: actions/checkout@v3
       - name: Run make test
         run: |
           make test

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -3,27 +3,28 @@ name: Smoke Tests
 on:
   workflow_run:
     workflows:
-    - Build and push image
+      - Build and push image
     types:
-    - completed
+      - completed
 
 jobs:
   on-success:
     name: Smoke Tests
     strategy:
       matrix:
-        go-version: [1.23.x]
-        platform: [ubuntu-latest]
+        platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     defaults:
       run:
         shell: bash
     steps:
-      - name: Set up Go ${{ matrix.go-version }}
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
         id: go
       - name: Install jq
         run: sudo apt-get install jq


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/authorino/issues/549

Uses go version from `go.mod` where possible

# Verification
- Passing github actions 
