### PR TITLE
feat: add --pprof-bind-address flag for runtime profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,5 +451,17 @@ If you are interested in contributing to Authorino, please refer to the [Develop
 Join us on the [#kuadrant](https://kubernetes.slack.com/archives/C05J0D0V525) channel in the Kubernetes Slack workspace, for live discussions about the roadmap and more.
 
 
+## Profiling
+
+Authorino supports runtime profiling via Go's built-in [pprof](https://pkg.go.dev/net/http/pprof) tooling. Enabled by default on `:8084`.
+
+Connect to a running instance:
+
+```bash
+kubectl port-forward -n <namespace> deploy/authorino 8084:8084
+go tool pprof -http=:8080 http://localhost:8084/debug/pprof/profile?seconds=30
+go tool pprof -http=:8080 http://localhost:8084/debug/pprof/heap
+```
+
 ## License
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FKuadrant%2Fauthorino.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2FKuadrant%2Fauthorino?ref=badge_large)

--- a/main.go
+++ b/main.go
@@ -104,6 +104,7 @@ type commonServerOptions struct {
 	log             logOptions
 	metricsAddr     string
 	healthProbeAddr string
+	pprofAddr       string
 	telemetry       telemetryOptions
 }
 
@@ -232,6 +233,7 @@ func registerCommonServerOptions(cmd *cobra.Command, opts *commonServerOptions) 
 	cmd.PersistentFlags().StringVar(&opts.log.mode, "log-mode", utils.EnvVar("LOG_MODE", "production"), "Log mode")
 	cmd.PersistentFlags().StringVar(&opts.metricsAddr, "metrics-addr", ":8080", "The network address the metrics endpoint binds to")
 	cmd.PersistentFlags().StringVar(&opts.healthProbeAddr, "health-probe-addr", ":8081", "The network address the health probe endpoint binds to")
+	cmd.PersistentFlags().StringVar(&opts.pprofAddr, "pprof-bind-address", ":8084", "The address the pprof endpoint binds to")
 	cmd.PersistentFlags().StringVar(&opts.telemetry.tracingServiceEndpoint, "tracing-service-endpoint", "", "Endpoint URL of the tracing exporter service - use either 'rpc://' or 'http://' scheme")
 	cmd.PersistentFlags().BoolVar(&opts.telemetry.tracingServiceInsecure, "tracing-service-insecure", false, "Disable TLS for the tracing service connection")
 	cmd.PersistentFlags().StringArrayVar(&opts.telemetry.tracingServiceTags, "tracing-service-tag", []string{}, "Fixed key=value tag to add to emitted traces")
@@ -288,6 +290,7 @@ func runAuthorizationServer(cmd *cobra.Command, _ []string) {
 		WebhookServer:          webhook.NewServer(webhook.Options{Port: opts.webhookServicePort}),
 		Metrics:                metricsserver.Options{BindAddress: opts.metricsAddr},
 		HealthProbeBindAddress: opts.healthProbeAddr,
+		PprofBindAddress:       opts.pprofAddr,
 		LeaderElection:         false,
 	}
 	if opts.watchNamespace != "" {
@@ -391,6 +394,7 @@ func runWebhookServer(cmd *cobra.Command, _ []string) {
 		Scheme:                 scheme,
 		Metrics:                metricsserver.Options{BindAddress: opts.metricsAddr},
 		HealthProbeBindAddress: opts.healthProbeAddr,
+		PprofBindAddress:       opts.pprofAddr,
 		LeaderElection:         true,
 		LeaderElectionID:       fmt.Sprintf("670aa2de.%s", leaderElectionIDSuffix),
 		WebhookServer:          webhook.NewServer(webhook.Options{Port: opts.port}),


### PR DESCRIPTION
## Summary

Adds runtime profiling support via Go's built-in [pprof](https://pkg.go.dev/net/http/pprof) using controller-runtime's `PprofBindAddress` option. Enabled by default on `:8084`.

## Motivation

pprof is the standard mechanism for diagnosing performance issues in Go applications. The Kubernetes [kube-apiserver](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) enables profiling via `--profiling` (default: `true`), exposing the same `/debug/pprof/` endpoints. OpenShift provides [built-in tooling](https://docs.openshift.com/container-platform/4.11/scalability_and_performance/node-observability-operator.html) for collecting pprof data from cluster components.

Port 8084 is used consistently across all Kuadrant Go components to avoid conflicts with existing services.

## Changes

- Added `pprofAddr` field to `commonServerOptions` struct
- Added `--pprof-bind-address` flag (default `:8084`) via cobra PersistentFlags
- Added `PprofBindAddress` to both the auth server and webhook server `ctrl.Options`
- Added `## Profiling` section to README.md