### PR TITLE
ci: trigger test workflow on release branches

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -2,10 +2,10 @@ name: Unit Tests
 
 on:
   push:
-    branches: [ 'main', 'master' ]
+    branches: [ 'main', 'master', 'release-*' ]
 
   pull_request:
-    branches: [ 'main', 'master' ]
+    branches: [ 'main', 'master', 'release-*' ]
 
   merge_group:
     types: [ checks_requested ]


### PR DESCRIPTION
## Summary

Adds `release-*` to the push and pull_request branch triggers in `go-test.yaml` so CI runs on release branches.

Without this, PRs targeting release branches (e.g., backport PRs for patch releases) don't get CI validation.

Part of the RFC 0018 migration (Kuadrant/kuadrant-operator#1981).

🤖 Generated with [Claude Code](https://claude.com/claude-code)