### PR TITLE
Add CRD XValidation rules for mutually exclusive fields

### DIFF
--- a/api/v1beta3/auth_config_types.go
+++ b/api/v1beta3/auth_config_types.go
@@ -292,11 +292,20 @@ func (s *AuthenticationSpec) GetMethod() AuthenticationMethod {
 	return UnknownAuthenticationMethod
 }
 
+// Defines where credentials are extracted from in the request.
+// When omitted, defaults to the HTTP Authorization header with the Bearer prefix.
+// +kubebuilder:validation:MaxProperties=1
 type Credentials struct {
-	AuthorizationHeader *Prefixed     `json:"authorizationHeader,omitempty"`
-	CustomHeader        *CustomHeader `json:"customHeader,omitempty"`
-	QueryString         *Named        `json:"queryString,omitempty"`
-	Cookie              *Named        `json:"cookie,omitempty"`
+	// Extract the credential from the HTTP Authorization header.
+	// The prefix specifies the authentication scheme to strip from the header value (e.g. "Bearer", "APIKEY", "Basic").
+	// Defaults to "Bearer" when prefix is omitted.
+	AuthorizationHeader *Prefixed `json:"authorizationHeader,omitempty"`
+	// Extract the credential from a custom HTTP header specified by name.
+	CustomHeader *CustomHeader `json:"customHeader,omitempty"`
+	// Extract the credential from a query string parameter specified by name.
+	QueryString *Named `json:"queryString,omitempty"`
+	// Extract the credential from a cookie specified by name.
+	Cookie *Named `json:"cookie,omitempty"`
 }
 
 func (c *Credentials) GetType() CredentialsType {
@@ -449,14 +458,18 @@ type X509CertificateSource struct {
 }
 
 // Settings to extract the identity object from the context.
+//
+//	+kubebuilder:validation:XValidation:rule="has(self.selector) != has(self.expression)",message="Use exactly one of: selector, expression"
 type PlainIdentitySpec struct {
 	// Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
 	// Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
 	// The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+	// Use alternatively to 'expression'.
 	Selector string `json:"selector,omitempty"`
 
 	// A Common Expression Language (CEL) expression that evaluates to a value that represents an identity.
 	// String expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).
+	// Use alternatively to 'selector'.
 	Expression CelExpression `json:"expression,omitempty"`
 }
 
@@ -488,6 +501,9 @@ type MetadataMethodSpec struct {
 }
 
 // Settings of the external HTTP request
+//
+//	+kubebuilder:validation:XValidation:rule="has(self.url) != has(self.urlExpression)",message="Use exactly one of: url, urlExpression"
+//	+kubebuilder:validation:XValidation:rule="!has(self.body) || !has(self.bodyParameters)",message="Use one of: body, bodyParameters"
 type HttpEndpointSpec struct {
 	// Endpoint URL of the HTTP service.
 	// The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
@@ -634,6 +650,8 @@ type PatternMatchingAuthorizationSpec struct {
 }
 
 // Settings of the Open Policy Agent (OPA) authorization.
+//
+//	+kubebuilder:validation:XValidation:rule="has(self.rego) != has(self.externalPolicy)",message="Use exactly one of: rego, externalPolicy"
 type OpaAuthorizationSpec struct {
 	// Authorization policy as a Rego language document.
 	// The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed).

--- a/install/crd/authorino.kuadrant.io_authconfigs.yaml
+++ b/install/crd/authorino.kuadrant.io_authconfigs.yaml
@@ -2477,13 +2477,20 @@ spec:
                       description: |-
                         Defines where credentials are required to be passed in the request for authentication based on this config.
                         If omitted, it defaults to credentials passed in the HTTP Authorization header and the "Bearer" prefix prepended to the secret credential value.
+                      maxProperties: 1
                       properties:
                         authorizationHeader:
+                          description: |-
+                            Extract the credential from the HTTP Authorization header.
+                            The prefix specifies the authentication scheme to strip from the header value (e.g. "Bearer", "APIKEY", "Basic").
+                            Defaults to "Bearer" when prefix is omitted.
                           properties:
                             prefix:
                               type: string
                           type: object
                         cookie:
+                          description: Extract the credential from a cookie specified
+                            by name.
                           properties:
                             name:
                               type: string
@@ -2491,6 +2498,8 @@ spec:
                           - name
                           type: object
                         customHeader:
+                          description: Extract the credential from a custom HTTP header
+                            specified by name.
                           properties:
                             name:
                               type: string
@@ -2498,6 +2507,8 @@ spec:
                           - name
                           type: object
                         queryString:
+                          description: Extract the credential from a query string
+                            parameter specified by name.
                           properties:
                             name:
                               type: string
@@ -2633,14 +2644,19 @@ spec:
                           description: |-
                             A Common Expression Language (CEL) expression that evaluates to a value that represents an identity.
                             String expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).
+                            Use alternatively to 'selector'.
                           type: string
                         selector:
                           description: |-
                             Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
                             Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
                             The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            Use alternatively to 'expression'.
                           type: string
                       type: object
+                      x-kubernetes-validations:
+                      - message: 'Use exactly one of: selector, expression'
+                        rule: has(self.selector) != has(self.expression)
                     priority:
                       default: 0
                       description: |-
@@ -3101,13 +3117,20 @@ spec:
                               description: |-
                                 Defines where client credentials will be passed in the request to the service.
                                 If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                              maxProperties: 1
                               properties:
                                 authorizationHeader:
+                                  description: |-
+                                    Extract the credential from the HTTP Authorization header.
+                                    The prefix specifies the authentication scheme to strip from the header value (e.g. "Bearer", "APIKEY", "Basic").
+                                    Defaults to "Bearer" when prefix is omitted.
                                   properties:
                                     prefix:
                                       type: string
                                   type: object
                                 cookie:
+                                  description: Extract the credential from a cookie
+                                    specified by name.
                                   properties:
                                     name:
                                       type: string
@@ -3115,6 +3138,8 @@ spec:
                                   - name
                                   type: object
                                 customHeader:
+                                  description: Extract the credential from a custom
+                                    HTTP header specified by name.
                                   properties:
                                     name:
                                       type: string
@@ -3122,6 +3147,8 @@ spec:
                                   - name
                                   type: object
                                 queryString:
+                                  description: Extract the credential from a query
+                                    string parameter specified by name.
                                   properties:
                                     name:
                                       type: string
@@ -3250,6 +3277,11 @@ spec:
                                 String expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).
                               type: string
                           type: object
+                          x-kubernetes-validations:
+                          - message: 'Use exactly one of: url, urlExpression'
+                            rule: has(self.url) != has(self.urlExpression)
+                          - message: 'Use one of: body, bodyParameters'
+                            rule: '!has(self.body) || !has(self.bodyParameters)'
                         rego:
                           description: |-
                             Authorization policy as a Rego language document.
@@ -3257,6 +3289,9 @@ spec:
                             The Rego document must NOT include the "package" declaration in line 1.
                           type: string
                       type: object
+                      x-kubernetes-validations:
+                      - message: 'Use exactly one of: rego, externalPolicy'
+                        rule: has(self.rego) != has(self.externalPolicy)
                     patternMatching:
                       description: Pattern-matching authorization rules.
                       properties:
@@ -3601,13 +3636,20 @@ spec:
                           description: |-
                             Defines where client credentials will be passed in the request to the service.
                             If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                          maxProperties: 1
                           properties:
                             authorizationHeader:
+                              description: |-
+                                Extract the credential from the HTTP Authorization header.
+                                The prefix specifies the authentication scheme to strip from the header value (e.g. "Bearer", "APIKEY", "Basic").
+                                Defaults to "Bearer" when prefix is omitted.
                               properties:
                                 prefix:
                                   type: string
                               type: object
                             cookie:
+                              description: Extract the credential from a cookie specified
+                                by name.
                               properties:
                                 name:
                                   type: string
@@ -3615,6 +3657,8 @@ spec:
                               - name
                               type: object
                             customHeader:
+                              description: Extract the credential from a custom HTTP
+                                header specified by name.
                               properties:
                                 name:
                                   type: string
@@ -3622,6 +3666,8 @@ spec:
                               - name
                               type: object
                             queryString:
+                              description: Extract the credential from a query string
+                                parameter specified by name.
                               properties:
                                 name:
                                   type: string
@@ -3746,6 +3792,11 @@ spec:
                             String expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).
                           type: string
                       type: object
