### PR TITLE
feat: emit custom labels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -141,5 +141,5 @@ require (
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
+	sigs.k8s.io/yaml v1.4.0
 )

--- a/pkg/metrics/auth_config_metrics.go
+++ b/pkg/metrics/auth_config_metrics.go
@@ -3,15 +3,33 @@ package metrics
 import "github.com/prometheus/client_golang/prometheus"
 
 func NewAuthConfigCounterMetric(name, help string, extraLabels ...string) *prometheus.CounterVec {
+	if CustomMetricsEnabled {
+		return NewCounterMetric(name, help, extendedAuthConfigMetricLabelsWithCustom(extraLabels...)...)
+	}
 	return NewCounterMetric(name, help, extendedAuthConfigMetricLabels(extraLabels...)...)
 }
 
 func NewAuthConfigDurationMetric(name, help string, extraLabels ...string) *prometheus.HistogramVec {
+	if CustomMetricsEnabled {
+		return NewDurationMetric(name, help, extendedAuthConfigMetricLabelsWithCustom(extraLabels...)...)
+	}
 	return NewDurationMetric(name, help, extendedAuthConfigMetricLabels(extraLabels...)...)
 }
 
 func extendedAuthConfigMetricLabels(extraLabels ...string) []string {
 	labels := []string{"namespace", "authconfig"}
 	labels = append(labels, extraLabels[:]...)
+	return labels
+}
+
+func extendedAuthConfigMetricLabelsWithCustom(extraLabels ...string) []string {
+	labels := []string{"namespace", "authconfig"}
+	labels = append(labels, extraLabels[:]...)
+
+	// Add custom label names in a consistent order
+	for labelName := range CustomMetricLabels {
+		labels = append(labels, labelName)
+	}
+
 	return labels
 }

