### PR TITLE
controllers/auth_config_controller: nil-guard optional user on kubernetesSubjectAccessReview

### DIFF
--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -578,10 +578,21 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 			}
 
 		case api.KubernetesSubjectAccessReviewAuthorization:
-			user := authorization.KubernetesSubjectAccessReview.User
-			authorinoUser, err := valueFrom(user)
-			if err != nil {
-				return nil, err
+			// The `user` field on kubernetesSubjectAccessReview is optional:
+			// omitting it is a valid way to request a group-only or self-SAR
+			// check. Guard against the nil pointer here so we don't segfault
+			// the controller's Reconcile (authorino then keeps crash-looping
+			// on every AuthConfig event). NewKubernetesAuthz + jsonValueToStr
+			// already treat a nil expressions.Value as "no user", which maps
+			// to SubjectAccessReviewSpec.User == "" and the Kubernetes API
+			// evaluates it as expected.
+			var authorinoUser expressions.Value
+			if user := authorization.KubernetesSubjectAccessReview.User; user != nil {
+				var err error
+				authorinoUser, err = valueFrom(user)
+				if err != nil {
+					return nil, err
+				}
 			}
 
 			var authorinoResourceAttributes *authorization_evaluators.KubernetesAuthzResourceAttributes


### PR DESCRIPTION
## What

`translateAuthConfig` in `controllers/auth_config_controller.go` handles `KubernetesSubjectAccessReviewAuthorization` with:

```go
case api.KubernetesSubjectAccessReviewAuthorization:
    user := authorization.KubernetesSubjectAccessReview.User
    authorinoUser, err := valueFrom(user)
    if err != nil {
        return nil, err
    }
    ...
```

`KubernetesSubjectAccessReview.User` is a `*ValueOrSelector` — a pointer — and the AuthConfig spec treats it as optional. A group-only SAR rule (only `groups:` set) or an implicit self-SAR doesn't have to spell out `user:`. When the caller omits it the pointer is `nil`, and the first deref inside `valueFrom` (`user.Expression != ""`) panics.

```go
// line 814
if user.Expression != "" {  // nil pointer deref when user == nil
```

Per #494: `sigs.k8s.io/controller-runtime` recovers the panic but then re-enqueues the reconcile, so the controller crash-loops on every AuthConfig event. The user-visible symptom is an otherwise-valid `AuthPolicy` like:

```yaml
rules:
  authorization:
    "k8s-rbac":
      kubernetesSubjectAccessReview:
        groups:
          - "some-group"
```

taking the whole authorino pod into a restart loop.

## Fix

The sibling optional fields on the same evaluator (`ResourceAttributes`, `AuthorizationGroups`) are already guarded by nil-checks at the caller level. Match that pattern for `User`: declare `authorinoUser` as a zero `expressions.Value` and only populate it when the caller supplied a `User` spec.

```go
var authorinoUser expressions.Value
if user := authorization.KubernetesSubjectAccessReview.User; user != nil {
    var err error
    authorinoUser, err = valueFrom(user)
    if err != nil {
        return nil, err
    }
}
```

Downstream, `NewKubernetesAuthz` + `jsonValueToStr` already treat a nil `expressions.Value` as "no user":

```go
jsonValueToStr := func(value expressions.Value) (string, error) {
    if value == nil {
        return "", nil
    }
    ...
}
```

which becomes `SubjectAccessReviewSpec.User == ""` on the wire, and the Kubernetes API evaluates it as expected (group-only / self-SAR). No behaviour change for any `AuthConfig` that does set `user:`.

Fixes #494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Resolved a crash in Kubernetes Subject Access Review authorisation when the User field was not provided in the configuration. The system now correctly handles configurations where the User field is optional, improving stability and allowing administrators to define authorisation policies with greater flexibility without requiring explicit User specifications in all cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->