### PR TITLE
fix: unwrap string-backed ValueOrSelector values in controller translation

### DIFF
--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	gojson "encoding/json"
 	"fmt"
 	"sort"
 	"sync"
@@ -827,7 +828,20 @@ func valueFrom(user *api.ValueOrSelector) (expressions.Value, error) {
 			return nil, err
 		}
 	} else {
-		strValue = &json.JSONValue{Static: user.Value, Pattern: user.Selector}
+		var staticValue interface{}
+		if len(user.Value.Raw) > 0 {
+			if err := gojson.Unmarshal(user.Value.Raw, &staticValue); err != nil {
+				return nil, err
+			}
+			if obj, ok := staticValue.(map[string]interface{}); ok && len(obj) == 1 {
+				if unwrapped, found := obj["string"]; found {
+					staticValue = unwrapped
+				}
+			}
+		} else {
+			staticValue = user.Value.Object
+		}
+		strValue = &json.JSONValue{Static: staticValue, Pattern: user.Selector}
 	}
 	return strValue, nil
 }

--- a/controllers/auth_config_controller_test.go
+++ b/controllers/auth_config_controller_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kuadrant/authorino/pkg/evaluators"
 	"github.com/kuadrant/authorino/pkg/httptest"
 	"github.com/kuadrant/authorino/pkg/index"
+	"github.com/kuadrant/authorino/pkg/json"
 	mock_index "github.com/kuadrant/authorino/pkg/index/mocks"
 	"github.com/kuadrant/authorino/pkg/log"
 
@@ -37,6 +38,18 @@ func TestMain(m *testing.M) {
 	})
 	defer authServer.Close()
 	os.Exit(m.Run())
+}
+
+func TestValueFromUnwrapsStringValue(t *testing.T) {
+	value, err := valueFrom(&api.ValueOrSelector{
+		Value: runtime.RawExtension{Raw: []byte(`{"string":"application/json"}`)},
+	})
+
+	assert.NilError(t, err)
+
+	jsonValue, ok := value.(*json.JSONValue)
+	assert.Assert(t, ok)
+	assert.Equal(t, jsonValue.Static, "application/json")
 }
 
 func newTestAuthConfig(authConfigLabels map[string]string) api.AuthConfig {


### PR DESCRIPTION
## Summary

I hit this error with an `AuthConfig` using Generic HTTP metadata like:

```yaml
http:
  method: GET
  url: https://some.url
  headers:
    Accept:
      value:
        string: application/json
```

This value round-trips through the Kubernetes API server as:

```json
{"string":"application/json"}
```

Without unwrapping this form during controller translation, Generic HTTP metadata headers can be sent with the serialized wrapper object instead of the intended primitive string value.

In practice, the `Accept` header above was effectively sent as:

```text
{"string":"application/json"}
```

instead of:

```text
application/json
```

This can cause metadata fetches that expect JSON responses to fail, depending on how strictly the upstream server validates request headers.

## Changes

- unwrap string-backed `ValueOrSelector.value` payloads in `valueFrom()`
- add a regression test covering the wrapped string case

## Verification

- `go test ./controllers -run 'TestValueFromUnwrapsStringValue'`
- `go test ./pkg/evaluators/metadata -run 'TestGenericHttpCallWithCustomHeaders'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved static value processing in configurations to correctly unmarshal JSON data and unwrap nested string values.

* **Tests**
  * Added test coverage to verify proper unwrapping of string values in configuration handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/authorino/pull/613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->