+                      x-kubernetes-validations:
+                      - message: 'Use exactly one of: url, urlExpression'
+                        rule: has(self.url) != has(self.urlExpression)
+                      - message: 'Use one of: body, bodyParameters'
+                        rule: '!has(self.body) || !has(self.bodyParameters)'
                     metrics:
                       default: false
                       description: Whether this config should generate individual
@@ -3920,13 +3971,20 @@ spec:
                           description: |-
                             Defines where client credentials will be passed in the request to the service.
                             If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                          maxProperties: 1
                           properties:
                             authorizationHeader:
+                              description: |-
+                                Extract the credential from the HTTP Authorization header.
+                                The prefix specifies the authentication scheme to strip from the header value (e.g. "Bearer", "APIKEY", "Basic").
+                                Defaults to "Bearer" when prefix is omitted.
                               properties:
                                 prefix:
                                   type: string
                               type: object
                             cookie:
+                              description: Extract the credential from a cookie specified
+                                by name.
                               properties:
                                 name:
                                   type: string
@@ -3934,6 +3992,8 @@ spec:
                               - name
                               type: object
                             customHeader:
+                              description: Extract the credential from a custom HTTP
+                                header specified by name.
                               properties:
                                 name:
                                   type: string
@@ -3941,6 +4001,8 @@ spec:
                               - name
                               type: object
                             queryString:
