### PR TITLE
Add authorino-operator manifests sync triggering workflow

### DIFF
--- a/.github/workflows/sync-operator-manifests.yaml
+++ b/.github/workflows/sync-operator-manifests.yaml
@@ -1,0 +1,24 @@
+name: Sync operator manifests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'install/manifests.yaml'
+      - 'install/crd/**'
+  workflow_dispatch: {}
+
+jobs:
+  notify-operator:
+    name: Notify authorino-operator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository dispatch
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.KUADRANT_DEV_PAT }}" \
+            https://api.github.com/repos/Kuadrant/authorino-operator/dispatches \
+            -d '{"event_type":"authorino-manifests-sync"}'


### PR DESCRIPTION
Adds a GitHub Actions workflow that sends a `repository_dispatch` event to [authorino-operator](https://github.com/Kuadrant/authorino-operator) when manifests are changed on the `main` branch (`install/manifests.yaml` or `install/crd/**`).

This triggers the operator's [sync-authorino-manifests](https://github.com/Kuadrant/authorino-operator/blob/sync-manifests-workflow/.github/workflows/sync-authorino-manifests.yaml) (https://github.com/Kuadrant/authorino-operator/pull/328) workflow, which regenerates and opens a PR with the updated operator manifests..
