### PR TITLE
feat: add gRPC well-known attributes

### DIFF
--- a/pkg/service/auth_pipeline_test.go
+++ b/pkg/service/auth_pipeline_test.go
@@ -595,6 +595,59 @@ func TestNewAuthorizationJSON(t *testing.T) {
 	assert.Equal(t, expectedAuthJSON, NewAuthorizationJSON(request, authPipeline))
 }
 
+func TestNewAuthorizationJSONWithGRPC(t *testing.T) {
+	grpcRequest := `{
+		"attributes": {
+			"request": {
+				"http": {
+					"host": "my-api",
+					"path": "/UserService/GetUser",
+					"method": "POST",
+					"headers": {
+						"content-type": "application/grpc"
+					}
+				}
+			}
+		}
+	}`
+
+	request := &envoy_auth.CheckRequest{}
+	_ = gojson.Unmarshal([]byte(grpcRequest), request)
+
+	authPipeline := map[string]any{
+		"identity": "leeloo",
+	}
+
+	authJSON := NewAuthorizationJSON(request, authPipeline)
+
+	var result map[string]any
+	_ = gojson.Unmarshal([]byte(authJSON), &result)
+
+	requestObj := result["request"].(map[string]any)
+	grpcObj, ok := requestObj["grpc"].(map[string]any)
+	assert.Check(t, ok, "grpc field should be present in request")
+	assert.Equal(t, "UserService", grpcObj["service"])
+	assert.Equal(t, "GetUser", grpcObj["method"])
+}
+
+func TestNewAuthorizationJSONWithoutGRPC(t *testing.T) {
+	request := &envoy_auth.CheckRequest{}
+	_ = gojson.Unmarshal([]byte(rawRequest), request)
+
+	authPipeline := map[string]any{
+		"identity": "leeloo",
+	}
+
+	authJSON := NewAuthorizationJSON(request, authPipeline)
+
+	var result map[string]any
+	_ = gojson.Unmarshal([]byte(authJSON), &result)
+
+	requestObj := result["request"].(map[string]any)
+	_, ok := requestObj["grpc"]
+	assert.Check(t, !ok, "grpc field should be absent for non-gRPC requests")
+}
+
 func TestPipelineMetricLabels(t *testing.T) {
 	reqJSON := `{
 		"attributes": {

--- a/pkg/service/well_known_attributes.go
+++ b/pkg/service/well_known_attributes.go
@@ -39,6 +39,13 @@ type WellKnownAttributes struct {
 	Auth *AuthAttributes `json:"auth,omitempty"`
 }
 
+// GRPCAttributes contains gRPC-specific request metadata extracted from the
+// request path. Only populated for gRPC requests with a valid /Service/Method path.
+type GRPCAttributes struct {
+	Service string `json:"service,omitempty"`
+	Method  string `json:"method,omitempty"`
+}
+
 type RequestAttributes struct {
 	// Request ID corresponding to x-request-id header value
 	Id string `json:"id,omitempty"`
@@ -70,6 +77,8 @@ type RequestAttributes struct {
 	Body string `json:"body,omitempty"`
 	// The HTTP request body in bytes. This is sometimes used instead of body depending on the proxy configuration. e.g. 1234
 	RawBody []byte `json:"raw_body,omitempty"`
+	// gRPC service and method extracted from the request path (only for gRPC requests)
+	GRPC *GRPCAttributes `json:"grpc,omitempty"`
 	// This is analogous to request.headers, however these contents are not sent to the upstream server. It provides an
 	// extension mechanism for sending additional information to the auth service without modifying the proto definition.
 	// It maps to the internal opaque context in the proxy filter chain. (Requires additional configuration in the proxy.)
@@ -141,6 +150,12 @@ func newRequestAttributes(attributes *envoyauth.AttributeContext) *RequestAttrib
 	httpRequest := request.GetHttp()
 	urlParsed, _ := url.Parse(httpRequest.Path)
 	headers := httpRequest.GetHeaders()
+
+	var grpcAttrs *GRPCAttributes
+	if isGRPCRequest(headers) {
+		grpcAttrs = parseGRPCPath(urlParsed.Path)
+	}
+
 	return &RequestAttributes{
 		Id:                httpRequest.Id,
 		Time:              request.Time,
@@ -157,6 +172,7 @@ func newRequestAttributes(attributes *envoyauth.AttributeContext) *RequestAttrib
 		Size:              httpRequest.GetSize(),
 		Body:              httpRequest.GetBody(),
 		RawBody:           httpRequest.GetRawBody(),
+		GRPC:              grpcAttrs,
 		ContextExtensions: attributes.GetContextExtensions(),
 	}
 }
@@ -197,4 +213,26 @@ func newAuthAttributes(authData map[string]interface{}) *AuthAttributes {
 		}
 	}
 	return authAttributes
+}
+
+// isGRPCRequest returns true if the request has a content-type header starting
+// with "application/grpc".
+func isGRPCRequest(headers map[string]string) bool {
+	return strings.HasPrefix(headers["content-type"], "application/grpc")
+}
+
+// parseGRPCPath extracts gRPC service and method from a path in /Service/Method
+// format. Returns nil if the path does not match the expected format.
+func parseGRPCPath(path string) *GRPCAttributes {
+	if !strings.HasPrefix(path, "/") {
+		return nil
+	}
+	parts := strings.Split(path[1:], "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil
+	}
+	return &GRPCAttributes{
+		Service: parts[0],
+		Method:  parts[1],
+	}
 }

--- a/pkg/service/well_known_attributes_test.go
+++ b/pkg/service/well_known_attributes_test.go
@@ -51,4 +51,182 @@ func TestNewWellKnownAttributes(t *testing.T) {
 	assert.Equal(t, map[string]any{"group": "rebels"}, wellKnownAttributes.Auth.Authorization)
 	assert.Equal(t, map[string]any{"status": 200}, wellKnownAttributes.Auth.Response)
 	assert.Nil(t, wellKnownAttributes.Auth.Callbacks)
+	assert.Nil(t, wellKnownAttributes.Request.GRPC)
+}
+
+func TestNewWellKnownAttributesGRPC(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		headers      map[string]string
+		expectedGRPC *GRPCAttributes
+	}{
+		{
+			name: "gRPC request with valid path",
+			path: "/UserService/GetUser",
+			headers: map[string]string{
+				"content-type": "application/grpc",
+			},
+			expectedGRPC: &GRPCAttributes{Service: "UserService", Method: "GetUser"},
+		},
+		{
+			name: "gRPC+proto request with packaged service",
+			path: "/com.example.UserService/GetUser",
+			headers: map[string]string{
+				"content-type": "application/grpc+proto",
+			},
+			expectedGRPC: &GRPCAttributes{Service: "com.example.UserService", Method: "GetUser"},
+		},
+		{
+			name: "gRPC request with malformed path",
+			path: "/OnlyService",
+			headers: map[string]string{
+				"content-type": "application/grpc",
+			},
+			expectedGRPC: nil,
+		},
+		{
+			name: "non-gRPC request",
+			path: "/UserService/GetUser",
+			headers: map[string]string{
+				"content-type": "application/json",
+			},
+			expectedGRPC: nil,
+		},
+		{
+			name:         "no content-type header",
+			path:         "/UserService/GetUser",
+			headers:      map[string]string{},
+			expectedGRPC: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envoyAttrs := &envoyauth.AttributeContext{
+				Request: &envoyauth.AttributeContext_Request{
+					Http: &envoyauth.AttributeContext_HttpRequest{
+						Headers: tt.headers,
+						Path:    tt.path,
+						Method:  "POST",
+					},
+				},
+				Source:      &envoyauth.AttributeContext_Peer{},
+				Destination: &envoyauth.AttributeContext_Peer{},
+			}
+
+			wellKnownAttributes := NewWellKnownAttributes(envoyAttrs, nil)
+			assert.Equal(t, tt.expectedGRPC, wellKnownAttributes.Request.GRPC)
+		})
+	}
+}
+
+func TestIsGRPCRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string]string
+		expected bool
+	}{
+		{
+			name:     "application/grpc content-type",
+			headers:  map[string]string{"content-type": "application/grpc"},
+			expected: true,
+		},
+		{
+			name:     "application/grpc+proto content-type",
+			headers:  map[string]string{"content-type": "application/grpc+proto"},
+			expected: true,
+		},
+		{
+			name:     "application/grpc+json content-type",
+			headers:  map[string]string{"content-type": "application/grpc+json"},
+			expected: true,
+		},
+		{
+			name:     "application/json content-type",
+			headers:  map[string]string{"content-type": "application/json"},
+			expected: false,
+		},
+		{
+			name:     "no content-type header",
+			headers:  map[string]string{},
+			expected: false,
+		},
+		{
+			name:     "empty content-type",
+			headers:  map[string]string{"content-type": ""},
+			expected: false,
+		},
+		{
+			name:     "nil headers",
+			headers:  nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isGRPCRequest(tt.headers))
+		})
+	}
+}
+
+func TestParseGRPCPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected *GRPCAttributes
+	}{
+		{
+			name:     "standard gRPC path",
+			path:     "/UserService/GetUser",
+			expected: &GRPCAttributes{Service: "UserService", Method: "GetUser"},
+		},
+		{
+			name:     "packaged service name",
+			path:     "/com.example.UserService/GetUser",
+			expected: &GRPCAttributes{Service: "com.example.UserService", Method: "GetUser"},
+		},
+		{
+			name:     "single segment path",
+			path:     "/OnlyService",
+			expected: nil,
+		},
+		{
+			name:     "root path",
+			path:     "/",
+			expected: nil,
+		},
+		{
+			name:     "empty path",
+			path:     "",
+			expected: nil,
+		},
+		{
+			name:     "too many segments",
+			path:     "/a/b/c",
+			expected: nil,
+		},
+		{
+			name:     "no leading slash",
+			path:     "Service/Method",
+			expected: nil,
+		},
+		{
+			name:     "empty service",
+			path:     "//Method",
+			expected: nil,
+		},
+		{
+			name:     "empty method",
+			path:     "/Service/",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, parseGRPCPath(tt.path))
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Extract `grpc.service` and `grpc.method` from gRPC requests and add to the authorization JSON under `request.grpc`, making gRPC-specific metadata available to OPA policies, CEL rules, and other evaluators.

- Detect gRPC requests via `content-type: application/grpc` header prefix
- Parse service and method from `/Service/Method` path format
- Omit the `grpc` field entirely for non-gRPC requests (aligns with OPA undefined value semantics)

Resolves #584

**RFC:** https://github.com/Kuadrant/architecture/blob/main/rfcs/0017-grpcroute-support.md

## Changes

- `pkg/service/well_known_attributes.go` — New `GRPCAttributes` struct, `GRPC` field on `RequestAttributes`, `isGRPCRequest()` and `parseGRPCPath()` helpers, wired into `newRequestAttributes()`
- `pkg/service/well_known_attributes_test.go` — Table-driven tests for gRPC detection, path parsing, and `NewWellKnownAttributes` integration
- `pkg/service/auth_pipeline_test.go` — Tests verifying `grpc` field presence/absence in authorization JSON

## Verification

### Prerequisites

```bash
make local-setup FF=1
kubectl port-forward -n default deployment/envoy 8000:8000
```

### Apply test AuthConfig

```bash
kubectl -n default apply -f - <<'EOF'
apiVersion: authorino.kuadrant.io/v1beta3
kind: AuthConfig
metadata:
  name: grpc-test
  namespace: default
spec:
  hosts:
  - talker-api.127.0.0.1.nip.io
  authentication:
    public:
      anonymous: {}
  authorization:
    grpc-check:
      opa:
        rego: |
          allow {
            input.request.grpc.service == "UserService"
          }
EOF
```

### Test 1: gRPC request with matching service (expect 200, proxied to upstream)

```bash
curl -s -D - http://localhost:8000/UserService/GetUser \
  -X POST \
  -H "Host: talker-api.127.0.0.1.nip.io" \
  -H "content-type: application/grpc" | head -3
# HTTP/1.1 200 OK
# content-type: application/json    <-- proxied to upstream
```

### Test 2: gRPC request with non-matching service (expect grpc-status: 7)

```bash
curl -s -D - http://localhost:8000/AdminService/DeleteAll \
  -X POST \
  -H "Host: talker-api.127.0.0.1.nip.io" \
  -H "content-type: application/grpc" | head -5
# HTTP/1.1 200 OK                   <-- gRPC uses 200 for all responses
# x-ext-auth-reason: Unauthorized
# content-type: application/grpc
# grpc-status: 7                    <-- 7 = PERMISSION_DENIED
```

### Test 3: Plain HTTP request — no gRPC attributes (expect 403)

```bash
curl -s -o /dev/null -w "%{http_code}\n" \
  http://localhost:8000/UserService/GetUser \
  -H "Host: talker-api.127.0.0.1.nip.io"
# 403
```

### Cleanup

```bash
kubectl -n default delete authconfig grpc-test
make local-cleanup
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Infrastructure**
  * Extended request attributes with gRPC-specific metadata fields
  * Implemented detection and parsing of gRPC request information from request paths

* **Tests**
  * Added comprehensive unit tests validating gRPC request detection based on content-type
  * Added tests for gRPC request path parsing and validation
  * Added tests confirming standard HTTP requests continue to function

<!-- end of auto-generated comment: release notes by coderabbit.ai -->