### PR TITLE
fix: add predicate to v1beta2 oneOf validation in AuthConfig CRD

### DIFF
--- a/install/crd/patches/oneof_in_authconfigs.yaml
+++ b/install/crd/patches/oneof_in_authconfigs.yaml
@@ -105,6 +105,9 @@
     - properties:
         any: {}
       required: [any]
+    - properties:
+        predicate: {}
+      required: [predicate]
 
 - op: add
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/when/items/oneOf
@@ -123,6 +126,9 @@
     - properties:
         any: {}
       required: [any]
+    - properties:
+        predicate: {}
+      required: [predicate]
 
 - op: add
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/authentication/additionalProperties/properties/when/items/oneOf
@@ -141,6 +147,9 @@
     - properties:
         any: {}
       required: [any]
+    - properties:
+        predicate: {}
+      required: [predicate]
 
 - op: add
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/metadata/additionalProperties/properties/when/items/oneOf
@@ -159,6 +168,9 @@
     - properties:
         any: {}
       required: [any]
+    - properties:
+        predicate: {}
+      required: [predicate]
 
 - op: add
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/authorization/additionalProperties/properties/when/items/oneOf
@@ -177,6 +189,9 @@
     - properties:
         any: {}
       required: [any]
+    - properties:
+        predicate: {}
+      required: [predicate]
 
 - op: add
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/response/properties/success/properties/headers/additionalProperties/properties/when/items/oneOf
@@ -195,6 +210,9 @@
     - properties:
         any: {}
       required: [any]
+    - properties:
+        predicate: {}
+      required: [predicate]
 
 - op: add
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/response/properties/success/properties/dynamicMetadata/additionalProperties/properties/when/items/oneOf
@@ -213,6 +231,9 @@
     - properties:
         any: {}
       required: [any]
+    - properties:
+        predicate: {}
+      required: [predicate]
 
 # v1beta3
 - op: add

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -379,6 +379,10 @@ spec:
                             any: {}
                           required:
                           - any
+                        - properties:
+                            predicate: {}
+                          required:
+                          - predicate
                         properties:
                           all:
                             description: A list of pattern expressions to be evaluated
@@ -895,6 +899,10 @@ spec:
                                 any: {}
                               required:
                               - any
+                            - properties:
+                                predicate: {}
+                              required:
+                              - predicate
                             properties:
                               all:
                                 description: A list of pattern expressions to be evaluated
@@ -1076,6 +1084,10 @@ spec:
                             any: {}
                           required:
                           - any
+                        - properties:
+                            predicate: {}
+                          required:
+                          - predicate
                         properties:
                           all:
                             description: A list of pattern expressions to be evaluated
@@ -1718,6 +1730,10 @@ spec:
                             any: {}
                           required:
                           - any
+                        - properties:
+                            predicate: {}
+                          required:
+                          - predicate
                         properties:
                           all:
                             description: A list of pattern expressions to be evaluated
@@ -1929,6 +1945,10 @@ spec:
                                     any: {}
                                   required:
                                   - any
+                                - properties:
+                                    predicate: {}
+                                  required:
+                                  - predicate
                                 properties:
                                   all:
                                     description: A list of pattern expressions to
@@ -2161,6 +2181,10 @@ spec:
                                     any: {}
                                   required:
                                   - any
+                                - properties:
+                                    predicate: {}
+                                  required:
+                                  - predicate
                                 properties:
                                   all:
                                     description: A list of pattern expressions to
@@ -2412,6 +2436,10 @@ spec:
                       any: {}
                     required:
                     - any
+                  - properties:
+                      predicate: {}
+                    required:
+                    - predicate
                   properties:
                     all:
                       description: A list of pattern expressions to be evaluated as


### PR DESCRIPTION
## Summary

- Add `predicate` as a valid `oneOf` option to all v1beta2 condition blocks in the AuthConfig CRD patch, fixing OLM upgrade failures on clusters with CEL predicate conditions

Fixes #627

## Problem

OLM validates all existing CRs against **all served CRD versions** on every operator upgrade ([`validateV1CRDCompatibility`](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/pkg/controller/operators/catalog/operator.go#L2276-L2298)). The v1beta2 `when` and `patternMatching.patterns` `oneOf` entries in [`install/crd/patches/oneof_in_authconfigs.yaml`](https://github.com/Kuadrant/authorino/blob/main/install/crd/patches/oneof_in_authconfigs.yaml) do not include `predicate` as a valid option, while v1beta3 does.

When v1beta3 AuthConfigs with predicate-only `when` conditions exist on the cluster (e.g. created by MaaS/RHOAI via AuthPolicy → Kuadrant Operator), OLM lists them via the v1beta2 endpoint (which returns the data as-is due to `conversion: None`) and validates against the v1beta2 schema. The `predicate` field doesn't match any v1beta2 `oneOf` option, so validation fails and the InstallPlan is rejected:

```
error validating existing CRs against new CRD's schema for "authconfigs.authorino.kuadrant.io":
  error validating authorino.kuadrant.io/v1beta2, Kind=AuthConfig:
  updated validation is too restrictive:
  "spec.authentication.openshift-identities.when[0]" must validate one and only one schema (oneOf). Found none valid
```

## Fix

Add `predicate` to all 7 v1beta2 `oneOf` blocks in the CRD patch to match the v1beta3 blocks. This is a schema-only change — v1beta2 doesn't process CEL predicates at runtime, but the relaxed validation allows OLM's cross-version check to pass for CRs that use them.

## Test plan

- [x] `make manifests` succeeds
- [x] Generated CRD has `predicate` in v1beta2 `when` oneOf
- [x] `make test` passes (all existing tests, no functional change)
- [ ] Verify on a cluster with MaaS AuthConfigs that the operator upgrade succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)