### PR TITLE
Add CEL validation for KubernetesSubjectAccessReview fields

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -31,6 +31,9 @@ jobs:
       - name: Run make test
         run: |
           make test
+      - name: Run CEL validation tests
+        run: |
+          make test-cel
       - name: Run test benchmarks
         run: |
           make benchmarks

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ ENVTEST_K8S_VERSION ?= $(K8S_VERSION)
 MOCKGEN_VERSION ?= v0.6.0
 BENCHSTAT_VERSION ?= latest
 GOLANGCI_LINT_VERSION ?= v2.1.6
+GO_VERSION ?= $(shell awk '/^go / {print $$2}' go.mod)
 
 ## Versioned Binaries (the actual files that 'make' will check for)
 KIND_V_BINARY := $(LOCALBIN)/kind-$(KIND_VERSION)
@@ -197,14 +198,14 @@ docker-build: ## Builds an image based on the current branch
 		-t $(AUTHORINO_IMAGE) .
 
 test: generate manifests envtest ## Runs the tests
-	KUBEBUILDER_ASSETS='$(strip $(shell $(ENVTEST) use -p path $(ENVTEST_K8S_VERSION) --os $(OS) --use-deprecated-gcs=false))' go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS='$(strip $(shell $(ENVTEST) use -p path $(ENVTEST_K8S_VERSION) --os $(OS) --use-deprecated-gcs=false))' GOTOOLCHAIN=go$(GO_VERSION)+auto go test ./api/... ./controllers/... ./pkg/... -coverprofile cover.out
 
 test-cel: generate manifests envtest ## Runs CEL validation tests
-	KUBEBUILDER_ASSETS='$(strip $(shell $(ENVTEST) use -p path $(ENVTEST_K8S_VERSION) --os $(OS) --use-deprecated-gcs=false))' go test ./tests/cel/v1beta3/... -v
+	KUBEBUILDER_ASSETS='$(strip $(shell $(ENVTEST) use -p path $(ENVTEST_K8S_VERSION) --os $(OS) --use-deprecated-gcs=false))' GOTOOLCHAIN=go$(GO_VERSION)+auto go test ./tests/cel/...
 
 BENCHMARKS_FILE=benchmarks.out
 benchmarks: generate manifests envtest benchstat ## Runs the test with benchmarks
-	KUBEBUILDER_ASSETS='$(strip $(shell $(ENVTEST) use -p path $(ENVTEST_K8S_VERSION) --os $(OS) --use-deprecated-gcs=false))' go test ./... -bench=. -run=^Benchmark -count=10 -cpu=1,4,10 -benchmem | tee $(BENCHMARKS_FILE)
+	KUBEBUILDER_ASSETS='$(strip $(shell $(ENVTEST) use -p path $(ENVTEST_K8S_VERSION) --os $(OS) --use-deprecated-gcs=false))' GOTOOLCHAIN=go$(GO_VERSION)+auto go test ./... -bench=. -run=^Benchmark -count=10 -cpu=1,4,10 -benchmem | tee $(BENCHMARKS_FILE)
 	$(MAKE) report-benchmarks
 
 report-benchmarks:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # Use bash as shell
 SHELL = /bin/bash
 
+# Detect OS for envtest
+OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+
 # Use vi as default editor
 EDITOR ?= vi
 
@@ -69,11 +72,13 @@ BENCHSTAT ?= $(LOCALBIN)/benchstat
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
-KIND_VERSION ?= v0.20.0
+KIND_VERSION ?= v0.31.0
 KUSTOMIZE_VERSION ?= v5.5.0
 CONTROLLER_GEN_VERSION ?= v0.19.0
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
+K8S_VERSION ?= 1.28.3
+ENVTEST_K8S_VERSION ?= $(K8S_VERSION)
 MOCKGEN_VERSION ?= v0.6.0
 BENCHSTAT_VERSION ?= latest
 GOLANGCI_LINT_VERSION ?= v2.1.6
@@ -151,7 +156,7 @@ endef
 
 ##@ Development
 
-.PHONY: vendor fmt vet generate manifests run build test benchmarks cover e2e docker-build
+.PHONY: vendor fmt vet generate manifests run build test test-cel benchmarks cover e2e docker-build
 
 vendor: ## Downloads vendor dependencies
 	go mod tidy
@@ -192,11 +197,14 @@ docker-build: ## Builds an image based on the current branch
 		-t $(AUTHORINO_IMAGE) .
 
 test: generate manifests envtest ## Runs the tests
-	KUBEBUILDER_ASSETS='$(strip $(shell $(ENVTEST) use -p path 1.21.2 --os linux))' go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS='$(strip $(shell $(ENVTEST) use -p path $(ENVTEST_K8S_VERSION) --os $(OS) --use-deprecated-gcs=false))' go test ./... -coverprofile cover.out
+
+test-cel: generate manifests envtest ## Runs CEL validation tests
+	KUBEBUILDER_ASSETS='$(strip $(shell $(ENVTEST) use -p path $(ENVTEST_K8S_VERSION) --os $(OS) --use-deprecated-gcs=false))' go test ./tests/cel/v1beta3/... -v
 
 BENCHMARKS_FILE=benchmarks.out
 benchmarks: generate manifests envtest benchstat ## Runs the test with benchmarks
-	KUBEBUILDER_ASSETS='$(strip $(shell $(ENVTEST) use -p path 1.21.2 --os linux))' go test ./... -bench=. -run=^Benchmark -count=10 -cpu=1,4,10 -benchmem | tee $(BENCHMARKS_FILE)
+	KUBEBUILDER_ASSETS='$(strip $(shell $(ENVTEST) use -p path $(ENVTEST_K8S_VERSION) --os $(OS) --use-deprecated-gcs=false))' go test ./... -bench=. -run=^Benchmark -count=10 -cpu=1,4,10 -benchmem | tee $(BENCHMARKS_FILE)
 	$(MAKE) report-benchmarks
 
 report-benchmarks:

