### PR TITLE
fix: convert ParseFloat result to float32 before type assertion

### DIFF
--- a/pkg/utils/envvar.go
+++ b/pkg/utils/envvar.go
@@ -29,7 +29,7 @@ func EnvVar[T envVar](key string, def T) T {
 			return any(v).(T)
 		case reflect.Float32:
 			v, _ := strconv.ParseFloat(val, 32)
-			return any(v).(T)
+			return any(float32(v)).(T)
 		case reflect.Float64:
 			v, _ := strconv.ParseFloat(val, 64)
 			return any(v).(T)

--- a/pkg/utils/envvar_test.go
+++ b/pkg/utils/envvar_test.go
@@ -47,6 +47,26 @@ func TestFetchEnvVarBool(t *testing.T) {
 	assert.Equal(t, EnvVar("AUTHORINO_TEST_ENV_VAR_OTHER", false), false)
 }
 
+func TestFetchEnvVarFloat32(t *testing.T) {
+	_ = os.Setenv("AUTHORINO_TEST_ENV_VAR", "3.14")
+	defer func() {
+		_ = os.Unsetenv("AUTHORINO_TEST_ENV_VAR")
+	}()
+
+	assert.Equal(t, EnvVar("AUTHORINO_TEST_ENV_VAR", float32(0)), float32(3.14))
+	assert.Equal(t, EnvVar("AUTHORINO_TEST_ENV_VAR_OTHER", float32(1.5)), float32(1.5))
+}
+
+func TestFetchEnvVarFloat64(t *testing.T) {
+	_ = os.Setenv("AUTHORINO_TEST_ENV_VAR", "3.14")
+	defer func() {
+		_ = os.Unsetenv("AUTHORINO_TEST_ENV_VAR")
+	}()
+
+	assert.Equal(t, EnvVar("AUTHORINO_TEST_ENV_VAR", float64(0)), float64(3.14))
+	assert.Equal(t, EnvVar("AUTHORINO_TEST_ENV_VAR_OTHER", float64(1.5)), float64(1.5))
+}
+
 func TestFetchEnvVarInvalid(t *testing.T) {
 	_ = os.Setenv("AUTHORINO_TEST_ENV_VAR", "NaN")
 	defer func() {


### PR DESCRIPTION
strconv.ParseFloat always returns float64 regardless of bitSize parameter. The float32 case in EnvVar was asserting the float64 result directly as float32, causing a runtime panic when the KUBE_CLIENT_QPS env var is set.

Adds test coverage for float32 and float64 EnvVar paths.