### PR TITLE
Fix credential leakage in debug logs

### DIFF
--- a/docs/user-guides/observability.md
+++ b/docs/user-guides/observability.md
@@ -1143,9 +1143,65 @@ spec:
 
 ### Sensitive data output to the logs
 
-Authorino will never output HTTP headers and query string parameters to `info` log messages, as such values usually include sensitive data (e.g. access tokens, API keys and Authorino Festival Wristbands). However, `debug` log messages may include such sensitive information and those are not redacted.
+Authorino will never output HTTP headers and query string parameters to `info` log messages, as such values usually include sensitive data (e.g. access tokens, API keys and Authorino Festival Wristbands).
 
-Therefore, **DO NOT USE `debug` LOG LEVEL IN PRODUCTION**! Instead, use either `info` or `error`.
+For `debug` log messages, Authorino automatically redacts sensitive information to prevent credential leakage (CWE-532). The following data is redacted by default:
+
+**Redacted form fields:**
+- `token`, `access_token`, `refresh_token`, `id_token`
+- `client_secret`, `password`, `secret`
+- `api_key`, `apikey`
+
+**Redacted HTTP headers:**
+- `Authorization`, `Cookie`
+- `X-API-Key`, `APIKey`
+
+**Additionally redacted:**
+- URL credentials (userinfo in URLs like `https://user:pass@example.com`)
+- Kubernetes TokenReview tokens
+- Complete request bodies for JSON and other content types (form-encoded data has specific fields redacted)
+
+#### Customizing redaction
+
+You can customize which fields and headers are redacted using command-line flags:
+
+```bash
+# Add custom sensitive fields to redact
+--log-redact-add-field=custom_token
+--log-redact-add-field=tenant_secret
+
+# Add custom sensitive headers to redact
+--log-redact-add-header=X-Custom-Auth
+--log-redact-add-header=X-Internal-Token
+
+# Remove fields from default redaction list (use with caution)
+--log-redact-remove-field=api_key
+
+# Remove headers from default redaction list (use with caution)
+--log-redact-remove-header=cookie
+```
+
+**Important notes:**
+
+1. **Field and header matching is case-insensitive**: Adding `MyCustomToken` will redact `mycustomtoken`, `MyCustomToken`, and `MYCUSTOMTOKEN`.
+
+2. **Flags can be repeated**: Use multiple `--log-redact-add-field` flags to add multiple custom fields.
+
+3. **Redacted values are replaced with** `***REDACTED***` in the logs.
+
+4. **Use debug logging carefully**: Even with redaction, debug logs expose more internal details than info logs. Use `debug` level only for troubleshooting and switch back to `info` or `error` for production.
+
+**Example of redacted debug log output:**
+
+Before redaction:
+```
+sending token introspection request url=https://client:secret@oauth.example.com/introspect data=token=user_token_123&grant_type=client_credentials
+```
+
+After redaction:
+```
+sending token introspection request url=https://***REDACTED***:***REDACTED***@oauth.example.com/introspect data=token=***REDACTED***&grant_type=client_credentials
+```
 
 ### Log messages printed by Authorino
 

--- a/docs/user-guides/observability.md
+++ b/docs/user-guides/observability.md
@@ -1160,6 +1160,7 @@ For `debug` log messages, Authorino automatically redacts sensitive information 
 - URL credentials (userinfo in URLs like `https://user:pass@example.com`)
 - Kubernetes TokenReview tokens
 - Complete request bodies for JSON and other content types (form-encoded data has specific fields redacted)
+- Authorization pipeline evaluation data (identity claims, metadata, and request context)
 
 #### Customizing redaction
 

