### PR TITLE
Add MetadataSpec and AuthorizationSpec CEL validation rules

### DIFF
--- a/api/v1beta2/auth_config_types.go
+++ b/api/v1beta2/auth_config_types.go
@@ -405,6 +405,7 @@ type PlainIdentitySpec struct {
 
 type AnonymousAccessSpec struct{}
 
+// +kubebuilder:validation:XValidation:rule="has(self.http) ? !(has(self.userInfo) || has(self.uma)) : has(self.userInfo) != has(self.uma)",message="Use exactly one of: http, userInfo, uma"
 type MetadataSpec struct {
 	CommonEvaluatorSpec `json:""`
 	MetadataMethodSpec  `json:""`
@@ -531,6 +532,7 @@ type UmaMetadataSpec struct {
 	Credentials *k8score.LocalObjectReference `json:"credentialsRef"`
 }
 
+// +kubebuilder:validation:XValidation:rule="has(self.patternMatching) ? !(has(self.opa) || has(self.kubernetesSubjectAccessReview) || has(self.spicedb)) : has(self.opa) ? !(has(self.kubernetesSubjectAccessReview) || has(self.spicedb)) : has(self.kubernetesSubjectAccessReview) != has(self.spicedb)",message="Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview, spicedb"
 type AuthorizationSpec struct {
 	CommonEvaluatorSpec     `json:""`
 	AuthorizationMethodSpec `json:""`

--- a/api/v1beta3/auth_config_types.go
+++ b/api/v1beta3/auth_config_types.go
@@ -368,7 +368,7 @@ type ApiKeyAuthenticationSpec struct {
 
 // Settings to fetch the JSON Web Key Set (JWKS) for the JWT authentication.
 //
-//	+kubebuilder:validation:XValidation:rule="!has(self.jwksUrl) || !has(self.issuerUrl)",message="Use one of: jwksUrl, issuerUrl"
+//	+kubebuilder:validation:XValidation:rule="has(self.jwksUrl) != has(self.issuerUrl)",message="Use one of: jwksUrl, issuerUrl"
 type JwtAuthenticationSpec struct {
 	// URL of the JSON Web Key Set (JWKS) endpoint.
 	// Use it for non-OpenID Connect (OIDC) JWT authentication, where the JWKS URL is known beforehand.
@@ -613,7 +613,7 @@ type OAuth2ClientAuthentication struct {
 
 // Settings of the OpendID Connect UserInfo linked to an OIDC-enabled JWT authentication config of this same AuthConfig.
 //
-//	+kubebuilder:validation:XValidation:rule="!has(self.identitySource) || !has(self.userInfoUrl)",message="Use one of: identitySource, userInfoUrl"
+//	+kubebuilder:validation:XValidation:rule="has(self.identitySource) != has(self.userInfoUrl)",message="Use one of: identitySource, userInfoUrl"
 type UserInfoMetadataSpec struct {
 	// Name of an OIDC JWT authentication rule whose obtained configuration includes an "userinfo_endpoint" claim.
 	// One of: identitySource, userInfoUrl

--- a/api/v1beta3/auth_config_types.go
+++ b/api/v1beta3/auth_config_types.go
@@ -368,7 +368,7 @@ type ApiKeyAuthenticationSpec struct {
 
 // Settings to fetch the JSON Web Key Set (JWKS) for the JWT authentication.
 //
-//	+kubebuilder:validation:XValidation:rule="!(has(self.jwksUrl) && self.jwksUrl != '' && has(self.issuerUrl) && self.issuerUrl != '')",message="Use one of: jwksUrl, issuerUrl"
+//	+kubebuilder:validation:XValidation:rule="!has(self.jwksUrl) || !has(self.issuerUrl)",message="Use one of: jwksUrl, issuerUrl"
 type JwtAuthenticationSpec struct {
 	// URL of the JSON Web Key Set (JWKS) endpoint.
 	// Use it for non-OpenID Connect (OIDC) JWT authentication, where the JWKS URL is known beforehand.
@@ -478,6 +478,7 @@ type PlainIdentitySpec struct {
 
 type AnonymousAccessSpec struct{}
 
+// +kubebuilder:validation:XValidation:rule="has(self.http) ? !(has(self.userInfo) || has(self.uma)) : has(self.userInfo) != has(self.uma)",message="Use exactly one of: http, userInfo, uma"
 type MetadataSpec struct {
 	CommonEvaluatorSpec `json:""`
 	MetadataMethodSpec  `json:""`
@@ -612,7 +613,7 @@ type OAuth2ClientAuthentication struct {
 
 // Settings of the OpendID Connect UserInfo linked to an OIDC-enabled JWT authentication config of this same AuthConfig.
 //
-//	+kubebuilder:validation:XValidation:rule="!(has(self.identitySource) && self.identitySource != '' && has(self.userInfoUrl) && self.userInfoUrl != '')",message="Use one of: identitySource, userInfoUrl"
+//	+kubebuilder:validation:XValidation:rule="!has(self.identitySource) || !has(self.userInfoUrl)",message="Use one of: identitySource, userInfoUrl"
 type UserInfoMetadataSpec struct {
 	// Name of an OIDC JWT authentication rule whose obtained configuration includes an "userinfo_endpoint" claim.
 	// One of: identitySource, userInfoUrl
@@ -640,6 +641,7 @@ type UmaMetadataSpec struct {
 	Credentials *k8score.LocalObjectReference `json:"credentialsRef"`
 }
 
+// +kubebuilder:validation:XValidation:rule="has(self.patternMatching) ? !(has(self.opa) || has(self.kubernetesSubjectAccessReview) || has(self.spicedb)) : has(self.opa) ? !(has(self.kubernetesSubjectAccessReview) || has(self.spicedb)) : has(self.kubernetesSubjectAccessReview) != has(self.spicedb)",message="Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview, spicedb"
 type AuthorizationSpec struct {
 	CommonEvaluatorSpec     `json:""`
 	AuthorizationMethodSpec `json:""`

--- a/install/crd/authorino.kuadrant.io_authconfigs.yaml
+++ b/install/crd/authorino.kuadrant.io_authconfigs.yaml
@@ -2577,7 +2577,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: 'Use one of: jwksUrl, issuerUrl'
-                        rule: '!has(self.jwksUrl) || !has(self.issuerUrl)'
+                        rule: has(self.jwksUrl) != has(self.issuerUrl)
                     kubernetesTokenReview:
                       description: Authentication by Kubernetes token review.
                       properties:
@@ -4257,7 +4257,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: 'Use one of: identitySource, userInfoUrl'
-                        rule: '!has(self.identitySource) || !has(self.userInfoUrl)'
+                        rule: has(self.identitySource) != has(self.userInfoUrl)
                     when:
                       description: |-
                         Conditions for Authorino to enforce this config.

--- a/install/crd/authorino.kuadrant.io_authconfigs.yaml
+++ b/install/crd/authorino.kuadrant.io_authconfigs.yaml
@@ -1007,6 +1007,13 @@ spec:
                         type: object
                       type: array
                   type: object
+                  x-kubernetes-validations:
+                  - message: 'Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview,
+                      spicedb'
+                    rule: 'has(self.patternMatching) ? !(has(self.opa) || has(self.kubernetesSubjectAccessReview)
+                      || has(self.spicedb)) : has(self.opa) ? !(has(self.kubernetesSubjectAccessReview)
+                      || has(self.spicedb)) : has(self.kubernetesSubjectAccessReview)
+                      != has(self.spicedb)'
                 description: |-
                   Authorization policies.
                   All policies MUST evaluate to "allowed = true" for the auth request be successful.
@@ -1616,6 +1623,10 @@ spec:
                         type: object
                       type: array
                   type: object
+                  x-kubernetes-validations:
+                  - message: 'Use exactly one of: http, userInfo, uma'
+                    rule: 'has(self.http) ? !(has(self.userInfo) || has(self.uma))
+                      : has(self.userInfo) != has(self.uma)'
                 description: |-
                   Metadata sources.
                   Authorino fetches auth metadata as JSON from sources specified in this config.
@@ -2566,8 +2577,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: 'Use one of: jwksUrl, issuerUrl'
-                        rule: '!(has(self.jwksUrl) && self.jwksUrl != '''' && has(self.issuerUrl)
-                          && self.issuerUrl != '''')'
+                        rule: '!has(self.jwksUrl) || !has(self.issuerUrl)'
                     kubernetesTokenReview:
                       description: Authentication by Kubernetes token review.
                       properties:
@@ -3555,6 +3565,13 @@ spec:
                         type: object
                       type: array
                   type: object
+                  x-kubernetes-validations:
+                  - message: 'Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview,
+                      spicedb'
+                    rule: 'has(self.patternMatching) ? !(has(self.opa) || has(self.kubernetesSubjectAccessReview)
+                      || has(self.spicedb)) : has(self.opa) ? !(has(self.kubernetesSubjectAccessReview)
+                      || has(self.spicedb)) : has(self.kubernetesSubjectAccessReview)
+                      != has(self.spicedb)'
                 description: |-
                   Authorization policies.
                   All policies MUST evaluate to "allowed = true" for the auth request be successful.
@@ -4240,8 +4257,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: 'Use one of: identitySource, userInfoUrl'
-                        rule: '!(has(self.identitySource) && self.identitySource !=
-                          '''' && has(self.userInfoUrl) && self.userInfoUrl != '''')'
+                        rule: '!has(self.identitySource) || !has(self.userInfoUrl)'
                     when:
                       description: |-
                         Conditions for Authorino to enforce this config.
@@ -4296,6 +4312,10 @@ spec:
                         type: object
                       type: array
                   type: object
+                  x-kubernetes-validations:
+                  - message: 'Use exactly one of: http, userInfo, uma'
+                    rule: 'has(self.http) ? !(has(self.userInfo) || has(self.uma))
+                      : has(self.userInfo) != has(self.uma)'
                 description: |-
                   Metadata sources.
                   Authorino fetches auth metadata as JSON from sources specified in this config.

--- a/install/crd/patches/oneof_in_authconfigs.yaml
+++ b/install/crd/patches/oneof_in_authconfigs.yaml
@@ -34,35 +34,6 @@
       required: [plain]
 
 - op: add
-  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/metadata/additionalProperties/oneOf
-  value:
-    - properties:
-        userInfo: {}
-      required: [userInfo]
-    - properties:
-        uma: {}
-      required: [uma]
-    - properties:
-        http: {}
-      required: [http]
-
-- op: add
-  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/authorization/additionalProperties/oneOf
-  value:
-    - properties:
-        opa: {}
-      required: [opa]
-    - properties:
-        patternMatching: {}
-      required: [patternMatching]
-    - properties:
-        kubernetesSubjectAccessReview: {}
-      required: [kubernetesSubjectAccessReview]
-    - properties:
-        spicedb: {}
-      required: [spicedb]
-
-- op: add
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/response/properties/success/properties/headers/additionalProperties/oneOf
   value:
     - properties:
@@ -246,35 +217,6 @@
         credentials: {}
         plain: {}
       required: [plain]
-
-- op: add
-  path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/metadata/additionalProperties/oneOf
-  value:
-    - properties:
-        userInfo: {}
-      required: [userInfo]
-    - properties:
-        uma: {}
-      required: [uma]
-    - properties:
-        http: {}
-      required: [http]
-
-- op: add
-  path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/authorization/additionalProperties/oneOf
-  value:
-    - properties:
-        opa: {}
-      required: [opa]
-    - properties:
-        patternMatching: {}
-      required: [patternMatching]
-    - properties:
-        kubernetesSubjectAccessReview: {}
-      required: [kubernetesSubjectAccessReview]
-    - properties:
-        spicedb: {}
-      required: [spicedb]
 
 - op: add
   path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/response/properties/success/properties/headers/additionalProperties/oneOf

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -2814,7 +2814,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: 'Use one of: jwksUrl, issuerUrl'
-                        rule: '!has(self.jwksUrl) || !has(self.issuerUrl)'
+                        rule: has(self.jwksUrl) != has(self.issuerUrl)
                     kubernetesTokenReview:
                       description: Authentication by Kubernetes token review.
                       properties:
@@ -4566,7 +4566,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: 'Use one of: identitySource, userInfoUrl'
-                        rule: '!has(self.identitySource) || !has(self.userInfoUrl)'
+                        rule: has(self.identitySource) != has(self.userInfoUrl)
                     when:
                       description: |-
                         Conditions for Authorino to enforce this config.

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -488,23 +488,6 @@ spec:
                 type: object
               authorization:
                 additionalProperties:
-                  oneOf:
-                  - properties:
-                      opa: {}
-                    required:
-                    - opa
-                  - properties:
-                      patternMatching: {}
-                    required:
-                    - patternMatching
-                  - properties:
-                      kubernetesSubjectAccessReview: {}
-                    required:
-                    - kubernetesSubjectAccessReview
-                  - properties:
-                      spicedb: {}
-                    required:
-                    - spicedb
                   properties:
                     cache:
                       description: |-
@@ -1119,6 +1102,13 @@ spec:
                         type: object
                       type: array
                   type: object
+                  x-kubernetes-validations:
+                  - message: 'Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview,
+                      spicedb'
+                    rule: 'has(self.patternMatching) ? !(has(self.opa) || has(self.kubernetesSubjectAccessReview)
+                      || has(self.spicedb)) : has(self.opa) ? !(has(self.kubernetesSubjectAccessReview)
+                      || has(self.spicedb)) : has(self.kubernetesSubjectAccessReview)
+                      != has(self.spicedb)'
                 description: |-
                   Authorization policies.
                   All policies MUST evaluate to "allowed = true" for the auth request be successful.
@@ -1416,19 +1406,6 @@ spec:
                 type: array
               metadata:
                 additionalProperties:
-                  oneOf:
-                  - properties:
-                      userInfo: {}
-                    required:
-                    - userInfo
-                  - properties:
-                      uma: {}
-                    required:
-                    - uma
-                  - properties:
-                      http: {}
-                    required:
-                    - http
                   properties:
                     cache:
                       description: |-
@@ -1761,6 +1738,10 @@ spec:
                         type: object
                       type: array
                   type: object
+                  x-kubernetes-validations:
+                  - message: 'Use exactly one of: http, userInfo, uma'
+                    rule: 'has(self.http) ? !(has(self.userInfo) || has(self.uma))
+                      : has(self.userInfo) != has(self.uma)'
                 description: |-
                   Metadata sources.
                   Authorino fetches auth metadata as JSON from sources specified in this config.
@@ -2833,8 +2814,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: 'Use one of: jwksUrl, issuerUrl'
-                        rule: '!(has(self.jwksUrl) && self.jwksUrl != '''' && has(self.issuerUrl)
-                          && self.issuerUrl != '''')'
+                        rule: '!has(self.jwksUrl) || !has(self.issuerUrl)'
                     kubernetesTokenReview:
                       description: Authentication by Kubernetes token review.
                       properties:
@@ -3109,23 +3089,6 @@ spec:
                 type: object
               authorization:
                 additionalProperties:
-                  oneOf:
-                  - properties:
-                      opa: {}
-                    required:
-                    - opa
-                  - properties:
-                      patternMatching: {}
-                    required:
-                    - patternMatching
-                  - properties:
-                      kubernetesSubjectAccessReview: {}
-                    required:
-                    - kubernetesSubjectAccessReview
-                  - properties:
-                      spicedb: {}
-                    required:
-                    - spicedb
                   properties:
                     cache:
                       description: |-
@@ -3911,6 +3874,13 @@ spec:
                         type: object
                       type: array
                   type: object
+                  x-kubernetes-validations:
+                  - message: 'Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview,
+                      spicedb'
+                    rule: 'has(self.patternMatching) ? !(has(self.opa) || has(self.kubernetesSubjectAccessReview)
+                      || has(self.spicedb)) : has(self.opa) ? !(has(self.kubernetesSubjectAccessReview)
+                      || has(self.spicedb)) : has(self.kubernetesSubjectAccessReview)
+                      != has(self.spicedb)'
                 description: |-
                   Authorization policies.
                   All policies MUST evaluate to "allowed = true" for the auth request be successful.
@@ -4267,19 +4237,6 @@ spec:
                 type: array
               metadata:
                 additionalProperties:
-                  oneOf:
-                  - properties:
-                      userInfo: {}
-                    required:
-                    - userInfo
-                  - properties:
-                      uma: {}
-                    required:
-                    - uma
-                  - properties:
-                      http: {}
-                    required:
-                    - http
                   properties:
                     cache:
                       description: |-
@@ -4609,8 +4566,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: 'Use one of: identitySource, userInfoUrl'
-                        rule: '!(has(self.identitySource) && self.identitySource !=
-                          '''' && has(self.userInfoUrl) && self.userInfoUrl != '''')'
+                        rule: '!has(self.identitySource) || !has(self.userInfoUrl)'
                     when:
                       description: |-
                         Conditions for Authorino to enforce this config.
@@ -4689,6 +4645,10 @@ spec:
                         type: object
                       type: array
                   type: object
+                  x-kubernetes-validations:
+                  - message: 'Use exactly one of: http, userInfo, uma'
+                    rule: 'has(self.http) ? !(has(self.userInfo) || has(self.uma))
+                      : has(self.userInfo) != has(self.uma)'
                 description: |-
                   Metadata sources.
                   Authorino fetches auth metadata as JSON from sources specified in this config.

--- a/tests/cel/v1beta3/authconfig_test.go
+++ b/tests/cel/v1beta3/authconfig_test.go
@@ -713,7 +713,7 @@ func TestPlainIdentitySpecCELValidation(t *testing.T) {
 
 // TestJwtAuthenticationSpecCELValidation tests the CEL validation rule on JwtAuthenticationSpec:
 //
-//	!has(self.jwksUrl) || !has(self.issuerUrl) -> "Use one of: jwksUrl, issuerUrl"
+//	has(self.jwksUrl) != has(self.issuerUrl) -> "Use one of: jwksUrl, issuerUrl"
 func TestJwtAuthenticationSpecCELValidation(t *testing.T) {
 	baseAuthConfig := v1beta3.AuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -750,7 +750,7 @@ func TestJwtAuthenticationSpecCELValidation(t *testing.T) {
 			},
 		},
 		{
-			desc: "valid - neither jwksUrl nor issuerUrl",
+			desc: "invalid - neither jwksUrl nor issuerUrl",
 			mutate: func(ac *v1beta3.AuthConfig) {
 				ac.Spec.Authentication["jwt"] = v1beta3.AuthenticationSpec{
 					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
@@ -758,6 +758,7 @@ func TestJwtAuthenticationSpecCELValidation(t *testing.T) {
 					},
 				}
 			},
+			wantErrors: []string{"Use one of: jwksUrl, issuerUrl"},
 		},
 		{
 			desc: "invalid - both jwksUrl and issuerUrl",
@@ -778,7 +779,7 @@ func TestJwtAuthenticationSpecCELValidation(t *testing.T) {
 
 // TestUserInfoMetadataSpecCELValidation tests the CEL validation rule on UserInfoMetadataSpec:
 //
-//	!has(self.identitySource) || !has(self.userInfoUrl) -> "Use one of: identitySource, userInfoUrl"
+//	has(self.identitySource) != has(self.userInfoUrl) -> "Use one of: identitySource, userInfoUrl"
 func TestUserInfoMetadataSpecCELValidation(t *testing.T) {
 	baseAuthConfig := v1beta3.AuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -822,7 +823,7 @@ func TestUserInfoMetadataSpecCELValidation(t *testing.T) {
 			},
 		},
 		{
-			desc: "valid - neither identitySource nor userInfoUrl",
+			desc: "invalid - neither identitySource nor userInfoUrl",
 			mutate: func(ac *v1beta3.AuthConfig) {
 				ac.Spec.Metadata["userinfo"] = v1beta3.MetadataSpec{
 					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
@@ -830,6 +831,7 @@ func TestUserInfoMetadataSpecCELValidation(t *testing.T) {
 					},
 				}
 			},
+			wantErrors: []string{"Use one of: identitySource, userInfoUrl"},
 		},
 		{
 			desc: "invalid - both identitySource and userInfoUrl",

--- a/tests/cel/v1beta3/authconfig_test.go
+++ b/tests/cel/v1beta3/authconfig_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/kuadrant/authorino/api/v1beta3"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -706,6 +707,590 @@ func TestPlainIdentitySpecCELValidation(t *testing.T) {
 				}
 			},
 			wantErrors: []string{"Use exactly one of: selector, expression"},
+		},
+	})
+}
+
+// TestJwtAuthenticationSpecCELValidation tests the CEL validation rule on JwtAuthenticationSpec:
+//
+//	!has(self.jwksUrl) || !has(self.issuerUrl) -> "Use one of: jwksUrl, issuerUrl"
+func TestJwtAuthenticationSpecCELValidation(t *testing.T) {
+	baseAuthConfig := v1beta3.AuthConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1beta3.AuthConfigSpec{
+			Hosts: []string{"test-jwt.example.com"},
+			Authentication: map[string]v1beta3.AuthenticationSpec{
+				"jwt": {
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						Jwt: &v1beta3.JwtAuthenticationSpec{
+							IssuerUrl: "https://issuer.example.com",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runTests(t, "test-jwt", baseAuthConfig, []validationTestCase{
+		{
+			desc: "valid - issuerUrl only",
+		},
+		{
+			desc: "valid - jwksUrl only",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authentication["jwt"] = v1beta3.AuthenticationSpec{
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						Jwt: &v1beta3.JwtAuthenticationSpec{
+							JwksUrl: "https://issuer.example.com/.well-known/jwks.json",
+						},
+					},
+				}
+			},
+		},
+		{
+			desc: "valid - neither jwksUrl nor issuerUrl",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authentication["jwt"] = v1beta3.AuthenticationSpec{
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						Jwt: &v1beta3.JwtAuthenticationSpec{},
+					},
+				}
+			},
+		},
+		{
+			desc: "invalid - both jwksUrl and issuerUrl",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authentication["jwt"] = v1beta3.AuthenticationSpec{
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						Jwt: &v1beta3.JwtAuthenticationSpec{
+							JwksUrl:   "https://issuer.example.com/.well-known/jwks.json",
+							IssuerUrl: "https://issuer.example.com",
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use one of: jwksUrl, issuerUrl"},
+		},
+	})
+}
+
+// TestUserInfoMetadataSpecCELValidation tests the CEL validation rule on UserInfoMetadataSpec:
+//
+//	!has(self.identitySource) || !has(self.userInfoUrl) -> "Use one of: identitySource, userInfoUrl"
+func TestUserInfoMetadataSpecCELValidation(t *testing.T) {
+	baseAuthConfig := v1beta3.AuthConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1beta3.AuthConfigSpec{
+			Hosts: []string{"test-userinfo.example.com"},
+			Authentication: map[string]v1beta3.AuthenticationSpec{
+				"anonymous": {
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						AnonymousAccess: &v1beta3.AnonymousAccessSpec{},
+					},
+				},
+			},
+			Metadata: map[string]v1beta3.MetadataSpec{
+				"userinfo": {
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						UserInfo: &v1beta3.UserInfoMetadataSpec{
+							IdentitySource: "jwt-auth",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runTests(t, "test-userinfo", baseAuthConfig, []validationTestCase{
+		{
+			desc: "valid - identitySource only",
+		},
+		{
+			desc: "valid - userInfoUrl only",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Metadata["userinfo"] = v1beta3.MetadataSpec{
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						UserInfo: &v1beta3.UserInfoMetadataSpec{
+							UserInfoUrl: "https://issuer.example.com/userinfo",
+						},
+					},
+				}
+			},
+		},
+		{
+			desc: "valid - neither identitySource nor userInfoUrl",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Metadata["userinfo"] = v1beta3.MetadataSpec{
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						UserInfo: &v1beta3.UserInfoMetadataSpec{},
+					},
+				}
+			},
+		},
+		{
+			desc: "invalid - both identitySource and userInfoUrl",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Metadata["userinfo"] = v1beta3.MetadataSpec{
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						UserInfo: &v1beta3.UserInfoMetadataSpec{
+							IdentitySource: "jwt-auth",
+							UserInfoUrl:    "https://issuer.example.com/userinfo",
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use one of: identitySource, userInfoUrl"},
+		},
+	})
+}
+
+// TestMetadataSpecCELValidation tests the CEL validation rule on MetadataSpec:
+//
+//	has(self.http) ? !(has(self.userInfo) || has(self.uma)) : has(self.userInfo) != has(self.uma)
+//	-> "Use exactly one of: http, userInfo, uma"
+func TestMetadataSpecCELValidation(t *testing.T) {
+	baseAuthConfig := v1beta3.AuthConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1beta3.AuthConfigSpec{
+			Hosts: []string{"test-metadata.example.com"},
+			Authentication: map[string]v1beta3.AuthenticationSpec{
+				"anonymous": {
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						AnonymousAccess: &v1beta3.AnonymousAccessSpec{},
+					},
+				},
+			},
+			Metadata: map[string]v1beta3.MetadataSpec{
+				"ext": {
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						Http: &v1beta3.HttpEndpointSpec{
+							Url: "http://metadata.example.com",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runTests(t, "test-metadata", baseAuthConfig, []validationTestCase{
+		{
+			desc: "valid - http only",
+		},
+		{
+			desc: "valid - userInfo only",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Metadata["ext"] = v1beta3.MetadataSpec{
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						UserInfo: &v1beta3.UserInfoMetadataSpec{
+							IdentitySource: "jwt-auth",
+						},
+					},
+				}
+			},
+		},
+		{
+			desc: "valid - uma only",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Metadata["ext"] = v1beta3.MetadataSpec{
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						Uma: &v1beta3.UmaMetadataSpec{
+							Endpoint:    "https://uma.example.com",
+							Credentials: &corev1.LocalObjectReference{Name: "uma-creds"},
+						},
+					},
+				}
+			},
+		},
+		{
+			desc: "invalid - no method specified",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Metadata["ext"] = v1beta3.MetadataSpec{}
+			},
+			wantErrors: []string{"Use exactly one of: http, userInfo, uma"},
+		},
+		{
+			desc: "invalid - both http and userInfo",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Metadata["ext"] = v1beta3.MetadataSpec{
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						Http: &v1beta3.HttpEndpointSpec{
+							Url: "http://metadata.example.com",
+						},
+						UserInfo: &v1beta3.UserInfoMetadataSpec{
+							IdentitySource: "jwt-auth",
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: http, userInfo, uma"},
+		},
+		{
+			desc: "invalid - both http and uma",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Metadata["ext"] = v1beta3.MetadataSpec{
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						Http: &v1beta3.HttpEndpointSpec{
+							Url: "http://metadata.example.com",
+						},
+						Uma: &v1beta3.UmaMetadataSpec{
+							Endpoint:    "https://uma.example.com",
+							Credentials: &corev1.LocalObjectReference{Name: "uma-creds"},
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: http, userInfo, uma"},
+		},
+		{
+			desc: "invalid - both userInfo and uma",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Metadata["ext"] = v1beta3.MetadataSpec{
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						UserInfo: &v1beta3.UserInfoMetadataSpec{
+							IdentitySource: "jwt-auth",
+						},
+						Uma: &v1beta3.UmaMetadataSpec{
+							Endpoint:    "https://uma.example.com",
+							Credentials: &corev1.LocalObjectReference{Name: "uma-creds"},
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: http, userInfo, uma"},
+		},
+		{
+			desc: "invalid - all three methods",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Metadata["ext"] = v1beta3.MetadataSpec{
+					MetadataMethodSpec: v1beta3.MetadataMethodSpec{
+						Http: &v1beta3.HttpEndpointSpec{
+							Url: "http://metadata.example.com",
+						},
+						UserInfo: &v1beta3.UserInfoMetadataSpec{
+							IdentitySource: "jwt-auth",
+						},
+						Uma: &v1beta3.UmaMetadataSpec{
+							Endpoint:    "https://uma.example.com",
+							Credentials: &corev1.LocalObjectReference{Name: "uma-creds"},
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: http, userInfo, uma"},
+		},
+	})
+}
+
+// TestAuthorizationSpecCELValidation tests the CEL validation rule on AuthorizationSpec:
+//
+//	has(self.patternMatching) ? !(has(self.opa) || has(self.kubernetesSubjectAccessReview) || has(self.spicedb))
+//	: has(self.opa) ? !(has(self.kubernetesSubjectAccessReview) || has(self.spicedb))
+//	: has(self.kubernetesSubjectAccessReview) != has(self.spicedb)
+//	-> "Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview, spicedb"
+func TestAuthorizationSpecCELValidation(t *testing.T) {
+	baseAuthConfig := v1beta3.AuthConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1beta3.AuthConfigSpec{
+			Hosts: []string{"test-authz.example.com"},
+			Authentication: map[string]v1beta3.AuthenticationSpec{
+				"anonymous": {
+					AuthenticationMethodSpec: v1beta3.AuthenticationMethodSpec{
+						AnonymousAccess: &v1beta3.AnonymousAccessSpec{},
+					},
+				},
+			},
+			Authorization: map[string]v1beta3.AuthorizationSpec{
+				"authz": {
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						PatternMatching: &v1beta3.PatternMatchingAuthorizationSpec{
+							Patterns: []v1beta3.PatternExpressionOrRef{
+								{CelPredicate: v1beta3.CelPredicate{Predicate: "true"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runTests(t, "test-authz", baseAuthConfig, []validationTestCase{
+		{
+			desc: "valid - patternMatching only",
+		},
+		{
+			desc: "valid - opa only",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["authz"] = v1beta3.AuthorizationSpec{
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						Opa: &v1beta3.OpaAuthorizationSpec{
+							Rego: "allow = true",
+						},
+					},
+				}
+			},
+		},
+		{
+			desc: "valid - kubernetesSubjectAccessReview only",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["authz"] = v1beta3.AuthorizationSpec{
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						KubernetesSubjectAccessReview: &v1beta3.KubernetesSubjectAccessReviewAuthorizationSpec{
+							User: &v1beta3.ValueOrSelector{
+								Selector: "auth.identity.username",
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			desc: "valid - spicedb only",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["authz"] = v1beta3.AuthorizationSpec{
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						SpiceDB: &v1beta3.SpiceDBAuthorizationSpec{
+							Endpoint: "spicedb:50051",
+						},
+					},
+				}
+			},
+		},
+		{
+			desc: "invalid - no method specified",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["authz"] = v1beta3.AuthorizationSpec{}
+			},
+			wantErrors: []string{"Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview, spicedb"},
+		},
+		{
+			desc: "invalid - patternMatching and opa",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["authz"] = v1beta3.AuthorizationSpec{
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						PatternMatching: &v1beta3.PatternMatchingAuthorizationSpec{
+							Patterns: []v1beta3.PatternExpressionOrRef{
+								{CelPredicate: v1beta3.CelPredicate{Predicate: "true"}},
+							},
+						},
+						Opa: &v1beta3.OpaAuthorizationSpec{
+							Rego: "allow = true",
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview, spicedb"},
+		},
+		{
+			desc: "invalid - patternMatching and kubernetesSubjectAccessReview",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["authz"] = v1beta3.AuthorizationSpec{
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						PatternMatching: &v1beta3.PatternMatchingAuthorizationSpec{
+							Patterns: []v1beta3.PatternExpressionOrRef{
+								{CelPredicate: v1beta3.CelPredicate{Predicate: "true"}},
+							},
+						},
+						KubernetesSubjectAccessReview: &v1beta3.KubernetesSubjectAccessReviewAuthorizationSpec{
+							User: &v1beta3.ValueOrSelector{
+								Selector: "auth.identity.username",
+							},
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview, spicedb"},
+		},
+		{
+			desc: "invalid - patternMatching and spicedb",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["authz"] = v1beta3.AuthorizationSpec{
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						PatternMatching: &v1beta3.PatternMatchingAuthorizationSpec{
+							Patterns: []v1beta3.PatternExpressionOrRef{
+								{CelPredicate: v1beta3.CelPredicate{Predicate: "true"}},
+							},
+						},
+						SpiceDB: &v1beta3.SpiceDBAuthorizationSpec{
+							Endpoint: "spicedb:50051",
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview, spicedb"},
+		},
+		{
+			desc: "invalid - opa and kubernetesSubjectAccessReview",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["authz"] = v1beta3.AuthorizationSpec{
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						Opa: &v1beta3.OpaAuthorizationSpec{
+							Rego: "allow = true",
+						},
+						KubernetesSubjectAccessReview: &v1beta3.KubernetesSubjectAccessReviewAuthorizationSpec{
+							User: &v1beta3.ValueOrSelector{
+								Selector: "auth.identity.username",
+							},
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview, spicedb"},
+		},
+		{
+			desc: "invalid - opa and spicedb",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["authz"] = v1beta3.AuthorizationSpec{
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						Opa: &v1beta3.OpaAuthorizationSpec{
+							Rego: "allow = true",
+						},
+						SpiceDB: &v1beta3.SpiceDBAuthorizationSpec{
+							Endpoint: "spicedb:50051",
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview, spicedb"},
+		},
+		{
+			desc: "invalid - kubernetesSubjectAccessReview and spicedb",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["authz"] = v1beta3.AuthorizationSpec{
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						KubernetesSubjectAccessReview: &v1beta3.KubernetesSubjectAccessReviewAuthorizationSpec{
+							User: &v1beta3.ValueOrSelector{
+								Selector: "auth.identity.username",
+							},
+						},
+						SpiceDB: &v1beta3.SpiceDBAuthorizationSpec{
+							Endpoint: "spicedb:50051",
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview, spicedb"},
+		},
+		{
+			desc: "invalid - patternMatching, opa, and kubernetesSubjectAccessReview",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["authz"] = v1beta3.AuthorizationSpec{
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						PatternMatching: &v1beta3.PatternMatchingAuthorizationSpec{
+							Patterns: []v1beta3.PatternExpressionOrRef{
+								{CelPredicate: v1beta3.CelPredicate{Predicate: "true"}},
+							},
+						},
+						Opa: &v1beta3.OpaAuthorizationSpec{
+							Rego: "allow = true",
+						},
+						KubernetesSubjectAccessReview: &v1beta3.KubernetesSubjectAccessReviewAuthorizationSpec{
+							User: &v1beta3.ValueOrSelector{
+								Selector: "auth.identity.username",
+							},
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview, spicedb"},
+		},
+		{
+			desc: "invalid - patternMatching, opa, and spicedb",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["authz"] = v1beta3.AuthorizationSpec{
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						PatternMatching: &v1beta3.PatternMatchingAuthorizationSpec{
+							Patterns: []v1beta3.PatternExpressionOrRef{
+								{CelPredicate: v1beta3.CelPredicate{Predicate: "true"}},
+							},
+						},
+						Opa: &v1beta3.OpaAuthorizationSpec{
+							Rego: "allow = true",
+						},
+						SpiceDB: &v1beta3.SpiceDBAuthorizationSpec{
+							Endpoint: "spicedb:50051",
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview, spicedb"},
+		},
+		{
+			desc: "invalid - patternMatching, kubernetesSubjectAccessReview, and spicedb",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["authz"] = v1beta3.AuthorizationSpec{
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						PatternMatching: &v1beta3.PatternMatchingAuthorizationSpec{
+							Patterns: []v1beta3.PatternExpressionOrRef{
+								{CelPredicate: v1beta3.CelPredicate{Predicate: "true"}},
+							},
+						},
+						KubernetesSubjectAccessReview: &v1beta3.KubernetesSubjectAccessReviewAuthorizationSpec{
+							User: &v1beta3.ValueOrSelector{
+								Selector: "auth.identity.username",
+							},
+						},
+						SpiceDB: &v1beta3.SpiceDBAuthorizationSpec{
+							Endpoint: "spicedb:50051",
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview, spicedb"},
+		},
+		{
+			desc: "invalid - opa, kubernetesSubjectAccessReview, and spicedb",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["authz"] = v1beta3.AuthorizationSpec{
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						Opa: &v1beta3.OpaAuthorizationSpec{
+							Rego: "allow = true",
+						},
+						KubernetesSubjectAccessReview: &v1beta3.KubernetesSubjectAccessReviewAuthorizationSpec{
+							User: &v1beta3.ValueOrSelector{
+								Selector: "auth.identity.username",
+							},
+						},
+						SpiceDB: &v1beta3.SpiceDBAuthorizationSpec{
+							Endpoint: "spicedb:50051",
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview, spicedb"},
+		},
+		{
+			desc: "invalid - all four methods",
+			mutate: func(ac *v1beta3.AuthConfig) {
+				ac.Spec.Authorization["authz"] = v1beta3.AuthorizationSpec{
+					AuthorizationMethodSpec: v1beta3.AuthorizationMethodSpec{
+						PatternMatching: &v1beta3.PatternMatchingAuthorizationSpec{
+							Patterns: []v1beta3.PatternExpressionOrRef{
+								{CelPredicate: v1beta3.CelPredicate{Predicate: "true"}},
+							},
+						},
+						Opa: &v1beta3.OpaAuthorizationSpec{
+							Rego: "allow = true",
+						},
+						KubernetesSubjectAccessReview: &v1beta3.KubernetesSubjectAccessReviewAuthorizationSpec{
+							User: &v1beta3.ValueOrSelector{
+								Selector: "auth.identity.username",
+							},
+						},
+						SpiceDB: &v1beta3.SpiceDBAuthorizationSpec{
+							Endpoint: "spicedb:50051",
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Use exactly one of: patternMatching, opa, kubernetesSubjectAccessReview, spicedb"},
 		},
 	})
 }


### PR DESCRIPTION
## Summary

Replaces oneOf patches with `+kubebuilder:validation:XValidation` CEL annotations for `MetadataSpec` and `AuthorizationSpec`, and simplifies the existing rules on `JwtAuthenticationSpec` and `UserInfoMetadataSpec`. Also adds comprehensive CEL validation tests for all four changed rules.

  Closes #599 — all candidates are now addressed between #602 and this PR. Migrating the remaining rules require further investigation as fitting them into the CRD cost budget would require simplifying existing rules. It is not worth spending time on in my opinion.

  ### Changes

  | Type | Fields | Change |
  |------|--------|--------|
  | `MetadataSpec` | `http` / `userInfo` / `uma` | New CEL rule (exactly one) |
  | `AuthorizationSpec` | `patternMatching` / `opa` / `kubernetesSubjectAccessReview` / `spicedb` | New CEL rule (exactly
  one) |
  | `JwtAuthenticationSpec` | `jwksUrl` / `issuerUrl` | Simplified CEL rule |
  | `UserInfoMetadataSpec` | `identitySource` / `userInfoUrl` | Simplified CEL rule |

  ## Verification

  ```bash
  make test-cel
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Strengthened CRD validation for `AuthConfig` to enforce correct “exactly one” combinations and mutual exclusivity across JWT authentication, metadata sources, and authorisation methods.
  * Updated validation logic and messages to make misconfigurations easier to diagnose.
* **Tests**
  * Added comprehensive CEL validation tests for `v1beta3` `AuthConfig`, covering missing required fields and invalid combinations for the updated configuration rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->