### PR TITLE
Upgrade Go to 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/authzed/authzed-go v0.7.0


### PR DESCRIPTION
## Summary
- Bump Go version from 1.25.8 to 1.25.9

### CVEs resolved

| CVE | Package | CVSS | Fixed in |
|-----|---------|------|----------|
| CVE-2026-32280 | `crypto/x509` | 7.5 (High) | 1.25.9 |
| CVE-2026-33810 | `crypto/x509` | Not scored | 1.25.9 |
| CVE-2026-32282 | `internal/syscall/unix` | 7.8 (High) | 1.25.9 |

Dockerfile uses `ubi10/go-toolset:1.25` (minor-only tag, no patch change needed). Go 1.25.9 is available in UBI10 go-toolset as of 2026-05-04.