--- a/pkg/metrics/auth_config_metrics.go
+++ b/pkg/metrics/auth_config_metrics.go
@@ -3,32 +3,22 @@ package metrics
 import "github.com/prometheus/client_golang/prometheus"
 
 func NewAuthConfigCounterMetric(name, help string, extraLabels ...string) *prometheus.CounterVec {
-	if CustomMetricsEnabled {
-		return NewCounterMetric(name, help, extendedAuthConfigMetricLabelsWithCustom(extraLabels...)...)
-	}
-	return NewCounterMetric(name, help, extendedAuthConfigMetricLabels(extraLabels...)...)
+	return NewCounterMetric(name, help, buildAuthConfigLabels(extraLabels...)...)
 }
 
 func NewAuthConfigDurationMetric(name, help string, extraLabels ...string) *prometheus.HistogramVec {
+	return NewDurationMetric(name, help, buildAuthConfigLabels(extraLabels...)...)
+}
+
+func buildAuthConfigLabels(extraLabels ...string) []string {
+	labels := []string{"namespace", "authconfig"}
+	labels = append(labels, extraLabels...)
+
+	// Add custom label names if custom metrics are enabled
 	if CustomMetricsEnabled {
-		return NewDurationMetric(name, help, extendedAuthConfigMetricLabelsWithCustom(extraLabels...)...)
-	}
-	return NewDurationMetric(name, help, extendedAuthConfigMetricLabels(extraLabels...)...)
-}
-
-func extendedAuthConfigMetricLabels(extraLabels ...string) []string {
-	labels := []string{"namespace", "authconfig"}
-	labels = append(labels, extraLabels[:]...)
-	return labels
-}
-
-func extendedAuthConfigMetricLabelsWithCustom(extraLabels ...string) []string {
-	labels := []string{"namespace", "authconfig"}
-	labels = append(labels, extraLabels[:]...)
-
-	// Add custom label names in a consistent order
-	for labelName := range CustomMetricLabels {
-		labels = append(labels, labelName)
+		for labelName := range CustomMetricLabels {
+			labels = append(labels, labelName)
+		}
 	}
 
 	return labels

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -3,10 +3,15 @@ package metrics
 import (
 	"fmt"
 
+	"github.com/kuadrant/authorino/pkg/expressions/cel"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var DeepMetricsEnabled = false
+var (
+	DeepMetricsEnabled   = false
+	CustomMetricLabels   map[string]*cel.Expression
+	CustomMetricsEnabled = false
+)
 
 type Object interface {
 	GetType() string
@@ -16,6 +21,38 @@ type Object interface {
 
 func Register(metrics ...prometheus.Collector) {
 	prometheus.MustRegister(metrics...)
+}
+
+func InitCustomMetricLabels(labelsConfig map[string]string) error {
+	CustomMetricLabels = make(map[string]*cel.Expression)
+
+	for labelName, celExpr := range labelsConfig {
+		if expr, err := cel.NewExpression(celExpr); err != nil {
+			return fmt.Errorf("failed to compile CEL expression for label %s: %w", labelName, err)
+		} else {
+			CustomMetricLabels[labelName] = expr
+		}
+	}
+
+	CustomMetricsEnabled = len(CustomMetricLabels) > 0
+	return nil
+}
+
+func EvaluateCustomLabels(authJSON string) (map[string]string, error) {
+	customLabels := make(map[string]string)
+
+	for labelName, expr := range CustomMetricLabels {
+		if value, err := expr.ResolveFor(authJSON); err != nil {
+			// Log error but don't fail the whole metric - use empty value
+			customLabels[labelName] = ""
+		} else if strValue, ok := value.(string); ok {
+			customLabels[labelName] = strValue
+		} else {
+			customLabels[labelName] = fmt.Sprintf("%v", value)
+		}
+	}
+
+	return customLabels, nil
 }
 
 func NewCounterMetric(name, help string, labels ...string) *prometheus.CounterVec {
@@ -75,6 +112,77 @@ func ReportTimedMetricWithObject(metric *prometheus.HistogramVec, f func(), obj 
 	} else {
 		f()
 	}
+}
+
+func ReportMetricWithCustomLabels(metric *prometheus.CounterVec, authJSON string, baseLabels ...string) {
+	labels := make([]string, len(baseLabels))
+	copy(labels, baseLabels)
+
+	if customLabels, err := EvaluateCustomLabels(authJSON); err == nil {
+		// Append custom label values in the same order as they appear in CustomMetricLabels
+		for labelName := range CustomMetricLabels {
+			if value, exists := customLabels[labelName]; exists {
+				labels = append(labels, value)
+			} else {
+				labels = append(labels, "")
+			}
+		}
+	} else {
+		// Append empty values for all custom labels if evaluation fails
+		for range CustomMetricLabels {
+			labels = append(labels, "")
+		}
+	}
+
+	metric.WithLabelValues(labels...).Inc()
+}
+
+func ReportTimedMetricWithCustomLabels(metric *prometheus.HistogramVec, f func(), authJSON string, baseLabels ...string) {
+	labels := make([]string, len(baseLabels))
+	copy(labels, baseLabels)
+
+	if customLabels, err := EvaluateCustomLabels(authJSON); err == nil {
+		for labelName := range CustomMetricLabels {
+			if value, exists := customLabels[labelName]; exists {
+				labels = append(labels, value)
+			} else {
+				labels = append(labels, "")
+			}
+		}
+	} else {
+		for range CustomMetricLabels {
+			labels = append(labels, "")
+		}
+	}
+
+	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(value float64) {
+		metric.WithLabelValues(labels...).Observe(value)
+	}))
+
+	defer timer.ObserveDuration()
+	f()
+}
+
+func ReportMetricWithStatusAndCustomLabels(metric *prometheus.CounterVec, status string, authJSON string, baseLabels ...string) {
+	labels := make([]string, len(baseLabels))
+	copy(labels, baseLabels)
+	labels = append(labels, status) // Add status to base labels
+
+	if customLabels, err := EvaluateCustomLabels(authJSON); err == nil {
+		for labelName := range CustomMetricLabels {
+			if value, exists := customLabels[labelName]; exists {
+				labels = append(labels, value)
+			} else {
+				labels = append(labels, "")
+			}
+		}
+	} else {
+		for range CustomMetricLabels {
+			labels = append(labels, "")
+		}
+	}
+
+	metric.WithLabelValues(labels...).Inc()
 }
 
 func extendLabelValuesWithStatus(status string, baseLabels ...string) []string {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -3,8 +3,9 @@ package metrics
 import (
 	"fmt"
 
-	"github.com/kuadrant/authorino/pkg/expressions/cel"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/kuadrant/authorino/pkg/expressions/cel"
 )
 
 var (
@@ -55,6 +56,33 @@ func EvaluateCustomLabels(authJSON string) (map[string]string, error) {
 	return customLabels, nil
 }
 
+// buildFinalLabels constructs the final label values by combining base labels with custom labels
+func buildFinalLabels(authJSON string, baseLabels ...string) []string {
+	labels := make([]string, len(baseLabels))
+	copy(labels, baseLabels)
+
+	// If custom metrics are enabled, append custom label values
+	if CustomMetricsEnabled && len(CustomMetricLabels) > 0 && authJSON != "" {
+		if customLabels, err := EvaluateCustomLabels(authJSON); err == nil {
+			// Append custom label values in consistent order
+			for labelName := range CustomMetricLabels {
+				if value, exists := customLabels[labelName]; exists {
+					labels = append(labels, value)
+				} else {
+					labels = append(labels, "")
+				}
+			}
+		} else {
+			// Append empty values for all custom labels if evaluation fails
+			for range CustomMetricLabels {
+				labels = append(labels, "")
+			}
+		}
+	}
+
+	return labels
+}
+
 func NewCounterMetric(name, help string, labels ...string) *prometheus.CounterVec {
 	return prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -76,23 +104,27 @@ func NewDurationMetric(name, help string, labels ...string) *prometheus.Histogra
 	)
 }
 
-func ReportMetric(metric *prometheus.CounterVec, labels ...string) {
-	metric.WithLabelValues(labels...).Inc()
+func ReportMetric(metric *prometheus.CounterVec, authJSON string, labels ...string) {
+	finalLabels := buildFinalLabels(authJSON, labels...)
+	metric.WithLabelValues(finalLabels...).Inc()
 }
 
-func ReportMetricWithStatus(metric *prometheus.CounterVec, status string, labels ...string) {
-	ReportMetric(metric, extendLabelValuesWithStatus(status, labels...)...)
+func ReportMetricWithStatus(metric *prometheus.CounterVec, status string, authJSON string, labels ...string) {
+	baseLabels := extendLabelValuesWithStatus(status, labels...)
+	ReportMetric(metric, authJSON, baseLabels...)
 }
 
-func ReportMetricWithObject(metric *prometheus.CounterVec, obj Object, labels ...string) {
-	if labels, err := extendLabelValuesWithObject(obj, labels...); err == nil {
-		ReportMetric(metric, labels...)
+func ReportMetricWithObject(metric *prometheus.CounterVec, obj Object, authJSON string, labels ...string) {
+	if extendedLabels, err := extendLabelValuesWithObject(obj, labels...); err == nil {
+		ReportMetric(metric, authJSON, extendedLabels...)
 	}
 }
 
-func ReportTimedMetric(metric *prometheus.HistogramVec, f func(), labels ...string) {
+func ReportTimedMetric(metric *prometheus.HistogramVec, f func(), authJSON string, labels ...string) {
+	finalLabels := buildFinalLabels(authJSON, labels...)
+
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(value float64) {
-		metric.WithLabelValues(labels...).Observe(value)
+		metric.WithLabelValues(finalLabels...).Observe(value)
 	}))
 
 	defer func() {
@@ -102,87 +134,17 @@ func ReportTimedMetric(metric *prometheus.HistogramVec, f func(), labels ...stri
 	f()
 }
 
-func ReportTimedMetricWithStatus(metric *prometheus.HistogramVec, f func(), status string, labels ...string) {
-	ReportTimedMetric(metric, f, extendLabelValuesWithStatus(status, labels...)...)
+func ReportTimedMetricWithStatus(metric *prometheus.HistogramVec, f func(), status string, authJSON string, labels ...string) {
+	baseLabels := extendLabelValuesWithStatus(status, labels...)
+	ReportTimedMetric(metric, f, authJSON, baseLabels...)
 }
 
-func ReportTimedMetricWithObject(metric *prometheus.HistogramVec, f func(), obj Object, labels ...string) {
-	if labels, err := extendLabelValuesWithObject(obj, labels...); err == nil {
-		ReportTimedMetric(metric, f, labels...)
+func ReportTimedMetricWithObject(metric *prometheus.HistogramVec, f func(), obj Object, authJSON string, labels ...string) {
+	if extendedLabels, err := extendLabelValuesWithObject(obj, labels...); err == nil {
+		ReportTimedMetric(metric, f, authJSON, extendedLabels...)
 	} else {
 		f()
 	}
-}
-
-func ReportMetricWithCustomLabels(metric *prometheus.CounterVec, authJSON string, baseLabels ...string) {
-	labels := make([]string, len(baseLabels))
-	copy(labels, baseLabels)
-
-	if customLabels, err := EvaluateCustomLabels(authJSON); err == nil {
-		// Append custom label values in the same order as they appear in CustomMetricLabels
-		for labelName := range CustomMetricLabels {
-			if value, exists := customLabels[labelName]; exists {
-				labels = append(labels, value)
-			} else {
-				labels = append(labels, "")
-			}
-		}
-	} else {
-		// Append empty values for all custom labels if evaluation fails
-		for range CustomMetricLabels {
-			labels = append(labels, "")
-		}
-	}
-
-	metric.WithLabelValues(labels...).Inc()
-}
-
-func ReportTimedMetricWithCustomLabels(metric *prometheus.HistogramVec, f func(), authJSON string, baseLabels ...string) {
-	labels := make([]string, len(baseLabels))
-	copy(labels, baseLabels)
-
-	if customLabels, err := EvaluateCustomLabels(authJSON); err == nil {
-		for labelName := range CustomMetricLabels {
-			if value, exists := customLabels[labelName]; exists {
-				labels = append(labels, value)
-			} else {
-				labels = append(labels, "")
-			}
-		}
-	} else {
-		for range CustomMetricLabels {
-			labels = append(labels, "")
-		}
-	}
-
-	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(value float64) {
-		metric.WithLabelValues(labels...).Observe(value)
-	}))
-
-	defer timer.ObserveDuration()
-	f()
-}
-
-func ReportMetricWithStatusAndCustomLabels(metric *prometheus.CounterVec, status string, authJSON string, baseLabels ...string) {
-	labels := make([]string, len(baseLabels))
-	copy(labels, baseLabels)
-	labels = append(labels, status) // Add status to base labels
-
-	if customLabels, err := EvaluateCustomLabels(authJSON); err == nil {
-		for labelName := range CustomMetricLabels {
-			if value, exists := customLabels[labelName]; exists {
-				labels = append(labels, value)
-			} else {
-				labels = append(labels, "")
-			}
-		}
-	} else {
-		for range CustomMetricLabels {
-			labels = append(labels, "")
-		}
-	}
-
-	metric.WithLabelValues(labels...).Inc()
 }
 
 func extendLabelValuesWithStatus(status string, baseLabels ...string) []string {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -12,13 +12,13 @@ import (
 
 func TestReportMetric(t *testing.T) {
 	metric := NewCounterMetric("foo", "Foo metric")
-	ReportMetric(metric)
+	ReportMetric(metric, "")
 	assert.Equal(t, 1, testutil.CollectAndCount(metric))
 }
 
 func TestReportMetricWithStatus(t *testing.T) {
 	metric := NewCounterMetric("foo", "Foo metric", "status")
-	ReportMetricWithStatus(metric, "OK")
+	ReportMetricWithStatus(metric, "OK", "")
 	assert.Equal(t, float64(1), testutil.ToFloat64(metric.WithLabelValues("OK")))
 	assert.Equal(t, float64(0), testutil.ToFloat64(metric.WithLabelValues("NOK")))
 }
@@ -34,15 +34,15 @@ func TestReportMetricWithObject(t *testing.T) {
 	object.EXPECT().GetName().Return("foo")
 
 	object.EXPECT().MetricsEnabled().Return(true)
-	ReportMetricWithObject(metric, object)
+	ReportMetricWithObject(metric, object, "")
 	assert.Equal(t, float64(1), testutil.ToFloat64(metric))
 	assert.Equal(t, float64(1), testutil.ToFloat64(metric.WithLabelValues("AUTHZ_X", "foo")))
 
 	object.EXPECT().MetricsEnabled().Return(false)
-	ReportMetricWithObject(metric, object)
+	ReportMetricWithObject(metric, object, "")
 	assert.Equal(t, float64(1), testutil.ToFloat64(metric))
 
-	ReportMetricWithObject(metric, nil)
+	ReportMetricWithObject(metric, nil, "")
 	assert.Equal(t, float64(1), testutil.ToFloat64(metric))
 }
 
@@ -52,7 +52,7 @@ func TestReportTimedMetric(t *testing.T) {
 	f := func() {
 		invoked = true
 	}
-	ReportTimedMetric(metric, f)
+	ReportTimedMetric(metric, f, "")
 	assert.Equal(t, 1, testutil.CollectAndCount(metric))
 	assert.Check(t, invoked)
 }
@@ -63,7 +63,7 @@ func TestReportTimedMetricWithStatus(t *testing.T) {
 	f := func() {
 		invoked = true
 	}
-	ReportTimedMetricWithStatus(metric, f, "OK")
+	ReportTimedMetricWithStatus(metric, f, "OK", "")
 	assert.Equal(t, 1, testutil.CollectAndCount(metric))
 	assert.Check(t, invoked)
 }
@@ -83,13 +83,13 @@ func TestReportTimedMetricWithObject(t *testing.T) {
 	object.EXPECT().GetName().Return("foo")
 
 	object.EXPECT().MetricsEnabled().Return(true)
-	ReportTimedMetricWithObject(metric, f, object)
+	ReportTimedMetricWithObject(metric, f, object, "")
 	assert.Equal(t, 1, testutil.CollectAndCount(metric))
 	assert.Check(t, invoked)
 
 	invoked = false
 	object.EXPECT().MetricsEnabled().Return(false)
-	ReportTimedMetricWithObject(metric, f, object)
+	ReportTimedMetricWithObject(metric, f, object, "")
 	assert.Equal(t, 1, testutil.CollectAndCount(metric))
 	assert.Check(t, invoked)
 }
@@ -106,11 +106,11 @@ func TestDeepMetricsEnabled(t *testing.T) {
 
 	DeepMetricsEnabled = true
 	object.EXPECT().MetricsEnabled().Return(false)
-	ReportMetricWithObject(metric, object)
+	ReportMetricWithObject(metric, object, "")
 	assert.Equal(t, 1, testutil.CollectAndCount(metric))
 
 	DeepMetricsEnabled = false
 	object.EXPECT().MetricsEnabled().Return(false)
-	ReportMetricWithObject(metric, object)
+	ReportMetricWithObject(metric, object, "")
 	assert.Equal(t, 1, testutil.CollectAndCount(metric)) // does not change
 }

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -231,7 +231,7 @@ func (a *AuthService) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		closeWithStatus(respStatusCode, resp, ctx, func() {
 			_, _ = resp.Write(respBody)
 		})
-	})
+	}, "")
 }
 
 // Check performs authorization check based on the attributes associated with the incoming request,
@@ -464,7 +464,7 @@ func buildEnvoyDynamicMetadata(data map[string]interface{}) (*structpb.Struct, e
 }
 
 func reportStatusMetric(rpcStatusCode rpc.Code) {
-	metrics.ReportMetricWithStatus(authServerResponseStatusMetric, rpc.Code_name[int32(rpcStatusCode)])
+	metrics.ReportMetricWithStatus(authServerResponseStatusMetric, rpc.Code_name[int32(rpcStatusCode)], "")
 }
 
 func admissionReviewFromPayload(payload []byte) *v1.AdmissionReview {
@@ -481,7 +481,7 @@ func admissionReviewFromPayload(payload []byte) *v1.AdmissionReview {
 
 // Writes the response status code to the raw HTTP external authorization and cancels the context
 func closeWithStatus(respStatusCode envoy_type.StatusCode, response http.ResponseWriter, ctx gocontext.Context, closingFunc func()) {
-	metrics.ReportMetric(httpServerHandledTotal, respStatusCode.String())
+	metrics.ReportMetric(httpServerHandledTotal, "", respStatusCode.String())
 	if respStatusCode != envoy_type.StatusCode_OK { // avoids 'http: superfluous response.WriteHeader call'
 		response.WriteHeader(int(respStatusCode))
 	}

--- a/pkg/service/auth_pipeline.go
+++ b/pkg/service/auth_pipeline.go
@@ -576,28 +576,36 @@ func (pipeline *AuthPipeline) GetAuthorizationJSON() string {
 	// metadata
 	metadata := make(map[string]interface{})
 	for config, obj := range pipeline.getMetadataObjs() {
-		metadata[config.Name] = obj
+		if config != nil {
+			metadata[config.Name] = obj
+		}
 	}
 	authData["metadata"] = metadata
 
 	// authorization
 	authorization := make(map[string]interface{})
 	for config, obj := range pipeline.getAuthorizationObjs() {
-		authorization[config.Name] = obj
+		if config != nil {
+			authorization[config.Name] = obj
+		}
 	}
 	authData["authorization"] = authorization
 
 	// response
 	response := make(map[string]interface{})
 	for config, obj := range pipeline.getResponseObjs() {
-		response[config.Name] = obj
+		if config != nil {
+			response[config.Name] = obj
+		}
 	}
 	authData["response"] = response
 
 	// callbacks
 	callbacks := make(map[string]interface{})
 	for config, obj := range pipeline.getCallbackObjs() {
-		callbacks[config.Name] = obj
+		if config != nil {
+			callbacks[config.Name] = obj
+		}
 	}
 	if len(callbacks) > 0 {
 		authData["callbacks"] = callbacks

--- a/pkg/service/auth_pipeline.go
+++ b/pkg/service/auth_pipeline.go
@@ -17,6 +17,7 @@ import (
 	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/gogo/googleapis/google/rpc"
+	"github.com/prometheus/client_golang/prometheus"
 	gocontext "golang.org/x/net/context"
 )
 
@@ -24,18 +25,37 @@ var (
 	evaluatorMetricLabels = []string{"evaluator_type", "evaluator_name"}
 
 	// evaluator metrics
-	authServerEvaluatorTotalMetric     = metrics.NewAuthConfigCounterMetric("auth_server_evaluator_total", "Total number of evaluations of individual authconfig rule performed by the auth server.", evaluatorMetricLabels...)
-	authServerEvaluatorCancelledMetric = metrics.NewAuthConfigCounterMetric("auth_server_evaluator_cancelled", "Number of evaluations of individual authconfig rule cancelled by the auth server.", evaluatorMetricLabels...)
-	authServerEvaluatorIgnoredMetric   = metrics.NewAuthConfigCounterMetric("auth_server_evaluator_ignored", "Number of evaluations of individual authconfig rule ignored by the auth server.", evaluatorMetricLabels...)
-	authServerEvaluatorDeniedMetric    = metrics.NewAuthConfigCounterMetric("auth_server_evaluator_denied", "Number of denials from individual authconfig rule evaluated by the auth server.", evaluatorMetricLabels...)
-	authServerEvaluatorDurationMetric  = metrics.NewAuthConfigDurationMetric("auth_server_evaluator_duration_seconds", "Response latency of individual authconfig rule evaluated by the auth server (in seconds).", evaluatorMetricLabels...)
+	authServerEvaluatorTotalMetric     *prometheus.CounterVec
+	authServerEvaluatorCancelledMetric *prometheus.CounterVec
+	authServerEvaluatorIgnoredMetric   *prometheus.CounterVec
+	authServerEvaluatorDeniedMetric    *prometheus.CounterVec
+	authServerEvaluatorDurationMetric  *prometheus.HistogramVec
 	// authconfig metrics
-	authServerAuthConfigTotalMetric          = metrics.NewAuthConfigCounterMetric("auth_server_authconfig_total", "Total number of authconfigs enforced by the auth server, partitioned by authconfig.")
-	authServerAuthConfigResponseStatusMetric = metrics.NewAuthConfigCounterMetric("auth_server_authconfig_response_status", "Response status of authconfigs sent by the auth server, partitioned by authconfig.", "status")
-	authServerAuthConfigDurationMetric       = metrics.NewAuthConfigDurationMetric("auth_server_authconfig_duration_seconds", "Response latency of authconfig enforced by the auth server (in seconds).")
+	authServerAuthConfigTotalMetric          *prometheus.CounterVec
+	authServerAuthConfigResponseStatusMetric *prometheus.CounterVec
+	authServerAuthConfigDurationMetric       *prometheus.HistogramVec
+
+	metricsInitialized = false
 )
 
-func init() {
+func InitializeMetrics() {
+	if metricsInitialized {
+		// Metrics already initialized, skip to avoid duplicate registration
+		return
+	}
+
+	// Metrics are created with label sets that depend on metrics.CustomMetricsEnabled at initialization.
+	// At reporting time, the code paths select between custom-label and default-label helpers accordingly.
+	authServerEvaluatorTotalMetric = metrics.NewAuthConfigCounterMetric("auth_server_evaluator_total", "Total number of evaluations of individual authconfig rule performed by the auth server.", evaluatorMetricLabels...)
+	authServerEvaluatorCancelledMetric = metrics.NewAuthConfigCounterMetric("auth_server_evaluator_cancelled", "Number of evaluations of individual authconfig rule cancelled by the auth server.", evaluatorMetricLabels...)
+	authServerEvaluatorIgnoredMetric = metrics.NewAuthConfigCounterMetric("auth_server_evaluator_ignored", "Number of evaluations of individual authconfig rule ignored by the auth server.", evaluatorMetricLabels...)
+	authServerEvaluatorDeniedMetric = metrics.NewAuthConfigCounterMetric("auth_server_evaluator_denied", "Number of denials from individual authconfig rule evaluated by the auth server.", evaluatorMetricLabels...)
+	authServerEvaluatorDurationMetric = metrics.NewAuthConfigDurationMetric("auth_server_evaluator_duration_seconds", "Response latency of individual authconfig rule evaluated by the auth server (in seconds).", evaluatorMetricLabels...)
+	// authconfig metrics
+	authServerAuthConfigTotalMetric = metrics.NewAuthConfigCounterMetric("auth_server_authconfig_total", "Total number of authconfigs enforced by the auth server, partitioned by authconfig.")
+	authServerAuthConfigResponseStatusMetric = metrics.NewAuthConfigCounterMetric("auth_server_authconfig_response_status", "Response status of authconfigs sent by the auth server, partitioned by authconfig.", "status")
+	authServerAuthConfigDurationMetric = metrics.NewAuthConfigDurationMetric("auth_server_authconfig_duration_seconds", "Response latency of authconfig enforced by the auth server (in seconds).")
+
 	metrics.Register(
 		authServerEvaluatorTotalMetric,
 		authServerEvaluatorCancelledMetric,
@@ -46,6 +66,8 @@ func init() {
 		authServerAuthConfigResponseStatusMetric,
 		authServerAuthConfigDurationMetric,
 	)
+
+	metricsInitialized = true
 }
 
 type EvaluationResponse struct {
@@ -109,17 +131,31 @@ type AuthPipeline struct {
 
 func (pipeline *AuthPipeline) evaluateAuthConfig(config auth.AuthConfigEvaluator, ctx gocontext.Context, respChannel *chan EvaluationResponse, successCallback func(), failureCallback func()) {
 	monitorable, _ := config.(metrics.Object)
-	metrics.ReportMetricWithObject(authServerEvaluatorTotalMetric, monitorable, pipeline.metricLabels()...)
+
+	// Report metrics with custom labels if enabled
+	if metrics.CustomMetricsEnabled {
+		metrics.ReportMetricWithCustomLabels(authServerEvaluatorTotalMetric, pipeline.GetAuthorizationJSON(), pipeline.evaluatorMetricLabels(monitorable)...)
+	} else {
+		metrics.ReportMetricWithObject(authServerEvaluatorTotalMetric, monitorable, pipeline.metricLabels()...)
+	}
 
 	if err := context.CheckContext(ctx); err != nil {
 		pipeline.Logger.V(1).Info("skipping config", "config", config, "reason", err)
-		metrics.ReportMetricWithObject(authServerEvaluatorCancelledMetric, monitorable, pipeline.metricLabels()...)
+		if metrics.CustomMetricsEnabled {
+			metrics.ReportMetricWithCustomLabels(authServerEvaluatorCancelledMetric, pipeline.GetAuthorizationJSON(), pipeline.evaluatorMetricLabels(monitorable)...)
+		} else {
+			metrics.ReportMetricWithObject(authServerEvaluatorCancelledMetric, monitorable, pipeline.metricLabels()...)
+		}
 		return
 	}
 
 	if conditionalEv, ok := config.(auth.ConditionalEvaluator); ok {
 		if err := pipeline.evaluateConditions(conditionalEv.GetConditions()); err != nil {
-			metrics.ReportMetricWithObject(authServerEvaluatorIgnoredMetric, monitorable, pipeline.metricLabels()...)
+			if metrics.CustomMetricsEnabled {
+				metrics.ReportMetricWithCustomLabels(authServerEvaluatorIgnoredMetric, pipeline.GetAuthorizationJSON(), pipeline.evaluatorMetricLabels(monitorable)...)
+			} else {
+				metrics.ReportMetricWithObject(authServerEvaluatorIgnoredMetric, monitorable, pipeline.metricLabels()...)
+			}
 			return
 		}
 	}
@@ -128,7 +164,11 @@ func (pipeline *AuthPipeline) evaluateAuthConfig(config auth.AuthConfigEvaluator
 		if authObj, err := config.Call(pipeline, ctx); err != nil {
 			*respChannel <- newEvaluationResponse(config, nil, err)
 
-			metrics.ReportMetricWithObject(authServerEvaluatorDeniedMetric, monitorable, pipeline.metricLabels()...)
+			if metrics.CustomMetricsEnabled {
+				metrics.ReportMetricWithCustomLabels(authServerEvaluatorDeniedMetric, pipeline.GetAuthorizationJSON(), pipeline.evaluatorMetricLabels(monitorable)...)
+			} else {
+				metrics.ReportMetricWithObject(authServerEvaluatorDeniedMetric, monitorable, pipeline.metricLabels()...)
+			}
 
 			if failureCallback != nil {
 				failureCallback()
@@ -142,7 +182,11 @@ func (pipeline *AuthPipeline) evaluateAuthConfig(config auth.AuthConfigEvaluator
 		}
 	}
 
-	metrics.ReportTimedMetricWithObject(authServerEvaluatorDurationMetric, evaluateFunc, monitorable, pipeline.metricLabels()...)
+	if metrics.CustomMetricsEnabled {
+		metrics.ReportTimedMetricWithCustomLabels(authServerEvaluatorDurationMetric, evaluateFunc, pipeline.GetAuthorizationJSON(), pipeline.evaluatorMetricLabels(monitorable)...)
+	} else {
+		metrics.ReportTimedMetricWithObject(authServerEvaluatorDurationMetric, evaluateFunc, monitorable, pipeline.metricLabels()...)
+	}
 }
 
 type authConfigEvaluationStrategy func(conf auth.AuthConfigEvaluator, ctx gocontext.Context, respChannel *chan EvaluationResponse, cancel func())
@@ -452,6 +496,7 @@ func (pipeline *AuthPipeline) setCallbackObj(conf *evaluators.CallbackConfig, ob
 
 // Evaluate evaluates all steps of the auth pipeline (identity → metadata → policy enforcement)
 func (pipeline *AuthPipeline) Evaluate() auth.AuthResult {
+	InitializeMetrics()
 	result := auth.AuthResult{Code: rpc.OK}
 
 	if err := pipeline.evaluateConditions(pipeline.AuthConfig.Conditions); err != nil {
@@ -459,7 +504,11 @@ func (pipeline *AuthPipeline) Evaluate() auth.AuthResult {
 		return result
 	}
 
-	metrics.ReportMetric(authServerAuthConfigTotalMetric, pipeline.metricLabels()...)
+	if metrics.CustomMetricsEnabled {
+		metrics.ReportMetricWithCustomLabels(authServerAuthConfigTotalMetric, pipeline.GetAuthorizationJSON(), pipeline.metricLabels()...)
+	} else {
+		metrics.ReportMetric(authServerAuthConfigTotalMetric, pipeline.metricLabels()...)
+	}
 
 	authResult := make(chan auth.AuthResult)
 
@@ -498,19 +547,40 @@ func (pipeline *AuthPipeline) Evaluate() auth.AuthResult {
 			authResult <- result
 		}
 
-		metrics.ReportTimedMetric(authServerAuthConfigDurationMetric, evaluateFunc, pipeline.metricLabels()...)
+		if metrics.CustomMetricsEnabled {
+			metrics.ReportTimedMetricWithCustomLabels(authServerAuthConfigDurationMetric, evaluateFunc, pipeline.GetAuthorizationJSON(), pipeline.metricLabels()...)
+		} else {
+			metrics.ReportTimedMetric(authServerAuthConfigDurationMetric, evaluateFunc, pipeline.metricLabels()...)
+		}
 	}()
 
 	return <-authResult
 }
 
 func (pipeline *AuthPipeline) reportStatusMetric(rpcStatusCode rpc.Code) {
-	metrics.ReportMetricWithStatus(authServerAuthConfigResponseStatusMetric, rpc.Code_name[int32(rpcStatusCode)], pipeline.metricLabels()...)
+	if metrics.CustomMetricsEnabled {
+		metrics.ReportMetricWithStatusAndCustomLabels(authServerAuthConfigResponseStatusMetric, rpc.Code_name[int32(rpcStatusCode)], pipeline.GetAuthorizationJSON(), pipeline.metricLabels()...)
+	} else {
+		metrics.ReportMetricWithStatus(authServerAuthConfigResponseStatusMetric, rpc.Code_name[int32(rpcStatusCode)], pipeline.metricLabels()...)
+	}
 }
 
 func (pipeline *AuthPipeline) metricLabels() []string {
 	labels := pipeline.AuthConfig.Labels
 	return []string{labels["namespace"], labels["name"]}
+}
+
+// evaluatorMetricLabels extends metricLabels with evaluator-specific labels for custom metrics.
+// When evaluator-level metrics are disabled for a given object (and deep metrics are not enabled),
+// this returns empty placeholders to preserve the expected label cardinality.
+func (pipeline *AuthPipeline) evaluatorMetricLabels(obj metrics.Object) []string {
+	baseLabels := pipeline.metricLabels()
+	if obj != nil && (obj.MetricsEnabled() || metrics.DeepMetricsEnabled) {
+		baseLabels = append(baseLabels, obj.GetType(), obj.GetName())
+	} else {
+		baseLabels = append(baseLabels, "", "")
+	}
+	return baseLabels
 }
 
 func (pipeline *AuthPipeline) GetRequest() *envoy_auth.CheckRequest {

--- a/pkg/service/oidc.go
+++ b/pkg/service/oidc.go
@@ -96,7 +96,7 @@ func (o *OidcService) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 		requestLogger.Info("response sent", "status", statusCode)
 	}
 
-	metrics.ReportMetricWithStatus(oidcServerResponseStatusMetric, strconv.Itoa(statusCode))
+	metrics.ReportMetricWithStatus(oidcServerResponseStatusMetric, strconv.Itoa(statusCode), "")
 }
 
 func (o *OidcService) findWristbandIssuer(realm string, wristbandConfigName string) auth.WristbandIssuer {


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/authorino/issues/553

* Allows loading a yaml file containing pairs of label name : cel expressions to be resolved from auth pipeline that will be emitted as part of the authconfig metrics in `/server-metrics`

Current limitations:
-  Prometheus requires the metric labels to be fixed when initialised. Meaning that the number of labels cannot change during runtime
  - Due to this, if the cel expressions errors, it resolves to an empty value to keep number of labels emitted on the metric the same,
- Changes in labels file does not reload/reinitialise the prometheus metrics
  - Investigated this -> might be done as a follow up PR
- cel expression must be referencing a root binding from the auth json

# Verification
- Create cluster
```
kind create cluster
```
- Install CRD
```
make install
```
- Run with examples labels file
```
 CUSTOM_METRIC_LABELS_FILE=examples/custom-metric-labels.yaml make run
go mod tidy
```
- Create AuthConfig
```
kubectl apply -f -<<EOF                                                                         
apiVersion: authorino.kuadrant.io/v1beta3
kind: AuthConfig
metadata:
  name: talker-api-protection
spec:
  hosts:
  - localhost:5001
  authentication:
    "friends":
      apiKey:
        selector:
          matchLabels:
            group: friends
      credentials:
        authorizationHeader:
          prefix: APIKEY
EOF
```
- Curl `/check` to give 401 to generate metrics
```
 curl -H 'Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx'  http://localhost:5001/check -v
```

- Curl metrics server to view metrics
```
curl localhost:8080/server-metrics 
```
