### PR TITLE
fix data races found in the tests

### DIFF
--- a/pkg/evaluators/authorization/opa.go
+++ b/pkg/evaluators/authorization/opa.go
@@ -116,6 +116,13 @@ func (opa *OPA) Clean(_ context.Context) error {
 	return opa.ExternalSource.cleanupRefresher()
 }
 
+// GetRego returns the current Rego policy in a thread-safe manner
+func (opa *OPA) GetRego() string {
+	opa.mu.RLock()
+	defer opa.mu.RUnlock()
+	return opa.Rego
+}
+
 func (opa *OPA) updateRego(rego string, ctx context.Context, force bool) (bool, error) {
 	opa.mu.Lock()
 	defer opa.mu.Unlock()

--- a/pkg/evaluators/authorization/opa_test.go
+++ b/pkg/evaluators/authorization/opa_test.go
@@ -153,11 +153,11 @@ func TestOPAExternalUrlWithTTL(t *testing.T) {
 	}(opa)
 
 	assert.NilError(t, err)
-	assert.Check(t, strings.Contains(opa.Rego, "GET"))
+	assert.Check(t, strings.Contains(opa.GetRego(), "GET"))
 	assert.Check(t, opa.ExternalSource.refresher != nil)
 
 	time.Sleep(4 * time.Second)
-	assert.Check(t, strings.Contains(opa.Rego, "POST"))
+	assert.Check(t, strings.Contains(opa.GetRego(), "POST"))
 }
 
 func TestOPAClean(t *testing.T) {

--- a/pkg/evaluators/identity/jwt.go
+++ b/pkg/evaluators/identity/jwt.go
@@ -155,6 +155,13 @@ func (v *oidcProviderVerifier) Clean(ctx gocontext.Context) error {
 	return v.refresher.Stop()
 }
 
+// GetProvider returns the current OIDC provider in a thread-safe manner
+func (v *oidcProviderVerifier) GetProvider() *oidc.Provider {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return v.provider
+}
+
 func (v *oidcProviderVerifier) getOpenIdProvider(ctx gocontext.Context, force bool) *oidc.Provider {
 	v.mu.Lock()
 	defer v.mu.Unlock()

--- a/pkg/evaluators/identity/jwt_test.go
+++ b/pkg/evaluators/identity/jwt_test.go
@@ -3,6 +3,7 @@ package identity
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -126,11 +127,15 @@ func TestOIDCProviderVerifierInternalError(t *testing.T) {
 }
 
 func TestOIDCProviderVerifierRefresh(t *testing.T) {
+	var mu sync.Mutex
 	count := 0
 	authServer := httptest.NewHttpServerMock(oidcServerHost, map[string]httptest.HttpServerMockResponseFunc{
 		"/.well-known/openid-configuration": func() httptest.HttpServerMockResponse {
+			mu.Lock()
 			count += 1
-			return oidcServerMockResponse(count)
+			currentCount := count
+			mu.Unlock()
+			return oidcServerMockResponse(currentCount)
 		},
 	})
 	defer authServer.Close()
@@ -149,9 +154,13 @@ func TestOIDCProviderVerifierRefresh(t *testing.T) {
 	assert.Check(t, verifier.refresher != nil)
 
 	time.Sleep(4 * time.Second)
-	assert.Equal(t, 2, count)
+	mu.Lock()
+	currentCount := count
+	mu.Unlock()
+	assert.Equal(t, 2, currentCount)
 	verifier, _ = jwtVerifier.(*oidcProviderVerifier)
-	assert.Equal(t, fmt.Sprintf("http://%v/auth?count=2", oidcServerHost), verifier.provider.Endpoint().AuthURL)
+	provider := verifier.GetProvider()
+	assert.Equal(t, fmt.Sprintf("http://%v/auth?count=2", oidcServerHost), provider.Endpoint().AuthURL)
 }
 
 func TestOIDCProviderVerifierRefreshDisabled(t *testing.T) {

--- a/pkg/workers/worker_test.go
+++ b/pkg/workers/worker_test.go
@@ -2,6 +2,7 @@ package workers
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -9,35 +10,53 @@ import (
 )
 
 func TestStartWorker(t *testing.T) {
+	var mu sync.Mutex
 	val := 0
 	worker, err := StartWorker(context.TODO(), 2, func() {
+		mu.Lock()
 		val += 1
+		mu.Unlock()
 	})
 	defer func(worker Worker) {
 		_ = worker.Stop()
 	}(worker)
 	assert.NilError(t, err)
 
-	assert.Equal(t, val, 0)
+	mu.Lock()
+	currentVal := val
+	mu.Unlock()
+	assert.Equal(t, currentVal, 0)
 
 	time.Sleep(3 * time.Second)
 
-	assert.Equal(t, val, 1)
+	mu.Lock()
+	currentVal = val
+	mu.Unlock()
+	assert.Equal(t, currentVal, 1)
 }
 
 func TestStopWorker(t *testing.T) {
+	var mu sync.Mutex
 	val := 0
 	worker, err := StartWorker(context.TODO(), 2, func() {
+		mu.Lock()
 		val += 1
+		mu.Unlock()
 	})
 	assert.NilError(t, err)
 
-	assert.Equal(t, val, 0)
+	mu.Lock()
+	currentVal := val
+	mu.Unlock()
+	assert.Equal(t, currentVal, 0)
 
 	err = worker.Stop()
 	assert.NilError(t, err)
 
 	time.Sleep(3 * time.Second)
 
-	assert.Equal(t, val, 0)
+	mu.Lock()
+	currentVal = val
+	mu.Unlock()
+	assert.Equal(t, currentVal, 0)
 }


### PR DESCRIPTION
Fixes #572

### How to the test this PR

```sh
go test -race ./pkg/evaluators/authorization/ ./pkg/evaluators/identity/ ./pkg/workers/
```

Expected output:

```
ok  	github.com/kuadrant/authorino/pkg/evaluators/authorization	6.380s
ok  	github.com/kuadrant/authorino/pkg/evaluators/identity	12.742s
ok  	github.com/kuadrant/authorino/pkg/workers	7.661s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved internal thread-safety mechanisms to prevent race conditions in concurrent execution scenarios.
  * Enhanced synchronisation protocols across authorisation and identity verification systems for improved stability.

* **Tests**
  * Strengthened test reliability and robustness across multi-threaded operations.
  * Added comprehensive race condition detection and prevention measures throughout the test suite.
  * Enhanced test coverage for concurrent access patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->