### PR TITLE
fix: disable pprof on status update manager to avoid port clash

### DIFF
--- a/main.go
+++ b/main.go
@@ -358,6 +358,7 @@ func runAuthorizationServer(cmd *cobra.Command, _ []string) {
 	statusUpdaterOptions := baseManagerOptions
 	statusUpdaterOptions.Metrics.BindAddress = "0"    // disabled so it does not clash with the reconciliation manager
 	statusUpdaterOptions.HealthProbeBindAddress = "0" // disabled so it does not clash with the reconciliation manager
+	statusUpdaterOptions.PprofBindAddress = "0"       // disabled so it does not clash with the reconciliation manager
 	statusUpdaterOptions.LeaderElection = opts.enableLeaderElection
 	statusUpdaterOptions.LeaderElectionID = fmt.Sprintf("%v.%v", hex.EncodeToString(leaderElectionId[:4]), leaderElectionIDSuffix)
 	statusUpdateManager, err := setupManager(restConfig, statusUpdaterOptions)


### PR DESCRIPTION
## Summary

Fixes Authorino failing to start after #612 merged. The status update manager inherits `PprofBindAddress` from `baseManagerOptions`, causing both managers to bind `:8084` and the second to fail with `address already in use`.

## Root cause

Authorino runs two `ctrl.Manager` instances — one for reconciliation, one for status updates. The status update manager is initialised as a copy of `baseManagerOptions` (line 358), which now includes `PprofBindAddress: ":8084"`. Metrics and health probe were already disabled on the second manager to avoid this exact conflict — pprof was missed.

## Fix

Disable pprof on the status update manager, matching the existing pattern:

```go
statusUpdaterOptions.Metrics.BindAddress = "0"    // already existed
statusUpdaterOptions.HealthProbeBindAddress = "0" // already existed
statusUpdaterOptions.PprofBindAddress = ""         // added
```

## Error before fix

```
{"level":"error","msg":"failed to setup status update manager","error":"failed to new pprof listener: error listening on :8084: listen tcp :8084: bind: address already in use"}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a conflict between internal monitoring endpoints to prevent port/binding clashes during startup, avoiding service startup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->