### PR TITLE
Backport patch-safe fixes for v0.24.1

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -2,10 +2,10 @@ name: Unit Tests
 
 on:
   push:
-    branches: [ 'main', 'master' ]
+    branches: [ 'main', 'master', 'release-*' ]
 
   pull_request:
-    branches: [ 'main', 'master' ]
+    branches: [ 'main', 'master', 'release-*' ]
 
   merge_group:
     types: [ checks_requested ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,7 @@ Both are registered in the scheme and controllers handle both versions.
 ## Dependencies
 
 Built with:
-- Go 1.25.5
+- Go 1.25.7
 - controller-runtime v0.16.3
 - Kubernetes client-go v0.28.3
 - Envoy go-control-plane v1.32.4

--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -564,10 +564,21 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 			}
 
 		case api.KubernetesSubjectAccessReviewAuthorization:
-			user := authorization.KubernetesSubjectAccessReview.User
-			authorinoUser, err := valueFrom(user)
-			if err != nil {
-				return nil, err
+			// The `user` field on kubernetesSubjectAccessReview is optional:
+			// omitting it is a valid way to request a group-only or self-SAR
+			// check. Guard against the nil pointer here so we don't segfault
+			// the controller's Reconcile (authorino then keeps crash-looping
+			// on every AuthConfig event). NewKubernetesAuthz + jsonValueToStr
+			// already treat a nil expressions.Value as "no user", which maps
+			// to SubjectAccessReviewSpec.User == "" and the Kubernetes API
+			// evaluates it as expected.
+			var authorinoUser expressions.Value
+			if user := authorization.KubernetesSubjectAccessReview.User; user != nil {
+				var err error
+				authorinoUser, err = valueFrom(user)
+				if err != nil {
+					return nil, err
+				}
 			}
 
 			var authorinoResourceAttributes *authorization_evaluators.KubernetesAuthzResourceAttributes

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/authzed/authzed-go v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/authzed/authzed-go v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/authzed/authzed-go v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.14.1
 	github.com/eko/gocache v1.2.0
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4
-	github.com/go-jose/go-jose/v4 v4.0.5
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.2
 	github.com/gogo/googleapis v1.4.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
@@ -124,7 +124,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.54.0
 	go.opentelemetry.io/otel/trace v1.35.0
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
 github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
-github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
-github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=
@@ -609,8 +609,6 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
-golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=

--- a/pkg/evaluators/authorization/opa.go
+++ b/pkg/evaluators/authorization/opa.go
@@ -116,6 +116,13 @@ func (opa *OPA) Clean(_ context.Context) error {
 	return opa.ExternalSource.cleanupRefresher()
 }
 
+// GetRego returns the current Rego policy in a thread-safe manner
+func (opa *OPA) GetRego() string {
+	opa.mu.RLock()
+	defer opa.mu.RUnlock()
+	return opa.Rego
+}
+
 func (opa *OPA) updateRego(rego string, ctx context.Context, force bool) (bool, error) {
 	opa.mu.Lock()
 	defer opa.mu.Unlock()

--- a/pkg/evaluators/authorization/opa_test.go
+++ b/pkg/evaluators/authorization/opa_test.go
@@ -153,11 +153,11 @@ func TestOPAExternalUrlWithTTL(t *testing.T) {
 	}(opa)
 
 	assert.NilError(t, err)
-	assert.Check(t, strings.Contains(opa.Rego, "GET"))
+	assert.Check(t, strings.Contains(opa.GetRego(), "GET"))
 	assert.Check(t, opa.ExternalSource.refresher != nil)
 
 	time.Sleep(4 * time.Second)
-	assert.Check(t, strings.Contains(opa.Rego, "POST"))
+	assert.Check(t, strings.Contains(opa.GetRego(), "POST"))
 }
 
 func TestOPAClean(t *testing.T) {

--- a/pkg/evaluators/identity/jwt.go
+++ b/pkg/evaluators/identity/jwt.go
@@ -155,6 +155,13 @@ func (v *oidcProviderVerifier) Clean(ctx gocontext.Context) error {
 	return v.refresher.Stop()
 }
 
+// GetProvider returns the current OIDC provider in a thread-safe manner
+func (v *oidcProviderVerifier) GetProvider() *oidc.Provider {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return v.provider
+}
+
 func (v *oidcProviderVerifier) getOpenIdProvider(ctx gocontext.Context, force bool) *oidc.Provider {
 	v.mu.Lock()
 	defer v.mu.Unlock()

--- a/pkg/evaluators/identity/jwt_test.go
+++ b/pkg/evaluators/identity/jwt_test.go
@@ -3,6 +3,7 @@ package identity
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -126,11 +127,15 @@ func TestOIDCProviderVerifierInternalError(t *testing.T) {
 }
 
 func TestOIDCProviderVerifierRefresh(t *testing.T) {
+	var mu sync.Mutex
 	count := 0
 	authServer := httptest.NewHttpServerMock(oidcServerHost, map[string]httptest.HttpServerMockResponseFunc{
 		"/.well-known/openid-configuration": func() httptest.HttpServerMockResponse {
+			mu.Lock()
 			count += 1
-			return oidcServerMockResponse(count)
+			currentCount := count
+			mu.Unlock()
+			return oidcServerMockResponse(currentCount)
 		},
 	})
 	defer authServer.Close()
@@ -149,9 +154,13 @@ func TestOIDCProviderVerifierRefresh(t *testing.T) {
 	assert.Check(t, verifier.refresher != nil)
 
 	time.Sleep(4 * time.Second)
-	assert.Equal(t, 2, count)
+	mu.Lock()
+	currentCount := count
+	mu.Unlock()
+	assert.Equal(t, 2, currentCount)
 	verifier, _ = jwtVerifier.(*oidcProviderVerifier)
-	assert.Equal(t, fmt.Sprintf("http://%v/auth?count=2", oidcServerHost), verifier.provider.Endpoint().AuthURL)
+	provider := verifier.GetProvider()
+	assert.Equal(t, fmt.Sprintf("http://%v/auth?count=2", oidcServerHost), provider.Endpoint().AuthURL)
 }
 
 func TestOIDCProviderVerifierRefreshDisabled(t *testing.T) {

--- a/pkg/evaluators/identity/mtls.go
+++ b/pkg/evaluators/identity/mtls.go
@@ -70,7 +70,11 @@ func (m *MTLS) loadSecrets(ctx context.Context) error {
 }
 
 func (m *MTLS) Call(pipeline auth.AuthPipeline, ctx context.Context) (interface{}, error) {
-	urlEncodedCert := pipeline.GetRequest().Attributes.Source.GetCertificate()
+	req := pipeline.GetRequest()
+	if req == nil || req.Attributes == nil || req.Attributes.Source == nil {
+		return nil, fmt.Errorf("client certificate is missing")
+	}
+	urlEncodedCert := req.Attributes.Source.GetCertificate()
 	if urlEncodedCert == "" {
 		return nil, fmt.Errorf("client certificate is missing")
 	}

--- a/pkg/utils/envvar.go
+++ b/pkg/utils/envvar.go
@@ -29,7 +29,7 @@ func EnvVar[T envVar](key string, def T) T {
 			return any(v).(T)
 		case reflect.Float32:
 			v, _ := strconv.ParseFloat(val, 32)
-			return any(v).(T)
+			return any(float32(v)).(T)
 		case reflect.Float64:
 			v, _ := strconv.ParseFloat(val, 64)
 			return any(v).(T)

--- a/pkg/utils/envvar_test.go
+++ b/pkg/utils/envvar_test.go
@@ -47,6 +47,26 @@ func TestFetchEnvVarBool(t *testing.T) {
 	assert.Equal(t, EnvVar("AUTHORINO_TEST_ENV_VAR_OTHER", false), false)
 }
 
+func TestFetchEnvVarFloat32(t *testing.T) {
+	_ = os.Setenv("AUTHORINO_TEST_ENV_VAR", "3.14")
+	defer func() {
+		_ = os.Unsetenv("AUTHORINO_TEST_ENV_VAR")
+	}()
+
+	assert.Equal(t, EnvVar("AUTHORINO_TEST_ENV_VAR", float32(0)), float32(3.14))
+	assert.Equal(t, EnvVar("AUTHORINO_TEST_ENV_VAR_OTHER", float32(1.5)), float32(1.5))
+}
+
+func TestFetchEnvVarFloat64(t *testing.T) {
+	_ = os.Setenv("AUTHORINO_TEST_ENV_VAR", "3.14")
+	defer func() {
+		_ = os.Unsetenv("AUTHORINO_TEST_ENV_VAR")
+	}()
+
+	assert.Equal(t, EnvVar("AUTHORINO_TEST_ENV_VAR", float64(0)), float64(3.14))
+	assert.Equal(t, EnvVar("AUTHORINO_TEST_ENV_VAR_OTHER", float64(1.5)), float64(1.5))
+}
+
 func TestFetchEnvVarInvalid(t *testing.T) {
 	_ = os.Setenv("AUTHORINO_TEST_ENV_VAR", "NaN")
 	defer func() {

--- a/pkg/workers/worker_test.go
+++ b/pkg/workers/worker_test.go
@@ -2,6 +2,7 @@ package workers
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -9,35 +10,53 @@ import (
 )
 
 func TestStartWorker(t *testing.T) {
+	var mu sync.Mutex
 	val := 0
 	worker, err := StartWorker(context.TODO(), 2, func() {
+		mu.Lock()
 		val += 1
+		mu.Unlock()
 	})
 	defer func(worker Worker) {
 		_ = worker.Stop()
 	}(worker)
 	assert.NilError(t, err)
 
-	assert.Equal(t, val, 0)
+	mu.Lock()
+	currentVal := val
+	mu.Unlock()
+	assert.Equal(t, currentVal, 0)
 
 	time.Sleep(3 * time.Second)
 
-	assert.Equal(t, val, 1)
+	mu.Lock()
+	currentVal = val
+	mu.Unlock()
+	assert.Equal(t, currentVal, 1)
 }
 
 func TestStopWorker(t *testing.T) {
+	var mu sync.Mutex
 	val := 0
 	worker, err := StartWorker(context.TODO(), 2, func() {
+		mu.Lock()
 		val += 1
+		mu.Unlock()
 	})
 	assert.NilError(t, err)
 
-	assert.Equal(t, val, 0)
+	mu.Lock()
+	currentVal := val
+	mu.Unlock()
+	assert.Equal(t, currentVal, 0)
 
 	err = worker.Stop()
 	assert.NilError(t, err)
 
 	time.Sleep(3 * time.Second)
 
-	assert.Equal(t, val, 0)
+	mu.Lock()
+	currentVal = val
+	mu.Unlock()
+	assert.Equal(t, currentVal, 0)
 }


### PR DESCRIPTION
## Summary

Cherry-picked patch-safe fixes from `main` for the v0.24.1 patch release (Kuadrant 1.4.4).

The `release-0.24` branch was created from the `v0.24.0` tag for this purpose — authorino previously tagged from `main` without release branches.

## Bug fixes
- **fix: convert ParseFloat result to float32 before type assertion** — runtime panic when `KUBE_CLIENT_QPS` env var is set (float64 asserted as float32)
- **fix: nil-guard optional user on kubernetesSubjectAccessReview** (#494) — panic on group-only SAR rules where `user` field is nil
- **fix: nil pointer safeguard when extracting cert from CheckRequest** — crash guard when certificate data is missing from the request (manual backport of 82fd0b40, adapted for pre-XFCC code)
- **fix: data races found in tests** — race conditions in OPA, JWT, and worker tests

## Security
- **CVE-2026-34986: bump go-jose to v4.1.4** — DoS via crafted JWE object with empty encrypted_key

## Dependency upgrades
- Go 1.25.5 → 1.25.9

## Skipped (not patch-safe)
- gRPC-Go 1.79.3 (pulls envoy control-plane v1.32.4 → v1.36.0, too many transitive changes)
- OpenTelemetry SDK 1.35.0 → 1.40.0 + trace schema updates (dependency chain with conflicts)
- gRPC well-known attributes (feature)
- XFCC / RFC 9440 client certificate extraction (feature, new API fields)
- CRD XValidation rules (feature, CRD schema changes)

## Test plan
- [x] CI passes on the release-0.24 branch
- [ ] Verify ParseFloat fix: set `KUBE_CLIENT_QPS=10.5` env var, confirm no panic
- [ ] Verify SAR nil-guard: create AuthConfig with group-only kubernetesSubjectAccessReview

🤖 Generated with [Claude Code](https://claude.com/claude-code)