+                              description: Extract the credential from a query string
+                                parameter specified by name.
                               properties:
                                 name:
                                   type: string
@@ -4065,6 +4127,11 @@ spec:
                             String expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).
                           type: string
                       type: object
+                      x-kubernetes-validations:
+                      - message: 'Use exactly one of: url, urlExpression'
+                        rule: has(self.url) != has(self.urlExpression)
+                      - message: 'Use one of: body, bodyParameters'
+                        rule: '!has(self.body) || !has(self.bodyParameters)'
                     metrics:
                       default: false
                       description: Whether this config should generate individual

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -2744,13 +2744,20 @@ spec:
                       description: |-
                         Defines where credentials are required to be passed in the request for authentication based on this config.
                         If omitted, it defaults to credentials passed in the HTTP Authorization header and the "Bearer" prefix prepended to the secret credential value.
+                      maxProperties: 1
                       properties:
                         authorizationHeader:
+                          description: |-
+                            Extract the credential from the HTTP Authorization header.
+                            The prefix specifies the authentication scheme to strip from the header value (e.g. "Bearer", "APIKEY", "Basic").
+                            Defaults to "Bearer" when prefix is omitted.
                           properties:
                             prefix:
                               type: string
                           type: object
                         cookie:
+                          description: Extract the credential from a cookie specified
+                            by name.
                           properties:
                             name:
                               type: string
@@ -2758,6 +2765,8 @@ spec:
                           - name
                           type: object
                         customHeader:
+                          description: Extract the credential from a custom HTTP header
+                            specified by name.
                           properties:
                             name:
                               type: string
@@ -2765,6 +2774,8 @@ spec:
                           - name
                           type: object
                         queryString:
+                          description: Extract the credential from a query string
+                            parameter specified by name.
                           properties:
                             name:
                               type: string
@@ -2900,14 +2911,19 @@ spec:
                           description: |-
                             A Common Expression Language (CEL) expression that evaluates to a value that represents an identity.
                             String expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).
+                            Use alternatively to 'selector'.
                           type: string
                         selector:
                           description: |-
                             Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
                             Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
                             The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            Use alternatively to 'expression'.
                           type: string
                       type: object
+                      x-kubernetes-validations:
+                      - message: 'Use exactly one of: selector, expression'
+                        rule: has(self.selector) != has(self.expression)
                     priority:
                       default: 0
                       description: |-
@@ -3409,13 +3425,20 @@ spec:
                               description: |-
                                 Defines where client credentials will be passed in the request to the service.
                                 If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                              maxProperties: 1
                               properties:
                                 authorizationHeader:
+                                  description: |-
+                                    Extract the credential from the HTTP Authorization header.
+                                    The prefix specifies the authentication scheme to strip from the header value (e.g. "Bearer", "APIKEY", "Basic").
+                                    Defaults to "Bearer" when prefix is omitted.
                                   properties:
                                     prefix:
                                       type: string
                                   type: object
                                 cookie:
+                                  description: Extract the credential from a cookie
+                                    specified by name.
                                   properties:
                                     name:
                                       type: string
@@ -3423,6 +3446,8 @@ spec:
                                   - name
                                   type: object
                                 customHeader:
+                                  description: Extract the credential from a custom
+                                    HTTP header specified by name.
                                   properties:
                                     name:
                                       type: string
@@ -3430,6 +3455,8 @@ spec:
                                   - name
                                   type: object
                                 queryString:
+                                  description: Extract the credential from a query
+                                    string parameter specified by name.
                                   properties:
                                     name:
                                       type: string
