### PR TITLE
hotfix: reduce complexity budget of the CEL validation for x509.source

### DIFF
--- a/api/v1beta3/auth_config_types.go
+++ b/api/v1beta3/auth_config_types.go
@@ -423,7 +423,7 @@ type X509ClientCertificateAuthenticationSpec struct {
 
 // Defines where to extract the client certificate from.
 //
-//	+kubebuilder:validation:XValidation:rule="(has(self.xfccHeader) && self.xfccHeader != '' ? 1 : 0) + (has(self.clientCertHeader) && self.clientCertHeader != '' ? 1 : 0) + (has(self.expression) && self.expression != '' ? 1 : 0) <= 1",message="Use one of: xfccHeader, clientCertHeader, expression"
+//	+kubebuilder:validation:XValidation:rule="(has(self.xfccHeader) ? 1 : 0) + (has(self.clientCertHeader) ? 1 : 0) + (has(self.expression) ? 1 : 0) <= 1",message="Use one of: xfccHeader, clientCertHeader, expression"
 type X509CertificateSource struct {
 	// Name of the X-Forwarded-Client-Cert (XFCC) HTTP header containing the client certificate.
 	// Use this option when Authorino is deployed behind a proxy that terminates TLS and forwards the client certificate

--- a/install/crd/authorino.kuadrant.io_authconfigs.yaml
+++ b/install/crd/authorino.kuadrant.io_authconfigs.yaml
@@ -2786,10 +2786,8 @@ spec:
                           type: object
                           x-kubernetes-validations:
                           - message: 'Use one of: xfccHeader, clientCertHeader, expression'
-                            rule: '(has(self.xfccHeader) && self.xfccHeader != ''''
-                              ? 1 : 0) + (has(self.clientCertHeader) && self.clientCertHeader
-                              != '''' ? 1 : 0) + (has(self.expression) && self.expression
-                              != '''' ? 1 : 0) <= 1'
+                            rule: '(has(self.xfccHeader) ? 1 : 0) + (has(self.clientCertHeader)
+                              ? 1 : 0) + (has(self.expression) ? 1 : 0) <= 1'
                       required:
                       - selector
                       type: object

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -3077,10 +3077,8 @@ spec:
                           type: object
                           x-kubernetes-validations:
                           - message: 'Use one of: xfccHeader, clientCertHeader, expression'
-                            rule: '(has(self.xfccHeader) && self.xfccHeader != ''''
-                              ? 1 : 0) + (has(self.clientCertHeader) && self.clientCertHeader
-                              != '''' ? 1 : 0) + (has(self.expression) && self.expression
-                              != '''' ? 1 : 0) <= 1'
+                            rule: '(has(self.xfccHeader) ? 1 : 0) + (has(self.clientCertHeader)
+                              ? 1 : 0) + (has(self.expression) ? 1 : 0) <= 1'
                       required:
                       - selector
                       type: object


### PR DESCRIPTION
Hotfix for: #585

### Verification steps

```sh
kind create cluster
make install
```

Without the fix:

```
clusterrole.rbac.authorization.k8s.io/authorino-authconfig-editor-role created
clusterrole.rbac.authorization.k8s.io/authorino-authconfig-viewer-role created
clusterrole.rbac.authorization.k8s.io/authorino-manager-k8s-auth-role created
clusterrole.rbac.authorization.k8s.io/authorino-manager-role created
The CustomResourceDefinition "authconfigs.authorino.kuadrant.io" is invalid: spec.versions[1].schema.openAPIV3Schema.properties[spec].properties[authentication].additionalProperties.properties[x509].properties[source].x-kubernetes-validations[0].rule: Forbidden: estimated rule cost exceeds budget by factor of 1.258291x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared)
```

With the fix:
```
customresourcedefinition.apiextensions.k8s.io/authconfigs.authorino.kuadrant.io created
clusterrole.rbac.authorization.k8s.io/authorino-authconfig-editor-role created
clusterrole.rbac.authorization.k8s.io/authorino-authconfig-viewer-role created
clusterrole.rbac.authorization.k8s.io/authorino-manager-k8s-auth-role created
clusterrole.rbac.authorization.k8s.io/authorino-manager-role created
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated X.509 certificate source field validation to check for field presence rather than requiring non-empty values, allowing more flexible certificate source configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->