### PR TITLE
Add deprecation message to the v1beta2 version

### DIFF
--- a/api/v1beta2/auth_config_types.go
+++ b/api/v1beta2/auth_config_types.go
@@ -91,6 +91,7 @@ type StatusConditionType string
 // AuthConfig is the schema for Authorino's AuthConfig API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion:warning="AuthConfig version authorino.kuadrant.io/v1beta2 is deprecated, use authorino.kuadrant.io/v1beta3 version instead"
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.summary.ready`,description="Ready for all hosts"
 // +kubebuilder:printcolumn:name="Hosts",type=string,JSONPath=`.status.summary.numHostsReady`,description="Number of hosts ready"
 // +kubebuilder:printcolumn:name="Authentication",type=integer,JSONPath=`.status.summary.numIdentitySources`,description="Number of trusted identity sources",priority=2

--- a/install/crd/authorino.kuadrant.io_authconfigs.yaml
+++ b/install/crd/authorino.kuadrant.io_authconfigs.yaml
@@ -48,6 +48,9 @@ spec:
       name: Wristband
       priority: 2
       type: boolean
+    deprecated: true
+    deprecationWarning: AuthConfig version authorino.kuadrant.io/v1beta2 is deprecated,
+      use authorino.kuadrant.io/v1beta3 version instead
     name: v1beta2
     schema:
       openAPIV3Schema:

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -47,6 +47,9 @@ spec:
       name: Wristband
       priority: 2
       type: boolean
+    deprecated: true
+    deprecationWarning: AuthConfig version authorino.kuadrant.io/v1beta2 is deprecated,
+      use authorino.kuadrant.io/v1beta3 version instead
     name: v1beta2
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
## Summary

Mark AuthConfig v1beta2 CRD version as deprecated in favor of v1beta3, to prepare the users for the complete removal in https://github.com/Kuadrant/authorino/issues/628

## Verification
Deploy a local Kind cluster with `make local-setup` and verify the deprecation warning appears by making an api request to the deprecated version:
   ```sh
   authorino ❯ kubectl get authconfigs.v1beta2.authorino.kuadrant.io
   Warning: AuthConfig version authorino.kuadrant.io/v1beta2 AuthConfig is deprecated, use authorino.kuadrant.io/v1beta3 version instead
   ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * AuthConfig API version `v1beta2` is now marked as deprecated. Users are advised to migrate to version `v1beta3` for continued support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->