### PR TITLE
chore: update actions/add-to-project to v2.0.0

### DIFF
--- a/.github/workflows/issues-workflow.yaml
+++ b/.github/workflows/issues-workflow.yaml
@@ -17,7 +17,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event.issue.number != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@v2.0.0
         with:
           project-url: https://github.com/orgs/Kuadrant/projects/18
           github-token: ${{ secrets.ADD_ISSUES_TOKEN }}


### PR DESCRIPTION
## Summary
- Bumps `actions/add-to-project` from v0.5.0 (node16) to v2.0.0 (node24)
- Drop-in upgrade — action inputs are unchanged, no breaking changes

## Test plan
- [x] CI passes
- [ ] Next issue or PR opened after merge is added to the [project board](https://github.com/orgs/Kuadrant/projects/18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->