--- a/main.go
+++ b/main.go
@@ -128,6 +128,10 @@ type authServerOptions struct {
 	maxHttpRequestBodySize         int64
 	kubeClientQPS                  float32
 	kubeClientBurst                int
+	addSensitiveFields             []string
+	removeSensitiveFields          []string
+	addSensitiveHeaders            []string
+	removeSensitiveHeaders         []string
 }
 
 type webhookServerOptions struct {
@@ -192,6 +196,10 @@ func authServerCmd(opts *authServerOptions) *cobra.Command {
 	cmd.PersistentFlags().Int64Var(&opts.maxHttpRequestBodySize, "max-http-request-body-size", utils.EnvVar("MAX_HTTP_REQUEST_BODY_SIZE", int64(8192)), "Maximum size of the body of requests accepted in the raw HTTP interface of the authorization server - in bytes")
 	cmd.PersistentFlags().Float32Var(&opts.kubeClientQPS, "kube-client-qps", utils.EnvVar("KUBE_CLIENT_QPS", float32(20)), "QPS limit for each client sending requests to the kube-apiserver")
 	cmd.PersistentFlags().IntVar(&opts.kubeClientBurst, "kube-client-burst", utils.EnvVar("KUBE_CLIENT_BURST", 30), "Burst limit for each client sending requests to the kube-apiserver")
+	cmd.PersistentFlags().StringArrayVar(&opts.addSensitiveFields, "log-redact-add-field", []string{}, "Add a field name to the list of sensitive fields to redact from logs (can be repeated)")
+	cmd.PersistentFlags().StringArrayVar(&opts.removeSensitiveFields, "log-redact-remove-field", []string{}, "Remove a field name from the default list of sensitive fields (can be repeated)")
+	cmd.PersistentFlags().StringArrayVar(&opts.addSensitiveHeaders, "log-redact-add-header", []string{}, "Add a header name to the list of sensitive headers to redact from logs (can be repeated)")
+	cmd.PersistentFlags().StringArrayVar(&opts.removeSensitiveHeaders, "log-redact-remove-header", []string{}, "Remove a header name from the default list of sensitive headers (can be repeated)")
 
 	registerCommonServerOptions(cmd, &opts.commonServerOptions)
 
@@ -233,6 +241,20 @@ func runAuthorizationServer(cmd *cobra.Command, _ []string) {
 	opts := cmd.Context().Value(keyAuthServerOptions{}).(*authServerOptions)
 
 	setup(cmd, opts.log, opts.telemetry)
+
+	// Configure log redaction
+	for _, field := range opts.addSensitiveFields {
+		log.AddSensitiveField(field)
+	}
+	for _, field := range opts.removeSensitiveFields {
+		log.RemoveSensitiveField(field)
+	}
+	for _, header := range opts.addSensitiveHeaders {
+		log.AddSensitiveHeader(header)
+	}
+	for _, header := range opts.removeSensitiveHeaders {
+		log.RemoveSensitiveHeader(header)
+	}
 
 	// global options
 	evaluators.EvaluatorCacheSize = opts.evaluatorCacheSize

--- a/pkg/evaluators/identity/kubernetes_auth.go
+++ b/pkg/evaluators/identity/kubernetes_auth.go
@@ -42,7 +42,7 @@ func (kubeAuth *KubernetesAuth) Call(pipeline auth.AuthPipeline, ctx gocontext.C
 			},
 		}
 
-		log.FromContext(ctx).WithName("kubernetesauth").V(1).Info("calling kubernetes token review api", "tokenreview", tr)
+		log.FromContext(ctx).WithName("kubernetesauth").V(1).Info("calling kubernetes token review api", "tokenreview", log.RedactedTokenReview(tr))
 
 		if err := kubeAuth.k8sClient.Create(ctx, tr); err != nil {
 			return nil, err

--- a/pkg/evaluators/identity/oauth2.go
+++ b/pkg/evaluators/identity/oauth2.go
@@ -70,7 +70,7 @@ func (oauth *OAuth2) Call(pipeline auth.AuthPipeline, ctx gocontext.Context) (in
 		return nil, err
 	}
 
-	log.FromContext(ctx).WithName("oauth2").V(1).Info("sending token introspection request", "url", tokenIntrospectionURL.String(), "data", encodedFormData)
+	log.FromContext(ctx).WithName("oauth2").V(1).Info("sending token introspection request", "url", log.RedactedURL(tokenIntrospectionURL), "data", log.RedactedFormData(encodedFormData))
 
 	otel.GetTextMapPropagator().Inject(ctx, otel_propagation.HeaderCarrier(req.Header))
 

--- a/pkg/evaluators/metadata/generic_http.go
+++ b/pkg/evaluators/metadata/generic_http.go
@@ -159,12 +159,12 @@ func (h *GenericHttp) buildRequest(ctx gocontext.Context, endpoint, authJSON str
 	if logger := log.FromContext(ctx).WithName("http").V(1); logger.Enabled() {
 		logData := []interface{}{
 			"method", method,
-			"url", endpoint,
-			"headers", req.Header,
+			"url", log.RedactedURLString(endpoint),
+			"headers", log.RedactedHeaders(req.Header),
 		}
 		if requestBody != nil {
 			if b, ok := requestBody.(*bytes.Buffer); ok {
-				logData = append(logData, "body", b.String())
+				logData = append(logData, "body", log.RedactedRequestBody(b.String(), contentType))
 			}
 		}
 		logger.Info("sending request", logData...)

--- a/pkg/evaluators/metadata/uma.go
+++ b/pkg/evaluators/metadata/uma.go
@@ -248,7 +248,7 @@ func (uma *UMA) requestPAT(ctx gocontext.Context, pat *PAT) error {
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	log.FromContext(ctx).V(1).Info("requesting pat", "url", tokenURL.String(), "data", encodedData, "headers", req.Header)
+	log.FromContext(ctx).V(1).Info("requesting pat", "url", log.RedactedURL(tokenURL), "data", log.RedactedRequestBody(encodedData.String(), "application/x-www-form-urlencoded"), "headers", log.RedactedHeaders(req.Header))
 
 	otel.GetTextMapPropagator().Inject(ctx, otel_propagation.HeaderCarrier(req.Header))
 	// get the response

--- a/pkg/log/redact.go
+++ b/pkg/log/redact.go
@@ -263,10 +263,12 @@ func RedactedAuthorizationJSON(authJSON string) interface{} {
 		}
 	}
 
-	// Redact identity data - it may contain tokens or sensitive claims
-	// We keep the structure but redact string values in common sensitive fields
-	if identity, ok := data["identity"].(map[string]interface{}); ok {
-		redactSensitiveIdentityFields(identity)
+	// Redact identity data in auth.identity
+	// The authorization JSON has identity nested under "auth"
+	if auth, ok := data["auth"].(map[string]interface{}); ok {
+		if identity, ok := auth["identity"].(map[string]interface{}); ok {
+			redactSensitiveIdentityFields(identity)
+		}
 	}
 
 	return data
@@ -293,6 +295,12 @@ func redactSensitiveIdentityFields(identity map[string]interface{}) {
 	}
 	sensitiveFieldsMu.RUnlock()
 
+	// Special handling for Kubernetes Secret objects
+	if kind, ok := identity["kind"].(string); ok && kind == "Secret" {
+		redactKubernetesSecret(identity)
+		return
+	}
+
 	// Redact fields (case-insensitive)
 	for field := range identity {
 		if fieldsToRedact[strings.ToLower(field)] {
@@ -306,4 +314,91 @@ func redactSensitiveIdentityFields(identity map[string]interface{}) {
 			redactSensitiveIdentityFields(nested)
 		}
 	}
+}
+
+// redactKubernetesSecret redacts all data fields in a Kubernetes Secret
+func redactKubernetesSecret(secret map[string]interface{}) {
+	// Redact all entries in the 'data' field (base64-encoded secrets)
+	if data, ok := secret["data"].(map[string]interface{}); ok {
+		for key := range data {
+			data[key] = redacted
+		}
+	}
+
+	// Redact all entries in the 'stringData' field (plain text secrets)
+	if stringData, ok := secret["stringData"].(map[string]interface{}); ok {
+		for key := range stringData {
+			stringData[key] = redacted
+		}
+	}
+
+	// Redact secrets in annotations (kubectl last-applied-configuration can contain plaintext secrets)
+	if metadata, ok := secret["metadata"].(map[string]interface{}); ok {
+		if annotations, ok := metadata["annotations"].(map[string]interface{}); ok {
+			for key, value := range annotations {
+				// kubectl stores the last applied configuration which may contain plaintext secrets
+				if strings.Contains(strings.ToLower(key), "last-applied-configuration") {
+					if strValue, ok := value.(string); ok {
+						// Try to parse and redact secrets from the JSON annotation
+						annotations[key] = redactSecretsFromJSONString(strValue)
+					}
+				}
+			}
+		}
+	}
+}
+
+// redactSecretsFromJSONString redacts secrets from a JSON string (used in annotations)
+func redactSecretsFromJSONString(jsonStr string) string {
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
+		// If we can't parse it, redact the whole thing to be safe
+		return redacted
+	}
+
+	// Redact stringData and data fields
+	if stringData, ok := data["stringData"].(map[string]interface{}); ok {
+		for key := range stringData {
+			stringData[key] = redacted
+		}
+	}
+	if dataField, ok := data["data"].(map[string]interface{}); ok {
+		for key := range dataField {
+			dataField[key] = redacted
+		}
+	}
+
+	// Re-serialize
+	redactedJSON, err := json.Marshal(data)
+	if err != nil {
+		return redacted
+	}
+	return string(redactedJSON)
+}
+
+// RedactedIdentityObject redacts sensitive data from identity objects
+// This is used for logging identity validation results
+func RedactedIdentityObject(identity interface{}) interface{} {
+	if identity == nil {
+		return nil
+	}
+
+	// Convert to map[string]interface{} via JSON for uniform handling
+	// This handles typed structs (like Kubernetes v1.Secret) as well as maps
+	jsonBytes, err := json.Marshal(identity)
+	if err != nil {
+		// If we can't serialize it, return redacted to be safe
+		return redacted
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(jsonBytes, &data); err != nil {
+		// If we can't deserialize to map, return the original
+		// (might be a primitive type like string or number)
+		return identity
+	}
+
+	// Apply redaction
+	redactSensitiveIdentityFields(data)
+	return data
 }

--- a/pkg/log/redact.go
+++ b/pkg/log/redact.go
@@ -1,0 +1,161 @@
+package log
+
+import (
+	"net/url"
+	"strings"
+
+	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	"google.golang.org/protobuf/proto"
+	authv1 "k8s.io/api/authentication/v1"
+)
+
+const redacted = "***REDACTED***"
+
+// RedactedURL returns a URL string with the userinfo (credentials) redacted
+func RedactedURL(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	redactedURL := *u
+	if redactedURL.User != nil {
+		redactedURL.User = url.UserPassword(redacted, redacted)
+	}
+	return redactedURL.String()
+}
+
+// RedactedURLString parses a URL string and returns it with userinfo redacted
+func RedactedURLString(rawURL string) string {
+	if u, err := url.Parse(rawURL); err == nil {
+		return RedactedURL(u)
+	}
+	return rawURL
+}
+
+// RedactedFormData returns form-encoded data with sensitive fields redacted
+func RedactedFormData(data string) string {
+	values, err := url.ParseQuery(data)
+	if err != nil {
+		return redacted
+	}
+
+	// Redact common sensitive fields
+	sensitiveFields := []string{
+		"token",
+		"access_token",
+		"refresh_token",
+		"id_token",
+		"client_secret",
+		"password",
+		"secret",
+		"api_key",
+		"apikey",
+	}
+
+	for _, field := range sensitiveFields {
+		if values.Has(field) {
+			values.Set(field, redacted)
+		}
+	}
+
+	return values.Encode()
+}
+
+// RedactedTokenReview returns a TokenReview with the token redacted
+func RedactedTokenReview(tr *authv1.TokenReview) *authv1.TokenReview {
+	if tr == nil {
+		return nil
+	}
+
+	redactedTR := tr.DeepCopy()
+	if redactedTR.Spec.Token != "" {
+		redactedTR.Spec.Token = redacted
+	}
+
+	return redactedTR
+}
+
+// RedactedHeaders returns a copy of headers with sensitive values redacted
+func RedactedHeaders(headers map[string][]string) map[string][]string {
+	if headers == nil {
+		return nil
+	}
+
+	redactedHeaders := make(map[string][]string, len(headers))
+	sensitiveHeaders := map[string]bool{
+		"authorization": true,
+		"cookie":        true,
+		"x-api-key":     true,
+		"apikey":        true,
+	}
+
+	for k, v := range headers {
+		if sensitiveHeaders[strings.ToLower(k)] {
+			redactedHeaders[k] = []string{redacted}
+		} else {
+			redactedHeaders[k] = v
+		}
+	}
+
+	return redactedHeaders
+}
+
+// RedactedStringMapHeaders returns a copy of headers (map[string]string) with sensitive values redacted
+func RedactedStringMapHeaders(headers map[string]string) map[string]string {
+	if headers == nil {
+		return nil
+	}
+
+	redactedHeaders := make(map[string]string, len(headers))
+	sensitiveHeaders := map[string]bool{
+		"authorization": true,
+		"cookie":        true,
+		"x-api-key":     true,
+		"apikey":        true,
+	}
+
+	for k, v := range headers {
+		if sensitiveHeaders[strings.ToLower(k)] {
+			redactedHeaders[k] = redacted
+		} else {
+			redactedHeaders[k] = v
+		}
+	}
+
+	return redactedHeaders
+}
+
+// RedactedRequestBody returns a request body with sensitive content redacted
+// For now, we redact all body content that might contain credentials
+func RedactedRequestBody(body string, contentType string) string {
+	if body == "" {
+		return ""
+	}
+
+	// For form-encoded data, try to redact specific fields
+	if strings.Contains(contentType, "application/x-www-form-urlencoded") {
+		return RedactedFormData(body)
+	}
+
+	// For other content types (JSON, etc.), redact the entire body
+	// to avoid accidentally leaking credentials in complex nested structures
+	return redacted
+}
+
+// RedactedAttributeContext returns a deep copy of the AttributeContext with sensitive headers redacted
+func RedactedAttributeContext(attrs *envoy_auth.AttributeContext) *envoy_auth.AttributeContext {
+	if attrs == nil {
+		return nil
+	}
+
+	// Create a deep copy using protobuf cloning
+	redactedAttrs := proto.Clone(attrs).(*envoy_auth.AttributeContext)
+
+	// Redact headers in the HTTP request if present
+	if redactedAttrs.Request != nil && redactedAttrs.Request.Http != nil {
+		if redactedAttrs.Request.Http.Headers != nil {
+			redactedAttrs.Request.Http.Headers = RedactedStringMapHeaders(redactedAttrs.Request.Http.Headers)
+		}
+	}
+
+	return redactedAttrs
+}

--- a/pkg/log/redact.go
+++ b/pkg/log/redact.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"encoding/json"
 	"net/url"
 	"strings"
 	"sync"
@@ -231,4 +232,78 @@ func RedactedAttributeContext(attrs *envoy_auth.AttributeContext) *envoy_auth.At
 	}
 
 	return redactedAttrs
+}
+
+// RedactedAuthorizationJSON returns authorization JSON with sensitive data redacted
+// This function attempts to parse the JSON, redact sensitive fields, and re-serialize it.
+// If parsing fails, it returns the redacted placeholder to be safe.
+func RedactedAuthorizationJSON(authJSON string) interface{} {
+	var data map[string]interface{}
+	decoder := strings.NewReader(authJSON)
+	if err := json.NewDecoder(decoder).Decode(&data); err != nil {
+		// If we can't parse it, return redacted to be safe
+		return redacted
+	}
+
+	// Redact headers in context.request.http.headers
+	if context, ok := data["context"].(map[string]interface{}); ok {
+		if request, ok := context["request"].(map[string]interface{}); ok {
+			if httpReq, ok := request["http"].(map[string]interface{}); ok {
+				if headers, ok := httpReq["headers"].(map[string]interface{}); ok {
+					httpReq["headers"] = redactHeadersFromInterface(headers)
+				}
+			}
+		}
+	}
+
+	// Redact headers in request.headers (copy at top level)
+	if request, ok := data["request"].(map[string]interface{}); ok {
+		if headers, ok := request["headers"].(map[string]interface{}); ok {
+			request["headers"] = redactHeadersFromInterface(headers)
+		}
+	}
+
+	// Redact identity data - it may contain tokens or sensitive claims
+	// We keep the structure but redact string values in common sensitive fields
+	if identity, ok := data["identity"].(map[string]interface{}); ok {
+		redactSensitiveIdentityFields(identity)
+	}
+
+	return data
+}
+
+// redactHeadersFromInterface converts interface{} headers to map[string]string and redacts them
+func redactHeadersFromInterface(headers map[string]interface{}) map[string]string {
+	headersMap := make(map[string]string)
+	for k, v := range headers {
+		if strVal, ok := v.(string); ok {
+			headersMap[k] = strVal
+		}
+	}
+	return RedactedStringMapHeaders(headersMap)
+}
+
+// redactSensitiveIdentityFields redacts known sensitive fields in identity objects
+func redactSensitiveIdentityFields(identity map[string]interface{}) {
+	// Get configured sensitive fields
+	sensitiveFieldsMu.RLock()
+	fieldsToRedact := make(map[string]bool, len(sensitiveFields))
+	for k, v := range sensitiveFields {
+		fieldsToRedact[k] = v
+	}
+	sensitiveFieldsMu.RUnlock()
+
+	// Redact fields (case-insensitive)
+	for field := range identity {
+		if fieldsToRedact[strings.ToLower(field)] {
+			identity[field] = redacted
+		}
+	}
+
+	// Recursively redact nested objects
+	for _, value := range identity {
+		if nested, ok := value.(map[string]interface{}); ok {
+			redactSensitiveIdentityFields(nested)
+		}
+	}
 }

--- a/pkg/log/redact.go
+++ b/pkg/log/redact.go
@@ -269,6 +269,16 @@ func RedactedAuthorizationJSON(authJSON string) interface{} {
 		if identity, ok := auth["identity"].(map[string]interface{}); ok {
 			redactSensitiveIdentityFields(identity)
 		}
+
+		// Redact metadata in auth.metadata
+		// Structure is {"name1": obj1, "name2": obj2, ...}
+		if metadata, ok := auth["metadata"].(map[string]interface{}); ok {
+			for _, metadataObj := range metadata {
+				if metadataMap, ok := metadataObj.(map[string]interface{}); ok {
+					redactSensitiveIdentityFields(metadataMap)
+				}
+			}
+		}
 	}
 
 	return data

--- a/pkg/log/redact.go
+++ b/pkg/log/redact.go
@@ -3,6 +3,7 @@ package log
 import (
 	"net/url"
 	"strings"
+	"sync"
 
 	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	"google.golang.org/protobuf/proto"
@@ -10,6 +11,80 @@ import (
 )
 
 const redacted = "***REDACTED***"
+
+var (
+	// Global configuration for sensitive fields and headers
+	sensitiveFieldsMu sync.RWMutex
+	sensitiveFields   = map[string]bool{
+		"token":         true,
+		"access_token":  true,
+		"refresh_token": true,
+		"id_token":      true,
+		"client_secret": true,
+		"password":      true,
+		"secret":        true,
+		"api_key":       true,
+		"apikey":        true,
+	}
+
+	sensitiveHeadersMu sync.RWMutex
+	sensitiveHeaders   = map[string]bool{
+		"authorization": true,
+		"cookie":        true,
+		"x-api-key":     true,
+		"apikey":        true,
+	}
+)
+
+// AddSensitiveField adds a field name to the list of sensitive fields to redact
+func AddSensitiveField(field string) {
+	sensitiveFieldsMu.Lock()
+	defer sensitiveFieldsMu.Unlock()
+	sensitiveFields[strings.ToLower(field)] = true
+}
+
+// RemoveSensitiveField removes a field name from the list of sensitive fields
+func RemoveSensitiveField(field string) {
+	sensitiveFieldsMu.Lock()
+	defer sensitiveFieldsMu.Unlock()
+	delete(sensitiveFields, strings.ToLower(field))
+}
+
+// AddSensitiveHeader adds a header name to the list of sensitive headers to redact
+func AddSensitiveHeader(header string) {
+	sensitiveHeadersMu.Lock()
+	defer sensitiveHeadersMu.Unlock()
+	sensitiveHeaders[strings.ToLower(header)] = true
+}
+
+// RemoveSensitiveHeader removes a header name from the list of sensitive headers
+func RemoveSensitiveHeader(header string) {
+	sensitiveHeadersMu.Lock()
+	defer sensitiveHeadersMu.Unlock()
+	delete(sensitiveHeaders, strings.ToLower(header))
+}
+
+// GetSensitiveFields returns a copy of the current sensitive fields map
+func GetSensitiveFields() map[string]bool {
+	sensitiveFieldsMu.RLock()
+	defer sensitiveFieldsMu.RUnlock()
+	copy := make(map[string]bool, len(sensitiveFields))
+	for k, v := range sensitiveFields {
+		copy[k] = v
+	}
+	return copy
+}
+
+// GetSensitiveHeaders returns a copy of the current sensitive headers map
+func GetSensitiveHeaders() map[string]bool {
+	sensitiveHeadersMu.RLock()
+	defer sensitiveHeadersMu.RUnlock()
+	copy := make(map[string]bool, len(sensitiveHeaders))
+	for k, v := range sensitiveHeaders {
+		copy[k] = v
+	}
+	return copy
+}
 
 // RedactedURL returns a URL string with the userinfo (credentials) redacted
 func RedactedURL(u *url.URL) string {
@@ -38,22 +113,18 @@ func RedactedFormData(data string) string {
 		return redacted
 	}
 
-	// Redact common sensitive fields
-	sensitiveFields := []string{
-		"token",
-		"access_token",
-		"refresh_token",
-		"id_token",
-		"client_secret",
-		"password",
-		"secret",
-		"api_key",
-		"apikey",
+	// Redact configured sensitive fields
+	sensitiveFieldsMu.RLock()
+	fieldsToRedact := make(map[string]bool, len(sensitiveFields))
+	for k, v := range sensitiveFields {
+		fieldsToRedact[k] = v
 	}
+	sensitiveFieldsMu.RUnlock()
 
-	for _, field := range sensitiveFields {
-		if values.Has(field) {
-			values.Set(field, redacted)
+	// Check each field in the values (case-insensitive)
+	for fieldName := range values {
+		if fieldsToRedact[strings.ToLower(fieldName)] {
+			values.Set(fieldName, redacted)
 		}
 	}
 
@@ -80,16 +151,17 @@ func RedactedHeaders(headers map[string][]string) map[string][]string {
 		return nil
 	}
 
-	redactedHeaders := make(map[string][]string, len(headers))
-	sensitiveHeaders := map[string]bool{
-		"authorization": true,
-		"cookie":        true,
-		"x-api-key":     true,
-		"apikey":        true,
+	// Get configured sensitive headers
+	sensitiveHeadersMu.RLock()
+	headersToRedact := make(map[string]bool, len(sensitiveHeaders))
+	for k, v := range sensitiveHeaders {
+		headersToRedact[k] = v
 	}
+	sensitiveHeadersMu.RUnlock()
 
+	redactedHeaders := make(map[string][]string, len(headers))
 	for k, v := range headers {
-		if sensitiveHeaders[strings.ToLower(k)] {
+		if headersToRedact[strings.ToLower(k)] {
 			redactedHeaders[k] = []string{redacted}
 		} else {
 			redactedHeaders[k] = v
@@ -105,16 +177,17 @@ func RedactedStringMapHeaders(headers map[string]string) map[string]string {
 		return nil
 	}
 
-	redactedHeaders := make(map[string]string, len(headers))
-	sensitiveHeaders := map[string]bool{
-		"authorization": true,
-		"cookie":        true,
-		"x-api-key":     true,
-		"apikey":        true,
+	// Get configured sensitive headers
+	sensitiveHeadersMu.RLock()
+	headersToRedact := make(map[string]bool, len(sensitiveHeaders))
+	for k, v := range sensitiveHeaders {
+		headersToRedact[k] = v
 	}
+	sensitiveHeadersMu.RUnlock()
 
+	redactedHeaders := make(map[string]string, len(headers))
 	for k, v := range headers {
-		if sensitiveHeaders[strings.ToLower(k)] {
+		if headersToRedact[strings.ToLower(k)] {
 			redactedHeaders[k] = redacted
 		} else {
 			redactedHeaders[k] = v

--- a/pkg/log/redact_test.go
+++ b/pkg/log/redact_test.go
@@ -928,6 +928,58 @@ func TestRedactedAuthorizationJSON(t *testing.T) {
 			},
 		},
 		{
+			name: "Authorization JSON with sensitive metadata",
+			authJSON: `{
+				"auth": {
+					"identity": {
+						"username": "john"
+					},
+					"metadata": {
+						"external_source": {
+							"access_token": "metadata-token-123",
+							"user_id": "12345",
+							"api_key": "metadata-api-key"
+						},
+						"user_info": {
+							"email": "john@example.com",
+							"secret": "user-secret"
+						}
+					}
+				}
+			}`,
+			shouldNotContain: []string{"metadata-token-123", "metadata-api-key", "user-secret"},
+			checkFn: func(t *testing.T, result interface{}) {
+				data, ok := result.(map[string]interface{})
+				if !ok {
+					t.Fatal("Result should be a map")
+				}
+
+				auth := data["auth"].(map[string]interface{})
+				metadata := auth["metadata"].(map[string]interface{})
+
+				// Check external_source metadata
+				externalSource := metadata["external_source"].(map[string]interface{})
+				if externalSource["access_token"] != "***REDACTED***" {
+					t.Errorf("metadata access_token should be redacted")
+				}
+				if externalSource["api_key"] != "***REDACTED***" {
+					t.Errorf("metadata api_key should be redacted")
+				}
+				if externalSource["user_id"] != "12345" {
+					t.Errorf("user_id should be preserved")
+				}
+
+				// Check user_info metadata
+				userInfo := metadata["user_info"].(map[string]interface{})
+				if userInfo["secret"] != "***REDACTED***" {
+					t.Errorf("metadata secret should be redacted")
+				}
+				if userInfo["email"] != "john@example.com" {
+					t.Errorf("email should be preserved")
+				}
+			},
+		},
+		{
 			name:             "Invalid JSON",
 			authJSON:         `{invalid json`,
 			shouldNotContain: []string{},

--- a/pkg/log/redact_test.go
+++ b/pkg/log/redact_test.go
@@ -429,3 +429,154 @@ func containsSubstring(s, substr string) bool {
 	}
 	return false
 }
+
+func TestAddRemoveSensitiveField(t *testing.T) {
+	// Save original state
+	originalFields := GetSensitiveFields()
+	defer func() {
+		// Restore original state
+		sensitiveFieldsMu.Lock()
+		sensitiveFields = originalFields
+		sensitiveFieldsMu.Unlock()
+	}()
+
+	// Add a custom field
+	AddSensitiveField("custom_token")
+
+	// Test that it's now redacted
+	data := "custom_token=secret123&other=value"
+	result := RedactedFormData(data)
+
+	parsed, _ := url.ParseQuery(result)
+	if !contains(parsed.Get("custom_token"), "REDACTED") {
+		t.Errorf("custom_token should be redacted after adding")
+	}
+	if parsed.Get("other") != "value" {
+		t.Errorf("other field should be preserved")
+	}
+
+	// Remove the custom field
+	RemoveSensitiveField("custom_token")
+
+	// Test that it's no longer redacted
+	result2 := RedactedFormData(data)
+	parsed2, _ := url.ParseQuery(result2)
+	if parsed2.Get("custom_token") != "secret123" {
+		t.Errorf("custom_token should not be redacted after removal, got %v", parsed2.Get("custom_token"))
+	}
+}
+
+func TestAddRemoveSensitiveHeader(t *testing.T) {
+	// Save original state
+	originalHeaders := GetSensitiveHeaders()
+	defer func() {
+		// Restore original state
+		sensitiveHeadersMu.Lock()
+		sensitiveHeaders = originalHeaders
+		sensitiveHeadersMu.Unlock()
+	}()
+
+	// Add a custom header
+	AddSensitiveHeader("X-Custom-Token")
+
+	// Test that it's now redacted
+	headers := map[string][]string{
+		"X-Custom-Token": {"secret123"},
+		"Content-Type":   {"application/json"},
+	}
+	result := RedactedHeaders(headers)
+
+	if result["X-Custom-Token"][0] != "***REDACTED***" {
+		t.Errorf("X-Custom-Token should be redacted after adding")
+	}
+	if result["Content-Type"][0] != "application/json" {
+		t.Errorf("Content-Type should be preserved")
+	}
+
+	// Remove the custom header
+	RemoveSensitiveHeader("X-Custom-Token")
+
+	// Test that it's no longer redacted
+	result2 := RedactedHeaders(headers)
+	if result2["X-Custom-Token"][0] != "secret123" {
+		t.Errorf("X-Custom-Token should not be redacted after removal, got %v", result2["X-Custom-Token"][0])
+	}
+}
+
+func TestCaseInsensitiveSensitiveFields(t *testing.T) {
+	// Save original state
+	originalFields := GetSensitiveFields()
+	defer func() {
+		sensitiveFieldsMu.Lock()
+		sensitiveFields = originalFields
+		sensitiveFieldsMu.Unlock()
+	}()
+
+	// Add field in mixed case
+	AddSensitiveField("MyCustomToken")
+
+	// Test that it matches in various cases
+	testCases := []string{
+		"mycustomtoken=secret",
+		"MyCustomToken=secret",
+		"MYCUSTOMTOKEN=secret",
+	}
+
+	for _, tc := range testCases {
+		result := RedactedFormData(tc)
+		if contains(result, "secret") {
+			t.Errorf("Field should be redacted regardless of case: %s", tc)
+		}
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	// Save original state
+	originalFields := GetSensitiveFields()
+	originalHeaders := GetSensitiveHeaders()
+	defer func() {
+		sensitiveFieldsMu.Lock()
+		sensitiveFields = originalFields
+		sensitiveFieldsMu.Unlock()
+		sensitiveHeadersMu.Lock()
+		sensitiveHeaders = originalHeaders
+		sensitiveHeadersMu.Unlock()
+	}()
+
+	// Test concurrent reads and writes
+	done := make(chan bool)
+
+	// Writer goroutines
+	for i := 0; i < 10; i++ {
+		go func(n int) {
+			for j := 0; j < 100; j++ {
+				if n%2 == 0 {
+					AddSensitiveField("test")
+					AddSensitiveHeader("test")
+				} else {
+					RemoveSensitiveField("test")
+					RemoveSensitiveHeader("test")
+				}
+			}
+			done <- true
+		}(i)
+	}
+
+	// Reader goroutines
+	for i := 0; i < 10; i++ {
+		go func() {
+			for j := 0; j < 100; j++ {
+				_ = GetSensitiveFields()
+				_ = GetSensitiveHeaders()
+				_ = RedactedFormData("test=value")
+				_ = RedactedHeaders(map[string][]string{"Test": {"value"}})
+			}
+			done <- true
+		}()
+	}
+
+	// Wait for all goroutines to complete
+	for i := 0; i < 20; i++ {
+		<-done
+	}
+}

--- a/pkg/log/redact_test.go
+++ b/pkg/log/redact_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	authv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestRedactedURL(t *testing.T) {
@@ -418,6 +420,155 @@ func TestRedactedRequestBody(t *testing.T) {
 	}
 }
 
+func TestRedactedIdentityObject(t *testing.T) {
+	tests := []struct {
+		name             string
+		identity         interface{}
+		shouldNotContain []string
+		checkFn          func(*testing.T, interface{})
+	}{
+		{
+			name: "Kubernetes Secret with data and annotation",
+			identity: map[string]interface{}{
+				"kind":       "Secret",
+				"apiVersion": "v1",
+				"metadata": map[string]interface{}{
+					"name":      "api-key-1",
+					"namespace": "default",
+					"annotations": map[string]interface{}{
+						"kubectl.kubernetes.io/last-applied-configuration": `{"apiVersion":"v1","kind":"Secret","metadata":{"name":"api-key-1"},"stringData":{"api_key":"ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx"}}`,
+					},
+				},
+				"data": map[string]interface{}{
+					"api_key": "bmR5QnpyZVV6RjR6cURRc3FTUE1Ia1JocmlFT3RjUng=",
+				},
+				"type": "Opaque",
+			},
+			shouldNotContain: []string{"bmR5QnpyZVV6RjR6cURRc3FTUE1Ia1JocmlFT3RjUng=", "ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx"},
+			checkFn: func(t *testing.T, result interface{}) {
+				secret := result.(map[string]interface{})
+
+				// Check data is redacted
+				data := secret["data"].(map[string]interface{})
+				if data["api_key"] != "***REDACTED***" {
+					t.Errorf("api_key in data should be redacted, got %v", data["api_key"])
+				}
+
+				// Check metadata name is preserved
+				metadata := secret["metadata"].(map[string]interface{})
+				if metadata["name"] != "api-key-1" {
+					t.Errorf("Secret name should be preserved")
+				}
+
+				// Check annotation secrets are redacted
+				annotations := metadata["annotations"].(map[string]interface{})
+				annotation := annotations["kubectl.kubernetes.io/last-applied-configuration"].(string)
+				if contains(annotation, "ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx") {
+					t.Errorf("Plaintext secret in annotation should be redacted")
+				}
+			},
+		},
+		{
+			name: "Regular identity object with sensitive fields",
+			identity: map[string]interface{}{
+				"username":     "john",
+				"access_token": "secret-token-123",
+				"email":        "john@example.com",
+			},
+			shouldNotContain: []string{"secret-token-123"},
+			checkFn: func(t *testing.T, result interface{}) {
+				identity := result.(map[string]interface{})
+				if identity["username"] != "john" {
+					t.Errorf("username should be preserved")
+				}
+				if identity["access_token"] != "***REDACTED***" {
+					t.Errorf("access_token should be redacted")
+				}
+				if identity["email"] != "john@example.com" {
+					t.Errorf("email should be preserved")
+				}
+			},
+		},
+		{
+			name: "Typed Kubernetes Secret struct (real v1.Secret)",
+			identity: &corev1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "api-key-1",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/last-applied-configuration": `{"apiVersion":"v1","kind":"Secret","stringData":{"api_key":"ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx"}}`,
+					},
+				},
+				Data: map[string][]byte{
+					"api_key": []byte("bmR5QnpyZVV6RjR6cURRc3FTUE1Ia1JocmlFT3RjUng="),
+				},
+				Type: corev1.SecretTypeOpaque,
+			},
+			shouldNotContain: []string{"bmR5QnpyZVV6RjR6cURRc3FTUE1Ia1JocmlFT3RjUng=", "ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx"},
+			checkFn: func(t *testing.T, result interface{}) {
+				secret := result.(map[string]interface{})
+
+				// Check it's recognized as a Secret
+				if secret["kind"] != "Secret" {
+					t.Errorf("Expected kind=Secret, got %v", secret["kind"])
+				}
+
+				// Check data is redacted
+				data := secret["data"].(map[string]interface{})
+				if data["api_key"] != "***REDACTED***" {
+					t.Errorf("Typed Secret data.api_key should be redacted, got %v", data["api_key"])
+				}
+
+				// Check metadata is preserved
+				metadata := secret["metadata"].(map[string]interface{})
+				if metadata["name"] != "api-key-1" {
+					t.Errorf("Secret name should be preserved")
+				}
+
+				// Check annotation secrets are redacted
+				annotations := metadata["annotations"].(map[string]interface{})
+				annotation := annotations["kubectl.kubernetes.io/last-applied-configuration"].(string)
+				if contains(annotation, "ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx") {
+					t.Errorf("Plaintext secret in annotation should be redacted")
+				}
+			},
+		},
+		{
+			name:             "Primitive identity value",
+			identity:         "some-string-identity",
+			shouldNotContain: []string{},
+			checkFn: func(t *testing.T, result interface{}) {
+				if result != "some-string-identity" {
+					t.Errorf("Primitive identity should be returned as-is")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RedactedIdentityObject(tt.identity)
+
+			// Serialize to check for sensitive data
+			serialized, _ := json.Marshal(result)
+			resultStr := string(serialized)
+			for _, notExpected := range tt.shouldNotContain {
+				if contains(resultStr, notExpected) {
+					t.Errorf("Result should not contain %q, got %v", notExpected, resultStr)
+				}
+			}
+
+			if tt.checkFn != nil {
+				tt.checkFn(t, result)
+			}
+		})
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) > 0 && len(substr) > 0 && (s == substr || len(s) >= len(substr) && containsSubstring(s, substr))
 }
@@ -687,14 +838,16 @@ func TestRedactedAuthorizationJSON(t *testing.T) {
 			},
 		},
 		{
-			name: "Authorization JSON with sensitive identity fields",
+			name: "Authorization JSON with sensitive identity fields under auth",
 			authJSON: `{
-				"identity": {
-					"username": "john",
-					"access_token": "secret-access-token",
-					"api_key": "my-api-key",
-					"nested": {
-						"refresh_token": "secret-refresh-token"
+				"auth": {
+					"identity": {
+						"username": "john",
+						"access_token": "secret-access-token",
+						"api_key": "my-api-key",
+						"nested": {
+							"refresh_token": "secret-refresh-token"
+						}
 					}
 				}
 			}`,
@@ -705,7 +858,8 @@ func TestRedactedAuthorizationJSON(t *testing.T) {
 					t.Fatal("Result should be a map")
 				}
 
-				identity := data["identity"].(map[string]interface{})
+				auth := data["auth"].(map[string]interface{})
+				identity := auth["identity"].(map[string]interface{})
 				if identity["username"] != "john" {
 					t.Errorf("username should be preserved")
 				}
@@ -719,6 +873,57 @@ func TestRedactedAuthorizationJSON(t *testing.T) {
 				nested := identity["nested"].(map[string]interface{})
 				if nested["refresh_token"] != "***REDACTED***" {
 					t.Errorf("nested refresh_token should be redacted")
+				}
+			},
+		},
+		{
+			name: "Authorization JSON with Kubernetes Secret identity under auth",
+			authJSON: `{
+				"auth": {
+					"identity": {
+						"kind": "Secret",
+						"apiVersion": "v1",
+						"metadata": {
+							"name": "api-key-1",
+							"namespace": "default",
+							"annotations": {
+								"kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Secret\",\"metadata\":{\"name\":\"api-key-1\"},\"stringData\":{\"api_key\":\"plaintext-secret\"}}"
+							}
+						},
+						"data": {
+							"api_key": "base64-encoded-secret"
+						},
+						"type": "Opaque"
+					}
+				}
+			}`,
+			shouldNotContain: []string{"base64-encoded-secret", "plaintext-secret"},
+			checkFn: func(t *testing.T, result interface{}) {
+				data, ok := result.(map[string]interface{})
+				if !ok {
+					t.Fatal("Result should be a map")
+				}
+
+				auth := data["auth"].(map[string]interface{})
+				identity := auth["identity"].(map[string]interface{})
+
+				// Check data field is redacted
+				identityData := identity["data"].(map[string]interface{})
+				if identityData["api_key"] != "***REDACTED***" {
+					t.Errorf("Secret data.api_key should be redacted, got %v", identityData["api_key"])
+				}
+
+				// Check metadata is preserved
+				metadata := identity["metadata"].(map[string]interface{})
+				if metadata["name"] != "api-key-1" {
+					t.Errorf("Secret name should be preserved")
+				}
+
+				// Check annotation is redacted
+				annotations := metadata["annotations"].(map[string]interface{})
+				annotationStr := annotations["kubectl.kubernetes.io/last-applied-configuration"].(string)
+				if contains(annotationStr, "plaintext-secret") {
+					t.Errorf("Secret in annotation should be redacted, got %v", annotationStr)
 				}
 			},
 		},

--- a/pkg/log/redact_test.go
+++ b/pkg/log/redact_test.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"encoding/json"
 	"net/url"
 	"testing"
 
@@ -578,5 +579,177 @@ func TestConcurrentAccess(t *testing.T) {
 	// Wait for all goroutines to complete
 	for i := 0; i < 20; i++ {
 		<-done
+	}
+}
+
+func TestRedactedAuthorizationJSON(t *testing.T) {
+	tests := []struct {
+		name             string
+		authJSON         string
+		shouldNotContain []string
+		checkFn          func(*testing.T, interface{})
+	}{
+		{
+			name: "Authorization JSON with sensitive headers",
+			authJSON: `{
+				"context": {
+					"request": {
+						"http": {
+							"headers": {
+								"authorization": "Bearer secret-token",
+								"cookie": "session=abc123",
+								"content-type": "application/json"
+							}
+						}
+					}
+				},
+				"identity": {
+					"username": "john"
+				}
+			}`,
+			shouldNotContain: []string{"secret-token", "abc123"},
+			checkFn: func(t *testing.T, result interface{}) {
+				data, ok := result.(map[string]interface{})
+				if !ok {
+					t.Fatal("Result should be a map")
+				}
+
+				context := data["context"].(map[string]interface{})
+				request := context["request"].(map[string]interface{})
+				httpReq := request["http"].(map[string]interface{})
+				headers := httpReq["headers"].(map[string]string)
+
+				if headers["authorization"] != "***REDACTED***" {
+					t.Errorf("authorization header should be redacted, got %v", headers["authorization"])
+				}
+				if headers["cookie"] != "***REDACTED***" {
+					t.Errorf("cookie header should be redacted, got %v", headers["cookie"])
+				}
+				if headers["content-type"] != "application/json" {
+					t.Errorf("content-type should be preserved, got %v", headers["content-type"])
+				}
+			},
+		},
+		{
+			name: "Authorization JSON with headers in both locations",
+			authJSON: `{
+				"context": {
+					"request": {
+						"http": {
+							"headers": {
+								"authorization": "Bearer context-token",
+								"content-type": "application/json"
+							}
+						}
+					}
+				},
+				"request": {
+					"headers": {
+						"authorization": "Bearer request-token",
+						"cookie": "session=xyz",
+						"user-agent": "curl/7.0"
+					}
+				}
+			}`,
+			shouldNotContain: []string{"context-token", "request-token", "xyz"},
+			checkFn: func(t *testing.T, result interface{}) {
+				data, ok := result.(map[string]interface{})
+				if !ok {
+					t.Fatal("Result should be a map")
+				}
+
+				// Check context.request.http.headers
+				context := data["context"].(map[string]interface{})
+				contextRequest := context["request"].(map[string]interface{})
+				httpReq := contextRequest["http"].(map[string]interface{})
+				contextHeaders := httpReq["headers"].(map[string]string)
+
+				if contextHeaders["authorization"] != "***REDACTED***" {
+					t.Errorf("context authorization header should be redacted, got %v", contextHeaders["authorization"])
+				}
+				if contextHeaders["content-type"] != "application/json" {
+					t.Errorf("context content-type should be preserved")
+				}
+
+				// Check request.headers
+				request := data["request"].(map[string]interface{})
+				requestHeaders := request["headers"].(map[string]string)
+
+				if requestHeaders["authorization"] != "***REDACTED***" {
+					t.Errorf("request authorization header should be redacted, got %v", requestHeaders["authorization"])
+				}
+				if requestHeaders["cookie"] != "***REDACTED***" {
+					t.Errorf("request cookie header should be redacted, got %v", requestHeaders["cookie"])
+				}
+				if requestHeaders["user-agent"] != "curl/7.0" {
+					t.Errorf("request user-agent should be preserved")
+				}
+			},
+		},
+		{
+			name: "Authorization JSON with sensitive identity fields",
+			authJSON: `{
+				"identity": {
+					"username": "john",
+					"access_token": "secret-access-token",
+					"api_key": "my-api-key",
+					"nested": {
+						"refresh_token": "secret-refresh-token"
+					}
+				}
+			}`,
+			shouldNotContain: []string{"secret-access-token", "my-api-key", "secret-refresh-token"},
+			checkFn: func(t *testing.T, result interface{}) {
+				data, ok := result.(map[string]interface{})
+				if !ok {
+					t.Fatal("Result should be a map")
+				}
+
+				identity := data["identity"].(map[string]interface{})
+				if identity["username"] != "john" {
+					t.Errorf("username should be preserved")
+				}
+				if identity["access_token"] != "***REDACTED***" {
+					t.Errorf("access_token should be redacted")
+				}
+				if identity["api_key"] != "***REDACTED***" {
+					t.Errorf("api_key should be redacted")
+				}
+
+				nested := identity["nested"].(map[string]interface{})
+				if nested["refresh_token"] != "***REDACTED***" {
+					t.Errorf("nested refresh_token should be redacted")
+				}
+			},
+		},
+		{
+			name:             "Invalid JSON",
+			authJSON:         `{invalid json`,
+			shouldNotContain: []string{},
+			checkFn: func(t *testing.T, result interface{}) {
+				if result != "***REDACTED***" {
+					t.Errorf("Invalid JSON should return redacted placeholder, got %v", result)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RedactedAuthorizationJSON(tt.authJSON)
+
+			// Check that sensitive data is not in the result when serialized
+			serialized, _ := json.Marshal(result)
+			resultStr := string(serialized)
+			for _, notExpected := range tt.shouldNotContain {
+				if contains(resultStr, notExpected) {
+					t.Errorf("Result should not contain %q, got %v", notExpected, resultStr)
+				}
+			}
+
+			if tt.checkFn != nil {
+				tt.checkFn(t, result)
+			}
+		})
 	}
 }

--- a/pkg/log/redact_test.go
+++ b/pkg/log/redact_test.go
@@ -1,0 +1,431 @@
+package log
+
+import (
+	"net/url"
+	"testing"
+
+	authv1 "k8s.io/api/authentication/v1"
+)
+
+func TestRedactedURL(t *testing.T) {
+	tests := []struct {
+		name             string
+		url              string
+		shouldContain    string
+		shouldNotContain []string
+	}{
+		{
+			name:             "URL with username and password",
+			url:              "https://clientid:clientsecret@example.com/token",
+			shouldContain:    "@example.com/token",
+			shouldNotContain: []string{"clientid", "clientsecret"},
+		},
+		{
+			name:             "URL without credentials",
+			url:              "https://example.com/token",
+			shouldContain:    "https://example.com/token",
+			shouldNotContain: []string{},
+		},
+		{
+			name:             "URL with only username",
+			url:              "https://user@example.com/api",
+			shouldContain:    "@example.com/api",
+			shouldNotContain: []string{"user"},
+		},
+		{
+			name:             "Nil URL",
+			url:              "",
+			shouldContain:    "",
+			shouldNotContain: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var u *url.URL
+			if tt.url != "" {
+				var err error
+				u, err = url.Parse(tt.url)
+				if err != nil {
+					t.Fatalf("Failed to parse URL: %v", err)
+				}
+			}
+
+			result := RedactedURL(u)
+
+			if tt.shouldContain != "" && !contains(result, tt.shouldContain) {
+				t.Errorf("RedactedURL() should contain %q, got %v", tt.shouldContain, result)
+			}
+
+			for _, notExpected := range tt.shouldNotContain {
+				if contains(result, notExpected) {
+					t.Errorf("RedactedURL() should not contain %q, got %v", notExpected, result)
+				}
+			}
+		})
+	}
+}
+
+func TestRedactedURLString(t *testing.T) {
+	tests := []struct {
+		name             string
+		url              string
+		shouldContain    string
+		shouldNotContain []string
+	}{
+		{
+			name:             "URL string with credentials",
+			url:              "https://admin:password123@api.example.com/introspect",
+			shouldContain:    "@api.example.com/introspect",
+			shouldNotContain: []string{"admin", "password123"},
+		},
+		{
+			name:             "URL string without credentials",
+			url:              "https://api.example.com/introspect",
+			shouldContain:    "https://api.example.com/introspect",
+			shouldNotContain: []string{},
+		},
+		{
+			name:             "Invalid URL",
+			url:              "://invalid",
+			shouldContain:    "://invalid",
+			shouldNotContain: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RedactedURLString(tt.url)
+
+			if tt.shouldContain != "" && !contains(result, tt.shouldContain) {
+				t.Errorf("RedactedURLString() should contain %q, got %v", tt.shouldContain, result)
+			}
+
+			for _, notExpected := range tt.shouldNotContain {
+				if contains(result, notExpected) {
+					t.Errorf("RedactedURLString() should not contain %q, got %v", notExpected, result)
+				}
+			}
+		})
+	}
+}
+
+func TestRedactedFormData(t *testing.T) {
+	tests := []struct {
+		name             string
+		data             string
+		shouldNotContain []string
+		checkFn          func(*testing.T, string)
+	}{
+		{
+			name:             "Token in form data",
+			data:             "token=secret123&token_type_hint=access_token",
+			shouldNotContain: []string{"secret123"},
+			checkFn: func(t *testing.T, result string) {
+				parsed, _ := url.ParseQuery(result)
+				if !contains(parsed.Get("token"), "REDACTED") {
+					t.Errorf("token should be redacted, got %v", parsed.Get("token"))
+				}
+				if parsed.Get("token_type_hint") != "access_token" {
+					t.Errorf("token_type_hint should be preserved, got %v", parsed.Get("token_type_hint"))
+				}
+			},
+		},
+		{
+			name:             "Multiple sensitive fields",
+			data:             "client_secret=secretvalue&access_token=tokenvalue&grant_type=client_credentials",
+			shouldNotContain: []string{"secretvalue", "tokenvalue"},
+			checkFn: func(t *testing.T, result string) {
+				parsed, _ := url.ParseQuery(result)
+				if !contains(parsed.Get("client_secret"), "REDACTED") {
+					t.Errorf("client_secret should be redacted")
+				}
+				if !contains(parsed.Get("access_token"), "REDACTED") {
+					t.Errorf("access_token should be redacted")
+				}
+				if parsed.Get("grant_type") != "client_credentials" {
+					t.Errorf("grant_type should be preserved")
+				}
+			},
+		},
+		{
+			name:             "No sensitive fields",
+			data:             "grant_type=client_credentials&scope=read",
+			shouldNotContain: []string{},
+			checkFn: func(t *testing.T, result string) {
+				if !contains(result, "grant_type=client_credentials") {
+					t.Errorf("grant_type should be preserved")
+				}
+				if !contains(result, "scope=read") {
+					t.Errorf("scope should be preserved")
+				}
+			},
+		},
+		{
+			name:             "Password field",
+			data:             "username=admin&password=mypassword",
+			shouldNotContain: []string{"mypassword"},
+			checkFn: func(t *testing.T, result string) {
+				parsed, _ := url.ParseQuery(result)
+				if parsed.Get("username") != "admin" {
+					t.Errorf("username should be preserved")
+				}
+				if !contains(parsed.Get("password"), "REDACTED") {
+					t.Errorf("password should be redacted")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RedactedFormData(tt.data)
+
+			for _, notExpected := range tt.shouldNotContain {
+				if contains(result, notExpected) {
+					t.Errorf("RedactedFormData() result should not contain %q, got %v", notExpected, result)
+				}
+			}
+
+			if tt.checkFn != nil {
+				tt.checkFn(t, result)
+			}
+		})
+	}
+}
+
+func TestRedactedTokenReview(t *testing.T) {
+	tests := []struct {
+		name    string
+		tr      *authv1.TokenReview
+		checkFn func(*testing.T, *authv1.TokenReview)
+	}{
+		{
+			name: "TokenReview with token",
+			tr: &authv1.TokenReview{
+				Spec: authv1.TokenReviewSpec{
+					Token:     "my-secret-token",
+					Audiences: []string{"my-api"},
+				},
+			},
+			checkFn: func(t *testing.T, result *authv1.TokenReview) {
+				if result.Spec.Token != "***REDACTED***" {
+					t.Errorf("Expected token to be redacted, got %v", result.Spec.Token)
+				}
+				if len(result.Spec.Audiences) != 1 || result.Spec.Audiences[0] != "my-api" {
+					t.Errorf("Audiences should be preserved, got %v", result.Spec.Audiences)
+				}
+			},
+		},
+		{
+			name: "TokenReview with empty token",
+			tr: &authv1.TokenReview{
+				Spec: authv1.TokenReviewSpec{
+					Token:     "",
+					Audiences: []string{"my-api"},
+				},
+			},
+			checkFn: func(t *testing.T, result *authv1.TokenReview) {
+				if result.Spec.Token != "" {
+					t.Errorf("Expected empty token to remain empty, got %v", result.Spec.Token)
+				}
+			},
+		},
+		{
+			name: "Nil TokenReview",
+			tr:   nil,
+			checkFn: func(t *testing.T, result *authv1.TokenReview) {
+				if result != nil {
+					t.Errorf("Expected nil result for nil input, got %v", result)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RedactedTokenReview(tt.tr)
+			tt.checkFn(t, result)
+
+			// Ensure original is not modified
+			if tt.tr != nil && tt.tr.Spec.Token != "" && tt.tr.Spec.Token == "***REDACTED***" {
+				t.Error("Original TokenReview was modified")
+			}
+		})
+	}
+}
+
+func TestRedactedHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string][]string
+		checkFn func(*testing.T, map[string][]string)
+	}{
+		{
+			name: "Headers with Authorization",
+			headers: map[string][]string{
+				"Authorization": {"Bearer secret-token"},
+				"Content-Type":  {"application/json"},
+			},
+			checkFn: func(t *testing.T, result map[string][]string) {
+				if result["Authorization"][0] != "***REDACTED***" {
+					t.Errorf("Authorization should be redacted, got %v", result["Authorization"])
+				}
+				if result["Content-Type"][0] != "application/json" {
+					t.Errorf("Content-Type should be preserved, got %v", result["Content-Type"])
+				}
+			},
+		},
+		{
+			name: "Headers with Cookie",
+			headers: map[string][]string{
+				"Cookie":       {"session=abc123"},
+				"Content-Type": {"text/html"},
+			},
+			checkFn: func(t *testing.T, result map[string][]string) {
+				if result["Cookie"][0] != "***REDACTED***" {
+					t.Errorf("Cookie should be redacted, got %v", result["Cookie"])
+				}
+			},
+		},
+		{
+			name: "Headers with case variations",
+			headers: map[string][]string{
+				"authorization": {"Bearer token"},
+				"COOKIE":        {"session=xyz"},
+			},
+			checkFn: func(t *testing.T, result map[string][]string) {
+				if result["authorization"][0] != "***REDACTED***" {
+					t.Errorf("authorization (lowercase) should be redacted, got %v", result["authorization"])
+				}
+				if result["COOKIE"][0] != "***REDACTED***" {
+					t.Errorf("COOKIE (uppercase) should be redacted, got %v", result["COOKIE"])
+				}
+			},
+		},
+		{
+			name:    "Nil headers",
+			headers: nil,
+			checkFn: func(t *testing.T, result map[string][]string) {
+				if result != nil {
+					t.Errorf("Expected nil result for nil input, got %v", result)
+				}
+			},
+		},
+		{
+			name: "Headers with X-API-Key",
+			headers: map[string][]string{
+				"X-API-Key": {"myapikey123"},
+			},
+			checkFn: func(t *testing.T, result map[string][]string) {
+				if result["X-API-Key"][0] != "***REDACTED***" {
+					t.Errorf("X-API-Key should be redacted, got %v", result["X-API-Key"])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RedactedHeaders(tt.headers)
+			tt.checkFn(t, result)
+
+			// Ensure original is not modified
+			if tt.headers != nil {
+				for k, v := range tt.headers {
+					if len(v) > 0 && v[0] == "***REDACTED***" {
+						t.Errorf("Original headers were modified for key %s", k)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRedactedRequestBody(t *testing.T) {
+	tests := []struct {
+		name             string
+		body             string
+		contentType      string
+		shouldNotContain []string
+		checkFn          func(*testing.T, string)
+	}{
+		{
+			name:             "Form-encoded body with token",
+			body:             "token=secrettoken&grant_type=client_credentials",
+			contentType:      "application/x-www-form-urlencoded",
+			shouldNotContain: []string{"secrettoken"},
+			checkFn: func(t *testing.T, result string) {
+				parsed, _ := url.ParseQuery(result)
+				if !contains(parsed.Get("token"), "REDACTED") {
+					t.Errorf("token should be redacted")
+				}
+				if parsed.Get("grant_type") != "client_credentials" {
+					t.Errorf("grant_type should be preserved")
+				}
+			},
+		},
+		{
+			name:             "JSON body",
+			body:             `{"token":"secret","username":"admin"}`,
+			contentType:      "application/json",
+			shouldNotContain: []string{"secret", "admin"},
+			checkFn: func(t *testing.T, result string) {
+				if !contains(result, "REDACTED") {
+					t.Errorf("JSON body should be redacted")
+				}
+			},
+		},
+		{
+			name:             "Empty body",
+			body:             "",
+			contentType:      "application/json",
+			shouldNotContain: []string{},
+			checkFn: func(t *testing.T, result string) {
+				if result != "" {
+					t.Errorf("Empty body should return empty string, got %v", result)
+				}
+			},
+		},
+		{
+			name:             "Unknown content type",
+			body:             "some sensitive data",
+			contentType:      "text/plain",
+			shouldNotContain: []string{"sensitive"},
+			checkFn: func(t *testing.T, result string) {
+				if !contains(result, "REDACTED") {
+					t.Errorf("Unknown content type body should be redacted")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RedactedRequestBody(tt.body, tt.contentType)
+
+			for _, notExpected := range tt.shouldNotContain {
+				if contains(result, notExpected) {
+					t.Errorf("RedactedRequestBody() result should not contain %q, got %v", notExpected, result)
+				}
+			}
+
+			if tt.checkFn != nil {
+				tt.checkFn(t, result)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && (s == substr || len(s) >= len(substr) && containsSubstring(s, substr))
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -388,7 +388,7 @@ func (a *AuthService) logAuthRequest(req *envoy_auth.CheckRequest, ctx gocontext
 	logger.Info("incoming authorization request", "object", reducedReq) // info
 
 	if logger.V(1).Enabled() {
-		logger.V(1).Info("incoming authorization request", "object", &reqAttrs) // debug
+		logger.V(1).Info("incoming authorization request", "object", log.RedactedAttributeContext(reqAttrs)) // debug
 	}
 }
 

--- a/pkg/service/auth_pipeline.go
+++ b/pkg/service/auth_pipeline.go
@@ -292,11 +292,7 @@ func (pipeline *AuthPipeline) evaluateAuthorizationConfigs() EvaluationResponse 
 	logger := pipeline.Logger.WithName("authorization").V(1)
 
 	if logger.Enabled() {
-		var authJSON interface{}
-		err := gojson.Unmarshal([]byte(pipeline.GetAuthorizationJSON()), &authJSON)
-		if err != nil {
-			logger.V(1).Error(err, "failed to unmarshal authorization JSON")
-		}
+		authJSON := log.RedactedAuthorizationJSON(pipeline.GetAuthorizationJSON())
 		logger.Info("evaluating for input", "input", authJSON)
 	}
 

--- a/pkg/service/auth_pipeline.go
+++ b/pkg/service/auth_pipeline.go
@@ -240,7 +240,7 @@ func (pipeline *AuthPipeline) evaluateIdentityConfigs() EvaluationResponse {
 				} else {
 					pipeline.setIdentityObj(conf, extendedObj)
 
-					logger.Info("identity validated", "config", conf, "object", extendedObj)
+					logger.Info("identity validated", "config", conf, "object", log.RedactedIdentityObject(extendedObj))
 					return resp
 				}
 			} else {


### PR DESCRIPTION
## Summary

Fixes #617 - Prevents sensitive credentials from leaking into debug logs by implementing comprehensive redaction across all log statements.

## Problem

When debug logging is enabled (`--log-level=debug`), Authorino logged sensitive information in plain text, including:

- OAuth2 client credentials embedded in URLs
- Bearer tokens in form data during token introspection
- User credentials in Authorization headers and cookies
- API keys
- Kubernetes service account tokens
- **Complete Kubernetes Secret objects** (both base64-encoded data and plaintext in annotations)

This exposed credentials in centralized logging systems during troubleshooting, incident response, and security audits.

## Solution

Implemented automatic redaction that replaces sensitive data with `***REDACTED***` while preserving useful debugging information.

### What Gets Redacted

**Default redacted form fields:**
- `token`, `access_token`, `refresh_token`, `id_token`
- `client_secret`, `password`, `secret`
- `api_key`, `apikey`

**Default redacted HTTP headers:**
- `Authorization`, `Cookie`
- `X-API-Key`, `APIKey`

**Additionally redacted:**
- URL credentials (userinfo in URLs)
- Kubernetes TokenReview tokens
- Kubernetes Secret data (all keys in `data` and `stringData`)
- Secrets in `kubectl.kubernetes.io/last-applied-configuration` annotations
- Request bodies (form-encoded fields or complete body)
- Authorization pipeline evaluation data

### Configurable Redaction

New command-line flags allow customization:

```bash
--log-redact-add-field=custom_token          # Add custom sensitive field
--log-redact-remove-field=api_key            # Remove from defaults
--log-redact-add-header=X-Custom-Auth        # Add custom sensitive header
--log-redact-remove-header=cookie            # Remove from defaults
```

## Changes Made

### Core Redaction Engine
- **pkg/log/redact.go** - Thread-safe redaction utilities with configurable sensitive fields/headers
- **pkg/log/redact_test.go** - Comprehensive test coverage including Kubernetes Secret redaction

### Log Statement Updates
- **pkg/service/auth_pipeline.go** - Redact identity validation and authorization evaluation logs
- **pkg/evaluators/identity/oauth2.go** - Redact OAuth2 token introspection requests
- **pkg/evaluators/metadata/uma.go** - Redact UMA PAT requests
- **pkg/evaluators/identity/kubernetes_auth.go** - Redact Kubernetes TokenReview tokens
- **pkg/evaluators/metadata/generic_http.go** - Redact generic HTTP metadata/callbacks
- **pkg/service/auth.go** - Redact incoming authorization requests

### Configuration
- **main.go** - Add command-line flags for customizing redaction

### Documentation
- **docs/user-guides/observability.md** - Document redaction feature and configuration

## Verification Steps

### Prerequisites
```bash
# Set up a local environment based on the current branch
make local-setup FF=1

# Expose the proxy to send requests from localhost
kubectl port-forward deployment/envoy 8000:8000 2>&1 >/dev/null &

# Watch Authorino logs for sensitive data leakage
kubectl logs -f $(kubectl get pods -l authorino-resource=authorino -o name)
```

### Test 1: API Key in Authorization Header

```bash
# Create an API key secret
kubectl apply -f -<<EOF
apiVersion: v1
kind: Secret
metadata:
  name: api-key-1
  labels:
    authorino.kuadrant.io/managed-by: authorino
    group: friends
stringData:
  api_key: ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx
type: Opaque
EOF

# Create AuthConfig expecting API key in Authorization header
kubectl apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta3
kind: AuthConfig
metadata:
  name: talker-api-protection
spec:
  hosts:
  - talker-api.127.0.0.1.nip.io
  authentication:
    "friends":
      apiKey:
        selector:
          matchLabels:
            group: friends
EOF

# Send request and verify logs show ***REDACTED*** instead of the actual API key
curl -H 'Authorization: Bearer ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx' \
  http://talker-api.127.0.0.1.nip.io:8000/hello
```

**Expected in logs:**
- ✅ Authorization header shows `***REDACTED***`
- ✅ Secret `data.api_key` shows `***REDACTED***` (not base64-encoded value)
- ✅ Annotation secrets show `***REDACTED***` (not plaintext value)
- ❌ Should NOT see `ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx`
- ❌ Should NOT see `bmR5QnpyZVV6RjR6cURRc3FTUE1Ia1JocmlFT3RjUng=`

### Test 2: API Key in Custom Header

```bash
# Update AuthConfig to expect API key in custom header
kubectl apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta3
kind: AuthConfig
metadata:
  name: talker-api-protection
spec:
  hosts:
  - talker-api.127.0.0.1.nip.io
  authentication:
    "friends":
      apiKey:
        selector:
          matchLabels:
            group: friends
      credentials:
        customHeader:
          name: APIKEY
EOF

# Send request with custom header and verify redaction
curl -H 'APIKEY: ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx' \
  http://talker-api.127.0.0.1.nip.io:8000/hello
```

**Expected in logs:**
- ✅ Same redaction as Test 1
- ✅ Custom header value is NOT redacted by default (only standard headers)
- ✅ Can be configured with `--log-redact-add-header=APIKEY` if needed

## Notes

- Redaction only applies to debug logs (`V(1)`); info logs already have reduced data exposure
- All tests pass with comprehensive coverage for typed structs, maps, and edge cases
- Thread-safe implementation using `sync.RWMutex` for concurrent access
- Backwards compatible - default behavior improves security without breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debug logging is now safe for production: automatic redaction of sensitive fields, headers, URL credentials, request bodies and auth pipeline data.
  * New CLI flags to customise added/removed sensitive fields and headers (case-insensitive).

* **Documentation**
  * Observability guide updated with redaction behaviour, examples and CLI flag usage.

* **Tests**
  * Added extensive tests covering redaction behaviour and concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->