@@ -3558,6 +3585,11 @@ spec:
                                 String expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).
                               type: string
                           type: object
+                          x-kubernetes-validations:
+                          - message: 'Use exactly one of: url, urlExpression'
+                            rule: has(self.url) != has(self.urlExpression)
+                          - message: 'Use one of: body, bodyParameters'
+                            rule: '!has(self.body) || !has(self.bodyParameters)'
                         rego:
                           description: |-
                             Authorization policy as a Rego language document.
@@ -3565,6 +3597,9 @@ spec:
                             The Rego document must NOT include the "package" declaration in line 1.
                           type: string
                       type: object
+                      x-kubernetes-validations:
+                      - message: 'Use exactly one of: rego, externalPolicy'
+                        rule: has(self.rego) != has(self.externalPolicy)
                     patternMatching:
                       description: Pattern-matching authorization rules.
                       properties:
@@ -3957,13 +3992,20 @@ spec:
                           description: |-
                             Defines where client credentials will be passed in the request to the service.
                             If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                          maxProperties: 1
                           properties:
                             authorizationHeader:
+                              description: |-
+                                Extract the credential from the HTTP Authorization header.
+                                The prefix specifies the authentication scheme to strip from the header value (e.g. "Bearer", "APIKEY", "Basic").
+                                Defaults to "Bearer" when prefix is omitted.
                               properties:
                                 prefix:
                                   type: string
                               type: object
                             cookie:
+                              description: Extract the credential from a cookie specified
+                                by name.
                               properties:
                                 name:
                                   type: string
@@ -3971,6 +4013,8 @@ spec:
                               - name
                               type: object
                             customHeader:
+                              description: Extract the credential from a custom HTTP
+                                header specified by name.
                               properties:
                                 name:
                                   type: string
@@ -3978,6 +4022,8 @@ spec:
                               - name
                               type: object
                             queryString:
+                              description: Extract the credential from a query string
+                                parameter specified by name.
                               properties:
                                 name:
                                   type: string
@@ -4102,6 +4148,11 @@ spec:
                             String expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).
                           type: string
                       type: object
+                      x-kubernetes-validations:
+                      - message: 'Use exactly one of: url, urlExpression'
+                        rule: has(self.url) != has(self.urlExpression)
+                      - message: 'Use one of: body, bodyParameters'
+                        rule: '!has(self.body) || !has(self.bodyParameters)'
                     metrics:
                       default: false
                       description: Whether this config should generate individual
@@ -4289,13 +4340,20 @@ spec:
                           description: |-
                             Defines where client credentials will be passed in the request to the service.
                             If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                          maxProperties: 1
                           properties:
                             authorizationHeader:
+                              description: |-
+                                Extract the credential from the HTTP Authorization header.
+                                The prefix specifies the authentication scheme to strip from the header value (e.g. "Bearer", "APIKEY", "Basic").
+                                Defaults to "Bearer" when prefix is omitted.
                               properties:
                                 prefix:
                                   type: string
                               type: object
                             cookie:
+                              description: Extract the credential from a cookie specified
+                                by name.
                               properties:
                                 name:
                                   type: string
@@ -4303,6 +4361,8 @@ spec:
                               - name
                               type: object
                             customHeader:
+                              description: Extract the credential from a custom HTTP
+                                header specified by name.
                               properties:
                                 name:
                                   type: string
@@ -4310,6 +4370,8 @@ spec:
                               - name
                               type: object
                             queryString:
+                              description: Extract the credential from a query string
+                                parameter specified by name.
                               properties:
                                 name:
                                   type: string
@@ -4434,6 +4496,11 @@ spec:
                             String expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).
                           type: string
                       type: object
+                      x-kubernetes-validations:
+                      - message: 'Use exactly one of: url, urlExpression'
+                        rule: has(self.url) != has(self.urlExpression)
+                      - message: 'Use one of: body, bodyParameters'
+                        rule: '!has(self.body) || !has(self.bodyParameters)'
                     metrics:
                       default: false
                       description: Whether this config should generate individual