--- a/api/v1beta3/auth_config_types.go
+++ b/api/v1beta3/auth_config_types.go
@@ -662,16 +662,28 @@ type ExternalOpaPolicy struct {
 }
 
 // Parameters of the Kubernetes SubjectAccessReview request.
+// +kubebuilder:validation:XValidation:rule="has(self.user) || size(self.groups) > 0 || has(self.authorizationGroups)",message="At least one of user, groups, or authorizationGroups must be specified"
 type KubernetesSubjectAccessReviewAuthorizationSpec struct {
 	// User to check for authorization in the Kubernetes RBAC.
-	// Omit it to check for group authorization only.
+	// Omit it to check for group authorization only (requires groups or authorizationGroups to be specified).
+	//
+	// WARNING: when using dynamic expressions (e.g., with CEL) to set the value of this field,
+	// the expression may evaluate to an empty string for specific requests. If both user and groups/authorizationGroups
+	// resolve to empty values simultaneously at runtime, the Kubernetes API may reject the SubjectAccessReview
+	// and Authorino will deny access.
 	User *ValueOrSelector `json:"user,omitempty"`
 
 	// Groups the user must be a member of or, if `user` is omitted, the groups to check for authorization in the Kubernetes RBAC.
 	// Deprecated: Use authorizationGroups instead.
 	Groups []string `json:"groups,omitempty"`
 
-	// Groups to check for existing permission in the Kubernetes RBAC alternatively to a specific user. This is typically obtained from a list of groups the user is a member of. Must be a static list of group names or dynamically resolve to one from the Authorization JSON.
+	// Groups to check for existing permission in the Kubernetes RBAC alternatively to a specific user.
+	// This is typically obtained from a list of groups the user is a member of.
+	// Must be a static list of group names or dynamically resolve to one from the Authorization JSON.
+	//
+	// WARNING: when using dynamic expressions to set groups, the expression may evaluate to an empty list
+	// for specific requests. If both user and groups/authorizationGroups resolve to empty values simultaneously
+	// at runtime, the Kubernetes API may reject the SubjectAccessReview and Authorino will deny access.
 	AuthorizationGroups *ValueOrSelector `json:"authorizationGroups,omitempty"`
 
 	// Use resourceAttributes to check permissions on Kubernetes resources.

--- a/api/v1beta3/auth_config_types.go
+++ b/api/v1beta3/auth_config_types.go
@@ -662,7 +662,7 @@ type ExternalOpaPolicy struct {
 }
 
 // Parameters of the Kubernetes SubjectAccessReview request.
-// +kubebuilder:validation:XValidation:rule="has(self.user) || size(self.groups) > 0 || has(self.authorizationGroups)",message="At least one of user, groups, or authorizationGroups must be specified"
+// +kubebuilder:validation:XValidation:rule="has(self.user) || (has(self.groups) && size(self.groups) > 0) || has(self.authorizationGroups)",message="At least one of user, groups, or authorizationGroups must be specified"
 type KubernetesSubjectAccessReviewAuthorizationSpec struct {
 	// User to check for authorization in the Kubernetes RBAC.
 	// Omit it to check for group authorization only (requires groups or authorizationGroups to be specified).

--- a/api/v1beta3/auth_config_types.go
+++ b/api/v1beta3/auth_config_types.go
@@ -662,7 +662,8 @@ type ExternalOpaPolicy struct {
 }
 
 // Parameters of the Kubernetes SubjectAccessReview request.
-// +kubebuilder:validation:XValidation:rule="has(self.user) || (has(self.groups) && size(self.groups) > 0) || has(self.authorizationGroups)",message="At least one of user, groups, or authorizationGroups must be specified"
+// +kubebuilder:validation:XValidation:rule="has(self.user) || has(self.groups) || has(self.authorizationGroups)",message="At least one of user, groups, or authorizationGroups must be specified"
+// +kubebuilder:validation:XValidation:rule="has(self.groups) ? size(self.groups) > 0 : true",message="'groups' must not be empty"
 type KubernetesSubjectAccessReviewAuthorizationSpec struct {
 	// User to check for authorization in the Kubernetes RBAC.
 	// Omit it to check for group authorization only (requires groups or authorizationGroups to be specified).

--- a/docs/features.md
+++ b/docs/features.md
@@ -556,6 +556,27 @@ authorization:
 
 An array of `groups` (optional) can as well be set. When defined, it will be used in the `SubjectAccessReview` request.
 
+**Important:** At least one of `user`, `groups`, or `authorizationGroups` must be specified in the AuthConfig. The API will reject configurations where all three fields are omitted.
+
+> [!WARNING] Dynamic expressions for user and groups
+> When using dynamic expressions (e.g., CEL) to set the values of `user` or `groups` (via `authorizationGroups`), be aware that these expressions may evaluate to empty values for specific requests. If both `user` and `groups`/`authorizationGroups` resolve to empty values simultaneously at runtime, the Kubernetes API may reject the SubjectAccessReview request and Authorino will deny access. To avoid this, consider declaring additional authorization rules to short-circuit the evaluation when values would be empty. E.g.:
+>
+> ```yaml
+> authorization:
+>   "deny-if-no-user-or-groups":
+>     patternMatching:
+>       patterns:
+>       - predicate: auth.identity.username != "" && size(auth.identity.groups) > 0
+>     priority: 0
+>   "kubernetes-rbac":
+>     kubernetesSubjectAccessReview:
+>       user:
+>         expression: auth.identity.username
+>       authorizationGroups:
+>         expression: auth.identity.groups
+>     priority: 1
+> ```
+
 ### SpiceDB ([`authorization.spicedb`](https://pkg.go.dev/github.com/kuadrant/authorino/api/v1beta2?utm_source=gopls#SpiceDBAuthorizationSpec))
 
 Check permission requests via gRPC with an external Google Zanzibar-inspired [SpiceDB](https://authzed.com) server, by Authzed.

--- a/install/crd/authorino.kuadrant.io_authconfigs.yaml
+++ b/install/crd/authorino.kuadrant.io_authconfigs.yaml
@@ -2836,11 +2836,14 @@ spec:
                       description: Authorization by Kubernetes SubjectAccessReview
                       properties:
                         authorizationGroups:
-                          description: Groups to check for existing permission in
-                            the Kubernetes RBAC alternatively to a specific user.
-                            This is typically obtained from a list of groups the user
-                            is a member of. Must be a static list of group names or
-                            dynamically resolve to one from the Authorization JSON.
+                          description: |-
+                            Groups to check for existing permission in the Kubernetes RBAC alternatively to a specific user.
+                            This is typically obtained from a list of groups the user is a member of.
+                            Must be a static list of group names or dynamically resolve to one from the Authorization JSON.
+
+                            WARNING: when using dynamic expressions to set groups, the expression may evaluate to an empty list
+                            for specific requests. If both user and groups/authorizationGroups resolve to empty values simultaneously
+                            at runtime, the Kubernetes API may reject the SubjectAccessReview and Authorino will deny access.
                           properties:
                             expression:
                               description: |-
@@ -2990,7 +2993,12 @@ spec:
                         user:
                           description: |-
                             User to check for authorization in the Kubernetes RBAC.
-                            Omit it to check for group authorization only.
+                            Omit it to check for group authorization only (requires groups or authorizationGroups to be specified).
+
+                            WARNING: when using dynamic expressions (e.g., with CEL) to set the value of this field,
+                            the expression may evaluate to an empty string for specific requests. If both user and groups/authorizationGroups
+                            resolve to empty values simultaneously at runtime, the Kubernetes API may reject the SubjectAccessReview
+                            and Authorino will deny access.
                           properties:
                             expression:
                               description: |-
@@ -3008,6 +3016,10 @@ spec:
                               x-kubernetes-preserve-unknown-fields: true
                           type: object
                       type: object
+                      x-kubernetes-validations:
+                      - message: At least one of user, groups, or authorizationGroups
+                          must be specified
+                        rule: has(self.user) || size(self.groups) > 0 || has(self.authorizationGroups)
                     metrics:
                       default: false
                       description: Whether this config should generate individual

--- a/install/crd/authorino.kuadrant.io_authconfigs.yaml
+++ b/install/crd/authorino.kuadrant.io_authconfigs.yaml
@@ -3019,7 +3019,8 @@ spec:
                       x-kubernetes-validations:
                       - message: At least one of user, groups, or authorizationGroups
                           must be specified
-                        rule: has(self.user) || size(self.groups) > 0 || has(self.authorizationGroups)
+                        rule: has(self.user) || (has(self.groups) && size(self.groups)
+                          > 0) || has(self.authorizationGroups)
                     metrics:
                       default: false
                       description: Whether this config should generate individual

--- a/install/crd/authorino.kuadrant.io_authconfigs.yaml
+++ b/install/crd/authorino.kuadrant.io_authconfigs.yaml
@@ -3019,8 +3019,9 @@ spec:
                       x-kubernetes-validations:
                       - message: At least one of user, groups, or authorizationGroups
                           must be specified
-                        rule: has(self.user) || (has(self.groups) && size(self.groups)
-                          > 0) || has(self.authorizationGroups)
+                        rule: has(self.user) || has(self.groups) || has(self.authorizationGroups)
+                      - message: '''groups'' must not be empty'
+                        rule: 'has(self.groups) ? size(self.groups) > 0 : true'
                     metrics:
                       default: false
                       description: Whether this config should generate individual

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -3144,11 +3144,14 @@ spec:
                       description: Authorization by Kubernetes SubjectAccessReview
                       properties:
                         authorizationGroups:
-                          description: Groups to check for existing permission in
-                            the Kubernetes RBAC alternatively to a specific user.
-                            This is typically obtained from a list of groups the user
-                            is a member of. Must be a static list of group names or
-                            dynamically resolve to one from the Authorization JSON.
+                          description: |-
+                            Groups to check for existing permission in the Kubernetes RBAC alternatively to a specific user.
+                            This is typically obtained from a list of groups the user is a member of.
+                            Must be a static list of group names or dynamically resolve to one from the Authorization JSON.
+
+                            WARNING: when using dynamic expressions to set groups, the expression may evaluate to an empty list
+                            for specific requests. If both user and groups/authorizationGroups resolve to empty values simultaneously
+                            at runtime, the Kubernetes API may reject the SubjectAccessReview and Authorino will deny access.
                           properties:
                             expression:
                               description: |-
@@ -3298,7 +3301,12 @@ spec:
                         user:
                           description: |-
                             User to check for authorization in the Kubernetes RBAC.
-                            Omit it to check for group authorization only.
+                            Omit it to check for group authorization only (requires groups or authorizationGroups to be specified).
+
+                            WARNING: when using dynamic expressions (e.g., with CEL) to set the value of this field,
+                            the expression may evaluate to an empty string for specific requests. If both user and groups/authorizationGroups
+                            resolve to empty values simultaneously at runtime, the Kubernetes API may reject the SubjectAccessReview
+                            and Authorino will deny access.
                           properties:
                             expression:
                               description: |-
@@ -3316,6 +3324,10 @@ spec:
                               x-kubernetes-preserve-unknown-fields: true
                           type: object
                       type: object
+                      x-kubernetes-validations:
+                      - message: At least one of user, groups, or authorizationGroups
+                          must be specified
+                        rule: has(self.user) || size(self.groups) > 0 || has(self.authorizationGroups)
                     metrics:
                       default: false
                       description: Whether this config should generate individual

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -3327,8 +3327,9 @@ spec:
                       x-kubernetes-validations:
                       - message: At least one of user, groups, or authorizationGroups
                           must be specified
-                        rule: has(self.user) || (has(self.groups) && size(self.groups)
-                          > 0) || has(self.authorizationGroups)
+                        rule: has(self.user) || has(self.groups) || has(self.authorizationGroups)
+                      - message: '''groups'' must not be empty'
+                        rule: 'has(self.groups) ? size(self.groups) > 0 : true'
                     metrics:
                       default: false
                       description: Whether this config should generate individual

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -3327,7 +3327,8 @@ spec:
                       x-kubernetes-validations:
                       - message: At least one of user, groups, or authorizationGroups
                           must be specified
-                        rule: has(self.user) || size(self.groups) > 0 || has(self.authorizationGroups)
+                        rule: has(self.user) || (has(self.groups) && size(self.groups)
+                          > 0) || has(self.authorizationGroups)
                     metrics:
                       default: false
                       description: Whether this config should generate individual

--- a/tests/cel/README.md
+++ b/tests/cel/README.md
@@ -37,9 +37,6 @@ KUBEBUILDER_ASSETS=$(bin/setup-envtest use -p path 1.28.3) go test ./tests/cel/.
 
 # Run with a specific Kubernetes version
 K8S_VERSION=1.28.0 go test ./tests/cel/... -v
-
-# Run against a real cluster (instead of envtest)
-KUBECONFIG=~/.kube/config go test ./tests/cel/... -v
 ```
 
 ### Run Specific Test
@@ -80,7 +77,6 @@ Failed validation (expected):
 
 ## Environment Variables
 
-- **`KUBECONFIG`**: Path to kubeconfig file. If set, tests run against a real cluster instead of envtest
 - **`K8S_VERSION`**: Kubernetes version for envtest (e.g., `1.28.0`). Defaults to latest GA version
 - **`ENVTEST_K8S_VERSION`**: Alternative name for `K8S_VERSION`
 

--- a/tests/cel/README.md
+++ b/tests/cel/README.md
@@ -1,0 +1,188 @@
+# CEL Validation Tests
+
+This directory contains CEL (Common Expression Language) validation tests for Authorino AuthConfig CRDs. These tests verify that CEL validation rules defined in the CRD schemas work correctly by attempting to create resources via the Kubernetes API.
+
+## Overview
+
+The tests use [envtest](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest) to spin up a real Kubernetes API server with the AuthConfig CRDs installed, then attempt to create AuthConfig resources with various valid and invalid configurations.
+
+## Test Structure
+
+Each version directory under `tests/cel/` contains:
+- **`main_test.go`**: Sets up the envtest environment, installs CRDs, and provides shared test infrastructure
+- **`authconfig_test.go`**: Tests CEL validation rules for AuthConfig
+
+## Running the Tests
+
+### Prerequisites
+
+The tests require:
+- Go 1.25+
+- `controller-gen` tool (for CRD generation)
+- `envtest` binaries (downloaded automatically by the test setup)
+
+### Run Tests
+
+From the repository root:
+
+```bash
+# Run all CEL validation tests
+make test-cel
+
+# Or run directly with go test
+go test ./tests/cel/... -v
+
+# Run with specific envtest binaries (e.g., for Kubernetes 1.28.3)
+KUBEBUILDER_ASSETS=$(bin/setup-envtest use -p path 1.28.3) go test ./tests/cel/... -v
+
+# Run with a specific Kubernetes version
+K8S_VERSION=1.28.0 go test ./tests/cel/... -v
+
+# Run against a real cluster (instead of envtest)
+KUBECONFIG=~/.kube/config go test ./tests/cel/... -v
+```
+
+### Run Specific Test
+
+```bash
+# Run only v1beta3 tests
+go test ./tests/cel/v1beta3/... -v
+
+# Run only the KubernetesSubjectAccessReview validation tests
+go test ./tests/cel/... -v -run TestKubernetesSubjectAccessReviewCELValidation
+
+# Run a specific test case
+go test ./tests/cel/v1beta3/... -v -run TestKubernetesSubjectAccessReviewCELValidation/valid_-_user_specified
+```
+
+## Test Output
+
+Successful test run:
+```text
+=== RUN   TestKubernetesSubjectAccessReviewCELValidation
+=== RUN   TestKubernetesSubjectAccessReviewCELValidation/valid_-_user_specified
+=== RUN   TestKubernetesSubjectAccessReviewCELValidation/valid_-_groups_specified_(static_list)
+=== RUN   TestKubernetesSubjectAccessReviewCELValidation/invalid_-_no_user,_groups,_or_authorizationGroups
+...
+--- PASS: TestKubernetesSubjectAccessReviewCELValidation (2.15s)
+PASS
+```
+
+Failed validation (expected):
+```text
+=== RUN   TestKubernetesSubjectAccessReviewCELValidation/invalid_-_no_user,_groups,_or_authorizationGroups
+    authconfig_sar_test.go:XXX: Got expected validation error:
+        AuthConfig.authorino.kuadrant.io "test-sar-1234567890" is invalid:
+        spec.authorization.k8s-sar.kubernetesSubjectAccessReview: Invalid value: "object":
+        At least one of user, groups, or authorizationGroups must be specified
+--- PASS: TestKubernetesSubjectAccessReviewCELValidation/invalid_-_no_user,_groups,_or_authorizationGroups
+```
+
+## Environment Variables
+
+- **`KUBECONFIG`**: Path to kubeconfig file. If set, tests run against a real cluster instead of envtest
+- **`K8S_VERSION`**: Kubernetes version for envtest (e.g., `1.28.0`). Defaults to latest GA version
+- **`ENVTEST_K8S_VERSION`**: Alternative name for `K8S_VERSION`
+
+## Adding New Tests
+
+To add new CEL validation tests:
+
+1. **Add the CEL validation rule** to the CRD type in `api/v1beta3/auth_config_types.go` (or `api/v1beta2/` for v1beta2):
+   ```go
+   // +kubebuilder:validation:XValidation:rule="your.cel.expression",message="Validation error message"
+   type YourSpec struct {
+       // ...
+   }
+   ```
+
+2. **Regenerate CRDs**:
+   ```bash
+   make manifests
+   ```
+
+3. **Add test cases** to the appropriate version's `authconfig_test.go` file (e.g., `tests/cel/v1beta3/authconfig_test.go`):
+   ```go
+   func TestYourCELValidation(t *testing.T) {
+       ctx := context.Background()
+       baseConfig := YourValidConfig{}
+
+       testCases := []struct {
+           desc       string
+           mutate     func(cfg *YourConfig)
+           wantErrors []string
+       }{
+           {
+               desc: "valid case",
+               mutate: func(cfg *YourConfig) {
+                   // mutations
+               },
+           },
+           {
+               desc: "invalid case",
+               mutate: func(cfg *YourConfig) {
+                   // mutations that violate CEL rule
+               },
+               wantErrors: []string{"expected error message"},
+           },
+       }
+
+       for _, tc := range testCases {
+           t.Run(tc.desc, func(t *testing.T) {
+               config := baseConfig.DeepCopy()
+               config.Name = fmt.Sprintf("test-%v", time.Now().UnixNano())
+
+               if tc.mutate != nil {
+                   tc.mutate(config)
+               }
+
+               err := k8sClient.Create(ctx, config)
+
+               if (len(tc.wantErrors) != 0) != (err != nil) {
+                   t.Fatalf("Unexpected validation result")
+               }
+
+               if err != nil {
+                   for _, wantError := range tc.wantErrors {
+                       if !celErrorStringMatches(err.Error(), wantError) {
+                           t.Errorf("Missing expected error: %s", wantError)
+                       }
+                   }
+               } else {
+                   _ = k8sClient.Delete(ctx, config)
+               }
+           })
+       }
+   }
+   ```
+
+## Troubleshooting
+
+### envtest fails to download binaries
+
+If you see errors about downloading envtest binaries:
+
+```bash
+# Manually download binaries
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+setup-envtest use 1.28.0
+
+# Set the path
+export KUBEBUILDER_ASSETS=$(setup-envtest use -p path 1.28.0)
+```
+
+### CRD validation not working
+
+Make sure you've regenerated the CRDs after adding CEL validation rules:
+
+```bash
+make manifests
+```
+
+### Tests fail with "scheme not registered"
+
+Ensure the scheme is properly registered in `main_test.go`:
+
+```go
+utilruntime.Must(v1beta3.AddToScheme(scheme))
+```

--- a/tests/cel/v1beta3/authconfig_test.go
+++ b/tests/cel/v1beta3/authconfig_test.go
@@ -25,16 +25,18 @@ import (
 	"github.com/kuadrant/authorino/api/v1beta3"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// TestKubernetesSubjectAccessReviewCELValidation tests the CEL validation rule
-// that requires at least one of user, groups, or authorizationGroups to be specified
-// in the kubernetesSubjectAccessReview authorization configuration.
+// TestKubernetesSubjectAccessReviewCELValidation tests the CEL validation rules
+// for the kubernetesSubjectAccessReview authorization configuration.
 //
-// The validation rule is:
-//
-//	has(self.user) || size(self.groups) > 0 || has(self.authorizationGroups)
+// The validation rules are:
+//  1. At least one of user, groups, or authorizationGroups must be specified:
+//     has(self.user) || has(self.groups) || has(self.authorizationGroups)
+//  2. If groups is specified, it must not be empty:
+//     has(self.groups) ? size(self.groups) > 0 : true
 func TestKubernetesSubjectAccessReviewCELValidation(t *testing.T) {
 	ctx := context.Background()
 
@@ -150,6 +152,10 @@ func TestKubernetesSubjectAccessReviewCELValidation(t *testing.T) {
 				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.AuthorizationGroups = nil
 			},
 			wantErrors: []string{
+				// Note: Empty slices are omitted during JSON marshaling (omitempty tag),
+				// so has(self.groups) returns false and the first validation rule fails.
+				// The second rule (size check) only triggers when groups is explicitly
+				// set to [] in raw YAML/JSON (which we can't easily test via Go client).
 				"At least one of user, groups, or authorizationGroups must be specified",
 			},
 		},
@@ -231,4 +237,117 @@ func TestKubernetesSubjectAccessReviewCELValidation(t *testing.T) {
 			}
 		})
 	}
+
+	// Test explicit empty groups array using unstructured to bypass omitempty marshaling
+	t.Run("invalid - explicit empty groups array via unstructured (no user or authorizationGroups)", func(t *testing.T) {
+		ctx := context.Background()
+
+		// Create an unstructured object with explicit groups: []
+		u := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "authorino.kuadrant.io/v1beta3",
+				"kind":       "AuthConfig",
+				"metadata": map[string]interface{}{
+					"name":      fmt.Sprintf("test-sar-%v", time.Now().UnixNano()),
+					"namespace": metav1.NamespaceDefault,
+				},
+				"spec": map[string]interface{}{
+					"hosts": []interface{}{"test.example.com"},
+					"authentication": map[string]interface{}{
+						"api-key": map[string]interface{}{
+							"plain": map[string]interface{}{
+								"selector": "context.request.http.headers.x-user-name",
+							},
+						},
+					},
+					"authorization": map[string]interface{}{
+						"k8s-sar": map[string]interface{}{
+							"kubernetesSubjectAccessReview": map[string]interface{}{
+								"groups": []interface{}{}, // Explicit empty array
+								"resourceAttributes": map[string]interface{}{
+									"namespace": map[string]interface{}{
+										"value": "default",
+									},
+									"verb": map[string]interface{}{
+										"value": "get",
+									},
+									"resource": map[string]interface{}{
+										"value": "secrets",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := k8sClient.Create(ctx, u)
+
+		if err == nil {
+			t.Fatalf("Expected validation error for explicit empty groups array, but creation succeeded")
+		}
+
+		// Should trigger the second validation rule about empty groups
+		if !celErrorStringMatches(err.Error(), "'groups' must not be empty") {
+			t.Errorf("Expected error containing \"'groups' must not be empty\", got: %v", err)
+		}
+	})
+
+	// Test explicit empty groups array with user present using unstructured
+	t.Run("invalid - explicit empty groups array via unstructured (user specified)", func(t *testing.T) {
+		ctx := context.Background()
+
+		u := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "authorino.kuadrant.io/v1beta3",
+				"kind":       "AuthConfig",
+				"metadata": map[string]interface{}{
+					"name":      fmt.Sprintf("test-sar-%v", time.Now().UnixNano()),
+					"namespace": metav1.NamespaceDefault,
+				},
+				"spec": map[string]interface{}{
+					"hosts": []interface{}{"test.example.com"},
+					"authentication": map[string]interface{}{
+						"api-key": map[string]interface{}{
+							"plain": map[string]interface{}{
+								"selector": "context.request.http.headers.x-user-name",
+							},
+						},
+					},
+					"authorization": map[string]interface{}{
+						"k8s-sar": map[string]interface{}{
+							"kubernetesSubjectAccessReview": map[string]interface{}{
+								"user": map[string]interface{}{
+									"selector": "auth.identity.username",
+								},
+								"groups": []interface{}{}, // Explicit empty array (should be invalid even with user)
+								"resourceAttributes": map[string]interface{}{
+									"namespace": map[string]interface{}{
+										"value": "default",
+									},
+									"verb": map[string]interface{}{
+										"value": "get",
+									},
+									"resource": map[string]interface{}{
+										"value": "secrets",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := k8sClient.Create(ctx, u)
+
+		if err == nil {
+			t.Fatalf("Expected validation error for explicit empty groups array, but creation succeeded")
+		}
+
+		if !celErrorStringMatches(err.Error(), "'groups' must not be empty") {
+			t.Errorf("Expected error containing \"'groups' must not be empty\", got: %v", err)
+		}
+	})
 }

--- a/tests/cel/v1beta3/authconfig_test.go
+++ b/tests/cel/v1beta3/authconfig_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta3_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kuadrant/authorino/api/v1beta3"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// TestKubernetesSubjectAccessReviewCELValidation tests the CEL validation rule
+// that requires at least one of user, groups, or authorizationGroups to be specified
+// in the kubernetesSubjectAccessReview authorization configuration.
+//
+// The validation rule is:
+//
+//	has(self.user) || size(self.groups) > 0 || has(self.authorizationGroups)
+func TestKubernetesSubjectAccessReviewCELValidation(t *testing.T) {
+	ctx := context.Background()
+
+	// Base valid AuthConfig with kubernetesSubjectAccessReview authorization
+	baseAuthConfig := v1beta3.AuthConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sar-authconfig",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1beta3.AuthConfigSpec{
+			Hosts: []string{"test.example.com"},
+			Authentication: map[string]v1beta3.AuthenticationSpec{
+				"api-key": {
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						Plain: &v1beta3.PlainIdentitySpec{
+							Selector: "context.request.http.headers.x-user-name",
+						},
+					},
+				},
+			},
+			Authorization: map[string]v1beta3.AuthorizationSpec{
+				"k8s-sar": {
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						KubernetesSubjectAccessReview: &v1beta3.KubernetesSubjectAccessReviewAuthorizationSpec{
+							User: &v1beta3.ValueOrSelector{
+								Selector: "auth.identity.username",
+							},
+							ResourceAttributes: &v1beta3.KubernetesSubjectAccessReviewResourceAttributesSpec{
+								Namespace: v1beta3.ValueOrSelector{Value: runtime.RawExtension{Raw: []byte(`"default"`)}},
+								Verb:      v1beta3.ValueOrSelector{Value: runtime.RawExtension{Raw: []byte(`"get"`)}},
+								Resource:  v1beta3.ValueOrSelector{Value: runtime.RawExtension{Raw: []byte(`"secrets"`)}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		desc       string
+		mutate     func(ac *v1beta3.AuthConfig)
+		wantErrors []string
+	}{
+		{
+			desc: "valid - user specified",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				// Default baseAuthConfig already has user specified
+			},
+		},
+		{
+			desc: "valid - groups specified (static list)",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.User = nil
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.Groups = []string{
+					"system:developers",
+					"admin-group",
+				}
+			},
+		},
+		{
+			desc: "valid - authorizationGroups specified (dynamic)",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.User = nil
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.AuthorizationGroups = &v1beta3.ValueOrSelector{
+					Selector: "auth.identity.groups",
+				}
+			},
+		},
+		{
+			desc: "valid - user and groups specified",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.Groups = []string{
+					"system:authenticated",
+				}
+			},
+		},
+		{
+			desc: "valid - user and authorizationGroups specified",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.AuthorizationGroups = &v1beta3.ValueOrSelector{
+					Selector: "auth.identity.groups",
+				}
+			},
+		},
+		{
+			desc: "valid - all three fields specified",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.Groups = []string{
+					"system:authenticated",
+				}
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.AuthorizationGroups = &v1beta3.ValueOrSelector{
+					Selector: "auth.identity.groups",
+				}
+			},
+		},
+		{
+			desc: "invalid - no user, groups, or authorizationGroups",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.User = nil
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.Groups = nil
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.AuthorizationGroups = nil
+			},
+			wantErrors: []string{
+				"At least one of user, groups, or authorizationGroups must be specified",
+			},
+		},
+		{
+			desc: "invalid - empty groups array (no user or authorizationGroups)",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.User = nil
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.Groups = []string{}
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.AuthorizationGroups = nil
+			},
+			wantErrors: []string{
+				"At least one of user, groups, or authorizationGroups must be specified",
+			},
+		},
+		{
+			desc: "valid - user with static value",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.User = &v1beta3.ValueOrSelector{
+					Value: runtime.RawExtension{Raw: []byte(`"system:serviceaccount:default:my-sa"`)},
+				}
+			},
+		},
+		{
+			desc: "valid - user with expression (CEL)",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.User = &v1beta3.ValueOrSelector{
+					Expression: "auth.identity.sub",
+				}
+			},
+		},
+		{
+			desc: "valid - authorizationGroups with static value",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.User = nil
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.AuthorizationGroups = &v1beta3.ValueOrSelector{
+					Value: runtime.RawExtension{Raw: []byte(`"system:developers"`)},
+				}
+			},
+		},
+		{
+			desc: "valid - non-resource SAR with user",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				// Non-resource SAR (no resourceAttributes)
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.ResourceAttributes = nil
+			},
+		},
+		{
+			desc: "invalid - non-resource SAR with no user, groups, or authorizationGroups",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.User = nil
+				ac.Spec.Authorization["k8s-sar"].KubernetesSubjectAccessReview.ResourceAttributes = nil
+			},
+			wantErrors: []string{
+				"At least one of user, groups, or authorizationGroups must be specified",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ac := baseAuthConfig.DeepCopy()
+			// Unique name for each test case to avoid conflicts
+			ac.Name = fmt.Sprintf("test-sar-%v", time.Now().UnixNano())
+
+			if tc.mutate != nil {
+				tc.mutate(ac)
+			}
+
+			err := k8sClient.Create(ctx, ac)
+
+			// Check if error expectation matches
+			if (len(tc.wantErrors) != 0) != (err != nil) {
+				t.Fatalf("Unexpected response while creating AuthConfig; got err=\n%v\n;want error=%v", err, tc.wantErrors != nil)
+			}
+
+			// If we expect errors, verify the error message contains expected strings
+			if err != nil {
+				var missingErrorStrings []string
+				for _, wantError := range tc.wantErrors {
+					if !celErrorStringMatches(err.Error(), wantError) {
+						missingErrorStrings = append(missingErrorStrings, wantError)
+					}
+				}
+				if len(missingErrorStrings) != 0 {
+					t.Errorf("Unexpected response while creating AuthConfig; got err=\n%v\n;missing strings within error=%q", err, missingErrorStrings)
+				}
+			} else {
+				// Cleanup successful creations
+				_ = k8sClient.Delete(ctx, ac)
+			}
+		})
+	}
+}

--- a/tests/cel/v1beta3/main_test.go
+++ b/tests/cel/v1beta3/main_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta3_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kuadrant/authorino/api/v1beta3"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var k8sClient client.Client
+
+func TestMain(m *testing.M) {
+	scheme := runtime.NewScheme()
+	var restConfig *rest.Config
+	var testEnv *envtest.Environment
+	var err error
+
+	utilruntime.Must(v1beta3.AddToScheme(scheme))
+
+	// Add core APIs in case we refer secrets, services and configmaps
+	utilruntime.Must(corev1.AddToScheme(scheme))
+
+	// If one wants to use a local cluster, a KUBECONFIG envvar should be passed,
+	// otherwise testenv will be used
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig != "" {
+		restConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			panic(fmt.Sprintf("Failed to get restConfig from BuildConfigFromFlags: %v", err))
+		}
+	} else {
+		// The version used here MUST reflect the available versions at
+		// controller-runtime repo: https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/HEAD/envtest-releases.yaml
+		// K8S_VERSION environment variable can be used by setup-envtest (in the Makefile)
+		// to download a specific Kubernetes version. If not set, the latest GA will be used.
+		testEnv = &envtest.Environment{
+			Scheme:                scheme,
+			ErrorIfCRDPathMissing: true,
+			CRDInstallOptions: envtest.CRDInstallOptions{
+				Paths: []string{
+					filepath.Join("..", "..", "..", "install", "crd"),
+				},
+				CleanUpAfterUse: true,
+			},
+		}
+
+		restConfig, err = testEnv.Start()
+		if err != nil {
+			panic(fmt.Sprintf("Error initializing test environment: %v", err))
+		}
+	}
+
+	k8sClient, err = client.New(restConfig, client.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		panic(fmt.Sprintf("Error initializing Kubernetes client: %v", err))
+	}
+
+	rc := m.Run()
+	if testEnv != nil {
+		if err := testEnv.Stop(); err != nil {
+			panic(fmt.Sprintf("error stopping test environment: %v", err))
+		}
+	}
+
+	os.Exit(rc)
+}
+
+func celErrorStringMatches(got, want string) bool {
+	// Starting in k8s v1.32, some CEL error messages changed to use "more" instead of "longer"
+	alternativeWant := strings.ReplaceAll(want, "more", "longer")
+
+	return strings.Contains(got, want) || strings.Contains(got, alternativeWant)
+}

--- a/tests/cel/v1beta3/main_test.go
+++ b/tests/cel/v1beta3/main_test.go
@@ -28,8 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -39,43 +37,31 @@ var k8sClient client.Client
 
 func TestMain(m *testing.M) {
 	scheme := runtime.NewScheme()
-	var restConfig *rest.Config
-	var testEnv *envtest.Environment
-	var err error
 
 	utilruntime.Must(v1beta3.AddToScheme(scheme))
 
 	// Add core APIs in case we refer secrets, services and configmaps
 	utilruntime.Must(corev1.AddToScheme(scheme))
 
-	// If one wants to use a local cluster, a KUBECONFIG envvar should be passed,
-	// otherwise testenv will be used
-	kubeconfig := os.Getenv("KUBECONFIG")
-	if kubeconfig != "" {
-		restConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		if err != nil {
-			panic(fmt.Sprintf("Failed to get restConfig from BuildConfigFromFlags: %v", err))
-		}
-	} else {
-		// The version used here MUST reflect the available versions at
-		// controller-runtime repo: https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/HEAD/envtest-releases.yaml
-		// K8S_VERSION environment variable can be used by setup-envtest (in the Makefile)
-		// to download a specific Kubernetes version. If not set, the latest GA will be used.
-		testEnv = &envtest.Environment{
-			Scheme:                scheme,
-			ErrorIfCRDPathMissing: true,
-			CRDInstallOptions: envtest.CRDInstallOptions{
-				Paths: []string{
-					filepath.Join("..", "..", "..", "install", "crd"),
-				},
-				CleanUpAfterUse: true,
+	// The version used here MUST reflect the available versions at
+	// controller-runtime repo: https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/HEAD/envtest-releases.yaml
+	// K8S_VERSION environment variable can be used by setup-envtest (in the Makefile)
+	// to download a specific Kubernetes version. If not set, the latest GA will be used.
+	testEnv := &envtest.Environment{
+		Scheme:                scheme,
+		UseExistingCluster:    new(bool), // false - always use envtest
+		ErrorIfCRDPathMissing: true,
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "install", "crd"),
 			},
-		}
+			CleanUpAfterUse: true,
+		},
+	}
 
-		restConfig, err = testEnv.Start()
-		if err != nil {
-			panic(fmt.Sprintf("Error initializing test environment: %v", err))
-		}
+	restConfig, err := testEnv.Start()
+	if err != nil {
+		panic(fmt.Sprintf("Error initializing test environment: %v", err))
 	}
 
 	k8sClient, err = client.New(restConfig, client.Options{
@@ -86,10 +72,9 @@ func TestMain(m *testing.M) {
 	}
 
 	rc := m.Run()
-	if testEnv != nil {
-		if err := testEnv.Stop(); err != nil {
-			panic(fmt.Sprintf("error stopping test environment: %v", err))
-		}
+
+	if err := testEnv.Stop(); err != nil {
+		panic(fmt.Sprintf("error stopping test environment: %v", err))
 	}
 
 	os.Exit(rc)


### PR DESCRIPTION
## Summary

Adds CEL validation to the `KubernetesSubjectAccessReviewAuthorizationSpec` to require at least one of `user`, `groups`, or `authorizationGroups` to be specified. This prevents AuthConfigs that would fail at runtime when the Kubernetes API rejects the SubjectAccessReview request.

## Problem

Before this change, users could create an AuthConfig with `kubernetesSubjectAccessReview` that has neither `user`, `groups`, nor `authorizationGroups` specified. While PR #595 fixed the controller panic when the `user` field is omitted, such configurations still fail at runtime with every authorization request:

```
spec.user: Invalid value: "": at least one of user or group must be specified
```

This creates a poor user experience:
- ✅ AuthConfig is accepted at creation time (no validation error)
- ✅ Controller reconciles successfully (thanks to #595)
- ❌ **Every authorization request fails** with a cryptic Kubernetes API error

## Solution

This PR adds CEL validation to catch the misconfiguration at `kubectl apply` time:

```go
// +kubebuilder:validation:XValidation:rule="has(self.user) || size(self.groups) > 0 || has(self.authorizationGroups)",message="At least one of user, groups, or authorizationGroups must be specified"
type KubernetesSubjectAccessReviewAuthorizationSpec struct {
    // ...
}
```

Now users get immediate feedback:

```bash
$ kubectl apply -f invalid-authconfig.yaml
Error from server (Invalid): error validating data:
  ValidationError(AuthConfig.spec.authorization.sar.kubernetesSubjectAccessReview):
  At least one of user, groups, or authorizationGroups must be specified
```

## Changes

### 1. API Validation ([api/v1beta3/auth_config_types.go](api/v1beta3/auth_config_types.go))

- Added CEL validation rule requiring at least one field
- Added warnings to field documentation about runtime risks with dynamic expressions

### 2. Documentation ([docs/features.md](docs/features.md))

- Added requirement notice
- Added warning about dynamic expressions potentially evaluating to empty values
- Provided mitigation strategies (priority-based deny rules, defaults, fallbacks)

### 3. CEL Validation Tests ([tests/cel/](tests/cel/))

Added comprehensive envtest-based tests:
- 13 test cases covering valid and invalid configurations
- Tests static values and dynamic selectors/expressions
- Organized by API version (v1beta3) for future extensibility
- Integrated into CI via `make test-cel`

### 4. Build System

- **Makefile**: Added `test-cel` target, upgraded envtest from 1.21.2 → 1.28.3, fixed OS detection
- **CI**: Added CEL validation tests as a separate workflow step

## Testing

### Automated Tests

```bash
make test-cel
```

All 13 test cases pass:
- ✅ Valid: user specified (static value, selector, expression)
- ✅ Valid: groups specified (static list)
- ✅ Valid: authorizationGroups specified (selector)
- ✅ Valid: combinations (user + groups, user + authorizationGroups, all three)
- ❌ Invalid: no user, groups, or authorizationGroups
- ❌ Invalid: empty groups array

### Manual Testing

To manually test the validation:

```bash
# This should FAIL with validation error
kubectl apply -f - <<EOF
apiVersion: authorino.kuadrant.io/v1beta3
kind: AuthConfig
metadata:
  name: invalid-sar
spec:
  hosts: ["test.local"]
  authentication:
    "plain": {plain: {selector: "context.request.http.headers.x-user"}}
  authorization:
    "invalid":
      kubernetesSubjectAccessReview:
        resourceAttributes:
          verb: {value: "list"}
          resource: {value: "secrets"}
EOF
```

## Limitations

The CEL validation can only verify that **fields are present** in the AuthConfig spec. It cannot prevent runtime errors when dynamic expressions evaluate to empty values:

```yaml
# Valid at apply time (user field exists)
# May fail at runtime (if expression returns empty string)
kubernetesSubjectAccessReview:
  user:
    expression: auth.identity.optional_field  # Could be empty!
```

This is documented with warnings in the API types and feature documentation, along with recommended mitigation strategies.

## Related

- PR #595: Fixed controller panic when `user` field is nil
- This PR: Prevents invalid configs from being created in the first place

Together: Controller doesn't panic + users get clear validation errors at config time.

## Checklist

- [x] Added CEL validation rule
- [x] Added field documentation warnings
- [x] Updated feature documentation
- [x] Added comprehensive tests (13 test cases)
- [x] Integrated tests into CI
- [x] Regenerated CRDs and manifests
- [x] Fixed Makefile envtest configuration
- [x] All tests passing locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CRD validation now requires at least one of user, groups, or authorizationGroups for KubernetesSubjectAccessReview.

* **Documentation**
  * Added guidance and warnings about dynamic CEL expressions that may evaluate to empty values and cause authorization rejections; example and troubleshooting included.

* **Tests**
  * Added envtest-based CEL validation test suite and README documenting execution and extension.

* **Chores**
  * CI and build tooling updated to run CEL validation tests and bumped test environment/tool versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->