### PR TITLE
gha: do not build sha image tag for releases

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -113,7 +113,7 @@ jobs:
           images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino
           tags: |
             type=raw,value=${{ github.ref_name }},enable={{is_not_default_branch}}
-            type=raw,value=${{ github.sha }}
+            type=raw,value=${{ github.sha }},enable={{is_default_branch}}
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Login to registry
         if: ${{ !env.ACT }}


### PR DESCRIPTION
# Description
Part of: https://github.com/Kuadrant/kuadrant-operator/issues/1752

Do not push SHA image tag for releases as this recreate the manifests and links the previous git sha tag with the release image tag rather than the latest tag

Ran on my own fork:
- Main run - https://github.com/KevFan/authorino/actions/runs/22761814801
- Release run - https://github.com/KevFan/authorino/actions/runs/22761907730

Quay images:
- https://quay.io/repository/kevfan/authorino?tab=tags