--- a/tests/cel/v1beta3/authconfig_test.go
+++ b/tests/cel/v1beta3/authconfig_test.go
@@ -29,6 +29,52 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+type validationTestCase struct {
+	desc       string
+	mutate     func(ac *v1beta3.AuthConfig)
+	wantErrors []string
+}
+
+func runTests(t *testing.T, namePrefix string, baseAuthConfig v1beta3.AuthConfig, testCases []validationTestCase) {
+	t.Helper()
+	ctx := context.Background()
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ac := baseAuthConfig.DeepCopy()
+			// Unique name for each test case to avoid conflicts
+			ac.Name = fmt.Sprintf("%s-%v", namePrefix, time.Now().UnixNano())
+
+			if tc.mutate != nil {
+				tc.mutate(ac)
+			}
+
+			err := k8sClient.Create(ctx, ac)
+
+			// Check if error expectation matches
+			if (len(tc.wantErrors) != 0) != (err != nil) {
+				t.Fatalf("Unexpected response while creating AuthConfig; got err=\n%v\n;want error=%v", err, tc.wantErrors != nil)
+			}
+
+			// If we expect errors, verify the error message contains expected strings
+			if err != nil {
+				var missingErrorStrings []string
+				for _, wantError := range tc.wantErrors {
+					if !celErrorStringMatches(err.Error(), wantError) {
+						missingErrorStrings = append(missingErrorStrings, wantError)
+					}
+				}
+				if len(missingErrorStrings) != 0 {
+					t.Errorf("Unexpected response while creating AuthConfig; got err=\n%v\n;missing strings within error=%q", err, missingErrorStrings)
+				}
+			} else {
+				// Cleanup successful creations
+				_ = k8sClient.Delete(ctx, ac)
+			}
+		})
+	}
+}
+
 // TestKubernetesSubjectAccessReviewCELValidation tests the CEL validation rules
 // for the kubernetesSubjectAccessReview authorization configuration.
 //
