### PR TITLE
Upgrade Go to 1.26.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,7 @@ Both are registered in the scheme and controllers handle both versions.
 ## Dependencies
 
 Built with:
-- Go 1.26.x
+- Go (see `go.mod`)
 - controller-runtime v0.16.x
 - Kubernetes client-go v0.28.x
 - Envoy go-control-plane v1.36.x

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,7 @@ Both are registered in the scheme and controllers handle both versions.
 ## Dependencies
 
 Built with:
-- Go 1.25.x
+- Go 1.26.x
 - controller-runtime v0.16.x
 - Kubernetes client-go v0.28.x
 - Envoy go-control-plane v1.36.x

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,7 +241,7 @@ See the full Developer's Guide in [docs/contributing.md](docs/contributing.md) f
 step-by-step instructions on setting up your development environment, running
 tests, generating code, and submitting changes. Quick highlights:
 
-- **Environment:** install Go >=1.25 and recommended tools (see the guide).
+- **Environment:** install Go (version per `go.mod`) and recommended tools (see the guide).
 - **Tests:** run `make test` locally; use `make local-setup` to try changes
   in a local Kind cluster.
 - **Commit signing:** commits must be signed; follow the linked GitHub docs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build the authorino binary
 # https://catalog.redhat.com/software/containers/ubi10/go-toolset
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi10/go-toolset:1.25 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi10/go-toolset:1.26 AS builder
 WORKDIR /usr/src/authorino
 COPY ./ ./
 ARG version

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,7 +4,7 @@
 
 Minimum requirements to contribute to Authorino are:
 
-- [Golang v1.25+](https://golang.org)
+- [Golang](https://golang.org) (version per `go.mod`)
 - [Docker](https://docker.com) or [Podman](https://podman.io)
 
 Authorino's code was originally bundled using the [Operator SDK](https://sdk.operatorframework.io/) (v1.9.0).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/authzed/authzed-go v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/authzed/authzed-go v0.7.0

--- a/tests/cel/README.md
+++ b/tests/cel/README.md
@@ -17,7 +17,7 @@ Each version directory under `tests/cel/` contains:
 ### Prerequisites
 
 The tests require:
-- Go 1.25+
+- Go 1.26+
 - `controller-gen` tool (for CRD generation)
 - `envtest` binaries (downloaded automatically by the test setup)
 

--- a/tests/cel/README.md
+++ b/tests/cel/README.md
@@ -17,7 +17,7 @@ Each version directory under `tests/cel/` contains:
 ### Prerequisites
 
 The tests require:
-- Go 1.26+
+- Go (version per `go.mod`)
 - `controller-gen` tool (for CRD generation)
 - `envtest` binaries (downloaded automatically by the test setup)
 


### PR DESCRIPTION
Upgrade Go from 1.25.9 to 1.26.3.

Changes:
- [x] `go.mod`: `go 1.25.9` → `go 1.26.3`
- [x] `Dockerfile`: `go-toolset:1.25` → `go-toolset:1.26`
- [x] `go mod tidy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Go version requirement from **1.25.x** to **1.26.x** across build, module, and validation test setup.
  * Refreshed the Go toolchain used for container builds and updated developer/contributor guidance to follow the version specified in `go.mod`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->