@@ -38,12 +84,9 @@ import (
 //  2. If groups is specified, it must not be empty:
 //     has(self.groups) ? size(self.groups) > 0 : true
 func TestKubernetesSubjectAccessReviewCELValidation(t *testing.T) {
-	ctx := context.Background()
-
 	// Base valid AuthConfig with kubernetesSubjectAccessReview authorization
 	baseAuthConfig := v1beta3.AuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-sar-authconfig",
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: v1beta3.AuthConfigSpec{
@@ -76,11 +119,7 @@ func TestKubernetesSubjectAccessReviewCELValidation(t *testing.T) {
 		},
 	}
 
-	testCases := []struct {
-		desc       string
-		mutate     func(ac *v1beta3.AuthConfig)
-		wantErrors []string
-	}{
+	runTests(t, "test-sar", baseAuthConfig, []validationTestCase{
 		{
 			desc: "valid - user specified",
 			mutate: func(ac *v1beta3.AuthConfig) {
@@ -201,42 +240,7 @@ func TestKubernetesSubjectAccessReviewCELValidation(t *testing.T) {
 				"At least one of user, groups, or authorizationGroups must be specified",
 			},
 		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			ac := baseAuthConfig.DeepCopy()
-			// Unique name for each test case to avoid conflicts
-			ac.Name = fmt.Sprintf("test-sar-%v", time.Now().UnixNano())
-
-			if tc.mutate != nil {
-				tc.mutate(ac)
-			}
-
-			err := k8sClient.Create(ctx, ac)
-
-			// Check if error expectation matches
-			if (len(tc.wantErrors) != 0) != (err != nil) {
-				t.Fatalf("Unexpected response while creating AuthConfig; got err=\n%v\n;want error=%v", err, tc.wantErrors != nil)
-			}
-
-			// If we expect errors, verify the error message contains expected strings
-			if err != nil {
-				var missingErrorStrings []string
-				for _, wantError := range tc.wantErrors {
-					if !celErrorStringMatches(err.Error(), wantError) {
-						missingErrorStrings = append(missingErrorStrings, wantError)
-					}
-				}
-				if len(missingErrorStrings) != 0 {
-					t.Errorf("Unexpected response while creating AuthConfig; got err=\n%v\n;missing strings within error=%q", err, missingErrorStrings)
-				}
-			} else {
-				// Cleanup successful creations
-				_ = k8sClient.Delete(ctx, ac)
-			}
-		})
-	}
+	})
 
 	// Test explicit empty groups array using unstructured to bypass omitempty marshaling
 	t.Run("invalid - explicit empty groups array via unstructured (no user or authorizationGroups)", func(t *testing.T) {
@@ -349,5 +353,359 @@ func TestKubernetesSubjectAccessReviewCELValidation(t *testing.T) {
 		if !celErrorStringMatches(err.Error(), "'groups' must not be empty") {
 			t.Errorf("Expected error containing \"'groups' must not be empty\", got: %v", err)
 		}
+	})
+}
+
+// TestHttpEndpointSpecCELValidation tests the CEL validation rules on HttpEndpointSpec:
+//
+//	has(self.url) != has(self.urlExpression) -> "Use exactly one of: url, urlExpression"
+//	!has(self.body) || !has(self.bodyParameters) -> "Use one of: body, bodyParameters"
+func TestHttpEndpointSpecCELValidation(t *testing.T) {
+	baseAuthConfig := v1beta3.AuthConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1beta3.AuthConfigSpec{
+			Hosts: []string{"test-http.example.com"},
+			Authentication: map[string]v1beta3.AuthenticationSpec{
+				"anonymous": {
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						AnonymousAccess: &v1beta3.AnonymousAccessSpec{},
+					},
+				},
+			},
+			Metadata: map[string]v1beta3.MetadataSpec{
+				"ext": {
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						Http: &v1beta3.HttpEndpointSpec{
+							Url: "http://metadata.example.com",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runTests(t, "test-http", baseAuthConfig, []validationTestCase{
+		{
+			desc: "valid - url only",
+		},
+		{
+			desc: "valid - urlExpression only",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Metadata["ext"] = v1beta3.MetadataSpec{
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						Http: &v1beta3.HttpEndpointSpec{
+							UrlExpression: `"http://metadata.example.com/" + request.path`,
+						},
+					},
+				}
+			},
+		},
+		{
+			desc: "invalid - both url and urlExpression",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Metadata["ext"] = v1beta3.MetadataSpec{
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						Http: &v1beta3.HttpEndpointSpec{
+							Url:           "http://metadata.example.com",
+							UrlExpression: `"http://metadata.example.com/" + request.path`,
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: url, urlExpression"},
+		},
+		{
+			desc: "invalid - neither url nor urlExpression",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Metadata["ext"] = v1beta3.MetadataSpec{
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						Http: &v1beta3.HttpEndpointSpec{},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: url, urlExpression"},
+		},
+		{
+			desc: "valid - body only",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Metadata["ext"] = v1beta3.MetadataSpec{
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						Http: &v1beta3.HttpEndpointSpec{
+							Url: "http://metadata.example.com",
+							Body: &v1beta3.ValueOrSelector{
+								Value: runtime.RawExtension{Raw: []byte(`"request body"`)},
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			desc: "valid - bodyParameters only",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Metadata["ext"] = v1beta3.MetadataSpec{
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						Http: &v1beta3.HttpEndpointSpec{
+							Url: "http://metadata.example.com",
+							Parameters: v1beta3.NamedValuesOrSelectors{
+								"param": {Value: runtime.RawExtension{Raw: []byte(`"value"`)}},
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			desc: "invalid - both body and bodyParameters",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Metadata["ext"] = v1beta3.MetadataSpec{
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						Http: &v1beta3.HttpEndpointSpec{
+							Url: "http://metadata.example.com",
+							Body: &v1beta3.ValueOrSelector{
+								Value: runtime.RawExtension{Raw: []byte(`"request body"`)},
+							},
+							Parameters: v1beta3.NamedValuesOrSelectors{
+								"param": {Value: runtime.RawExtension{Raw: []byte(`"value"`)}},
+							},
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use one of: body, bodyParameters"},
+		},
+	})
+}
+
+// TestOpaAuthorizationSpecCELValidation tests the CEL validation rule on OpaAuthorizationSpec:
+//
+//	has(self.rego) != has(self.externalPolicy) -> "Use exactly one of: rego, externalPolicy"
+func TestOpaAuthorizationSpecCELValidation(t *testing.T) {
+	baseAuthConfig := v1beta3.AuthConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1beta3.AuthConfigSpec{
+			Hosts: []string{"test-opa.example.com"},
+			Authentication: map[string]v1beta3.AuthenticationSpec{
+				"anonymous": {
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						AnonymousAccess: &v1beta3.AnonymousAccessSpec{},
+					},
+				},
+			},
+			Authorization: map[string]v1beta3.AuthorizationSpec{
+				"opa-policy": {
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						Opa: &v1beta3.OpaAuthorizationSpec{
+							Rego: "allow = true",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runTests(t, "test-opa", baseAuthConfig, []validationTestCase{
+		{
+			desc: "valid - rego only",
+		},
+		{
+			desc: "valid - externalPolicy only",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["opa-policy"] = v1beta3.AuthorizationSpec{
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						Opa: &v1beta3.OpaAuthorizationSpec{
+							External: &v1beta3.ExternalOpaPolicy{
+								HttpEndpointSpec: &v1beta3.HttpEndpointSpec{
+									Url: "https://opa.example.com/policy.rego",
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			desc: "invalid - neither rego nor externalPolicy",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["opa-policy"] = v1beta3.AuthorizationSpec{
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						Opa: &v1beta3.OpaAuthorizationSpec{},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: rego, externalPolicy"},
+		},
+		{
+			desc: "invalid - both rego and externalPolicy",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["opa-policy"] = v1beta3.AuthorizationSpec{
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						Opa: &v1beta3.OpaAuthorizationSpec{
+							Rego: "allow = true",
+							External: &v1beta3.ExternalOpaPolicy{
+								HttpEndpointSpec: &v1beta3.HttpEndpointSpec{
+									Url: "https://opa.example.com/policy.rego",
+								},
+							},
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: rego, externalPolicy"},
+		},
+	})
+}
+
+// TestCredentialsMaxPropertiesValidation tests the maxProperties=1 constraint on Credentials.
+// This uses OpenAPI maxProperties instead of CEL to stay within the CRD cost budget
+func TestCredentialsMaxPropertiesValidation(t *testing.T) {
+	baseAuthConfig := v1beta3.AuthConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1beta3.AuthConfigSpec{
+			Hosts: []string{"test-creds.example.com"},
+			Authentication: map[string]v1beta3.AuthenticationSpec{
+				"apikey": {
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						ApiKey: &v1beta3.ApiKeyAuthenticationSpec{
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "test"},
+							},
+						},
+					},
+					Credentials: v1beta3.Credentials{
+						AuthorizationHeader: &v1beta3.Prefixed{Prefix: "APIKEY"},
+					},
+				},
+			},
+		},
+	}
+
+	runTests(t, "test-creds", baseAuthConfig, []validationTestCase{
+		{
+			desc: "valid - single credential source (authorizationHeader)",
+		},
+		{
+			desc: "valid - single credential source (customHeader)",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authentication["apikey"] = v1beta3.AuthenticationSpec{
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						ApiKey: &v1beta3.ApiKeyAuthenticationSpec{
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "test"},
+							},
+						},
+					},
+					Credentials: v1beta3.Credentials{
+						CustomHeader: &v1beta3.CustomHeader{Named: v1beta3.Named{Name: "X-API-KEY"}},
+					},
+				}
+			},
+		},
+		{
+			desc: "valid - no credential source (defaults to Authorization: Bearer)",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authentication["apikey"] = v1beta3.AuthenticationSpec{
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						ApiKey: &v1beta3.ApiKeyAuthenticationSpec{
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "test"},
+							},
+						},
+					},
+					Credentials: v1beta3.Credentials{},
+				}
+			},
+		},
+		{
+			desc: "invalid - two credential sources (authorizationHeader + customHeader)",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authentication["apikey"] = v1beta3.AuthenticationSpec{
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						ApiKey: &v1beta3.ApiKeyAuthenticationSpec{
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "test"},
+							},
+						},
+					},
+					Credentials: v1beta3.Credentials{
+						AuthorizationHeader: &v1beta3.Prefixed{Prefix: "APIKEY"},
+						CustomHeader:        &v1beta3.CustomHeader{Named: v1beta3.Named{Name: "X-API-KEY"}},
+					},
+				}
+			},
+			wantErrors: []string{"must have at most 1 items"},
+		},
+	})
+}
+
+// TestPlainIdentitySpecCELValidation tests the CEL validation rule on PlainIdentitySpec:
+//
+//	has(self.selector) != has(self.expression) -> "Use exactly one of: selector, expression"
+func TestPlainIdentitySpecCELValidation(t *testing.T) {
+	baseAuthConfig := v1beta3.AuthConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1beta3.AuthConfigSpec{
+			Hosts: []string{"test-plain.example.com"},
+			Authentication: map[string]v1beta3.AuthenticationSpec{
+				"plain": {
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						Plain: &v1beta3.PlainIdentitySpec{
+							Selector: "request.headers.x-user",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runTests(t, "test-plain", baseAuthConfig, []validationTestCase{
+		{
+			desc: "valid - selector only",
+		},
+		{
+			desc: "valid - expression only",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authentication["plain"] = v1beta3.AuthenticationSpec{
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						Plain: &v1beta3.PlainIdentitySpec{
+							Expression: "request.headers['x-user']",
+						},
+					},
+				}
+			},
+		},
+		{
+			desc: "invalid - neither selector nor expression",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authentication["plain"] = v1beta3.AuthenticationSpec{
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						Plain: &v1beta3.PlainIdentitySpec{},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: selector, expression"},
+		},
+		{
+			desc: "invalid - both selector and expression",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authentication["plain"] = v1beta3.AuthenticationSpec{
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						Plain: &v1beta3.PlainIdentitySpec{
+							Selector:   "request.headers.x-user",
+							Expression: "request.headers['x-user']",
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: selector, expression"},
+		},
 	})
 }


### PR DESCRIPTION
## Summary
> [!NOTE]
> New changes are rebased and depend on the testing infrastructure being added in https://github.com/Kuadrant/authorino/pull/596.

  Adds `+kubebuilder:validation:XValidation` CEL annotations to AuthConfig types to enforce mutual exclusivity of
  fields at admission time.

Related to #599 — this PR covers the XValidation rules for mutually exclusive fields within types. Seems like the issue also encompasses migrating the existing `oneOf` kustomize patches (`install/crd/patches/oneof_in_authconfigs.yaml`) to CEL annotations, which requires further investigation due to increasing CRD cost budget after new rules are added.

  ### Rules added

  | Type | Fields | Constraint |
  |------|--------|------------|
  | `HttpEndpointSpec` | `url` / `urlExpression` | Exactly one |
  | `HttpEndpointSpec` | `body` / `bodyParameters` | At most one |
  | `OpaAuthorizationSpec` | `rego` / `externalPolicy` | Exactly one |
  | `Credentials` | `authorizationHeader` / `customHeader` / `queryString` / `cookie` | At most one |
  | `PlainIdentitySpec` | `selector` / `expression` | Exactly one |

  ## Verification
  
```bash
# 1. Verify crd new validation tests work together with existing ones:
make test-cel 

# 2. (Optional) Verify invalid resources are rejected manually:
make local-setup
kustomize build install/crd | kubectl apply -f -

# url + urlExpression → rejected
kubectl apply --dry-run=server -f - <<'EOF'
apiVersion: authorino.kuadrant.io/v1beta3
kind: AuthConfig
metadata:
  name: test-invalid
spec:
  hosts: [test.example.com]
  authentication:
    anonymous: { anonymous: {} }
  metadata:
    ext:
      http:
        url: "http://example.com"
        urlExpression: '"http://example.com/" + request.path'
EOF

# rego + externalPolicy → rejected
kubectl apply --dry-run=server -f - <<'EOF'
apiVersion: authorino.kuadrant.io/v1beta3
kind: AuthConfig
metadata:
  name: test-invalid
spec:
  hosts: [test.example.com]
  authentication:
    anonymous: { anonymous: {} }
  authorization:
    pol:
      opa:
        rego: "allow = true"
        externalPolicy:
          url: "http://opa.example.com/policy.rego"
EOF

# two credential sources → rejected
kubectl apply --dry-run=server -f - <<'EOF'
apiVersion: authorino.kuadrant.io/v1beta3
kind: AuthConfig
metadata:
  name: test-invalid
spec:
  hosts: [test.example.com]
  authentication:
    apikey:
      apiKey:
        selector:
          matchLabels: { app: test }
      credentials:
        authorizationHeader: { prefix: "APIKEY" }
        customHeader: { name: "X-API-KEY" }
EOF

# selector + expression → rejected
kubectl apply --dry-run=server -f - <<'EOF'
apiVersion: authorino.kuadrant.io/v1beta3
kind: AuthConfig
metadata:
  name: test-invalid
spec:
  hosts: [test.example.com]
  authentication:
    plain:
      plain:
        selector: "request.headers.x-user"
        expression: "request.headers['x-user']"
EOF

# body + bodyParameters → rejected
kubectl apply --dry-run=server -f - <<'EOF'
apiVersion: authorino.kuadrant.io/v1beta3
kind: AuthConfig
metadata:
  name: test-invalid
spec:
  hosts: [test.example.com]
  authentication:
    anonymous: { anonymous: {} }
  metadata:
    ext:
      http:
        url: "http://example.com"
        body:
          value: "test"
        bodyParameters:
          param: { value: "val" }
EOF
```
  
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced validation rules for AuthConfig configurations to prevent conflicting or ambiguous settings.
  * Stricter enforcement of mutually-exclusive options across authentication and authorisation modules.
  * Improved credential configuration constraints to ensure only one credential mechanism is specified per section.

* **Tests**
  * Expanded test coverage for new validation rules and configuration constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->