### PR TITLE
Pin github action versions with Ratchet

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
       - 'master'
-  workflow_dispatch: { }
+  workflow_dispatch: {}
 
 env:
   IMG_TAGS: ${{ github.sha }}
@@ -61,19 +61,19 @@ jobs:
             runner: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Login to registry
         if: ${{ !env.ACT }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
         with:
           registry: ${{ env.IMG_REGISTRY_HOST }}
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -89,7 +89,7 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         with:
           name: digests-${{ strategy.job-index }}
           path: /tmp/digests/*
@@ -106,16 +106,16 @@ jobs:
     needs: [ prepare, build ]
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
         with:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
         with:
           images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino
           tags: |
@@ -124,7 +124,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Login to registry
         if: ${{ !env.ACT }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
         with:
           registry: ${{ env.IMG_REGISTRY_HOST }}
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -19,10 +19,10 @@ name: Code Style
 
 on:
   pull_request:
-    branches: [ 'main', 'master', 'release-*' ]
+    branches: ['main', 'master', 'release-*']
 
   merge_group:
-    types: [ checks_requested ]
+    types: [checks_requested]
 
 permissions:
   contents: read
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
         id: go
@@ -98,10 +98,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
         id: go
@@ -245,9 +245,9 @@ jobs:
     # This check adds a list of checks to one job to simplify adding settings to the repo.
     # If a new check is added in this file, and it should be retested on entry to the merge queue,
     # it needs to be added to the list below aka needs: [ existing check 1, existing check 2, new check ].
-    needs: [ lint, autoformat ]
+    needs: [lint, autoformat]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - run: echo '${{ toJSON(needs) }}' | jq -e 'all(.[]; .result == "success" or .result == "skipped")'

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -16,19 +16,19 @@ jobs:
     name: End-to-end Tests
     strategy:
       matrix:
-        platform: [ ubuntu-latest ]
-        authconfig_version: [ v1beta3 ]
+        platform: [ubuntu-latest]
+        authconfig_version: [v1beta3]
     runs-on: ${{ matrix.platform }}
     defaults:
       run:
         shell: bash
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
         with:
           ref: ${{ github.sha }}
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
         id: go

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -2,13 +2,13 @@ name: Unit Tests
 
 on:
   push:
-    branches: [ 'main', 'master', 'release-*' ]
+    branches: ['main', 'master', 'release-*']
 
   pull_request:
-    branches: [ 'main', 'master', 'release-*' ]
+    branches: ['main', 'master', 'release-*']
 
   merge_group:
-    types: [ checks_requested ]
+    types: [checks_requested]
 
 permissions:
   contents: read
@@ -18,16 +18,16 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        platform: [ ubuntu-latest ]
+        platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     defaults:
       run:
         shell: bash
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
         id: go
@@ -45,9 +45,9 @@ jobs:
     # This check adds a list of checks to one job to simplify adding settings to the repo.
     # If a new check is added in this file, and it should be retested on entry to the merge queue,
     # it needs to be added to the list below aka needs: [ existing check 1, existing check 2, new check ].
-    needs: [ unit-tests ]
+    needs: [unit-tests]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - run: echo '${{ toJSON(needs) }}' | jq -e 'all(.[]; .result == "success" or .result == "skipped")'

--- a/.github/workflows/issues-workflow.yaml
+++ b/.github/workflows/issues-workflow.yaml
@@ -20,7 +20,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event.issue.number != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v2.0.0
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # ratchet:actions/add-to-project@v2.0.0
         with:
           project-url: https://github.com/orgs/Kuadrant/projects/18
           github-token: ${{ secrets.ADD_ISSUES_TOKEN }}

--- a/.github/workflows/ratchet-check.yaml
+++ b/.github/workflows/ratchet-check.yaml
@@ -1,0 +1,26 @@
+name: Ratchet Check
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+jobs:
+  ratchet:
+    runs-on: ubuntu-latest
+    name: Check pinned actions
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: sethvargo/ratchet@8b4ca256dbed184350608a3023620f267f0a5253 # ratchet:sethvargo/ratchet@v0.11.4
+        with:
+          files: |
+            .github/workflows/*.yaml
+            .github/workflows/*.yml

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Smoke Tests
     strategy:
       matrix:
-        platform: [ ubuntu-latest ]
+        platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     defaults:
@@ -23,9 +23,9 @@ jobs:
         shell: bash
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
         id: go

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,16 @@ go test -v ./pkg/evaluators/...
 go test -race ./...
 ```
 
+### Static Analysis
+
+```bash
+# Verify GitHub Actions are pinned to commit SHAs
+make verify-ratchet
+
+# Pin GitHub Actions to commit SHAs
+make ratchet-pin
+```
+
 ## Architecture
 
 ### Core Components

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 MOCKGEN ?= $(LOCALBIN)/mockgen
 BENCHSTAT ?= $(LOCALBIN)/benchstat
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+RATCHET ?= $(LOCALBIN)/ratchet
 
 ## Tool Versions
 KIND_VERSION ?= v0.31.0
@@ -82,6 +83,7 @@ ENVTEST_K8S_VERSION ?= $(K8S_VERSION)
 MOCKGEN_VERSION ?= v0.6.0
 BENCHSTAT_VERSION ?= latest
 GOLANGCI_LINT_VERSION ?= v2.1.6
+RATCHET_VERSION ?= v0.11.4
 GO_VERSION ?= $(shell awk '/^go / {print $$2}' go.mod)
 
 ## Versioned Binaries (the actual files that 'make' will check for)
@@ -92,6 +94,7 @@ ENVTEST_V_BINARY := $(LOCALBIN)/setup-envtest-$(ENVTEST_VERSION)
 MOCKGEN_V_BINARY := $(LOCALBIN)/mockgen-$(MOCKGEN_VERSION)
 BENCHSTAT_V_BINARY := $(LOCALBIN)/benchstat-$(BENCHSTAT_VERSION)
 GOLANGCI_LINT_V_BINARY = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
+RATCHET_V_BINARY := $(LOCALBIN)/ratchet-$(RATCHET_VERSION)
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE_V_BINARY) ## Download kustomize locally if necessary.
@@ -127,6 +130,11 @@ $(KIND_V_BINARY): $(LOCALBIN)  ## Installs kind in $PROJECT_DIR/bin
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+.PHONY: ratchet
+ratchet: $(RATCHET_V_BINARY) ## Download ratchet locally if necessary.
+$(RATCHET_V_BINARY): $(LOCALBIN)
+	$(call go-install-tool,$(RATCHET),github.com/sethvargo/ratchet,$(RATCHET_VERSION))
 
 ifeq ($(shell uname),Darwin)
 SED=$(shell which gsed)
@@ -232,6 +240,19 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 .PHONY: lint-config
 lint-config: golangci-lint ## Verify golangci-lint linter configuration
 	$(GOLANGCI_LINT) config verify
+
+##@ Verify
+
+.PHONY: verify-all
+verify-all: verify-ratchet ## Run all verification checks.
+
+.PHONY: ratchet-pin
+ratchet-pin: ratchet ## Pin GitHub Actions to commit SHAs.
+	$(RATCHET) pin $$(find .github/workflows -name '*.yaml' -o -name '*.yml')
+
+.PHONY: verify-ratchet
+verify-ratchet: ratchet ## Verify GitHub Actions are pinned to commit SHAs.
+	$(RATCHET) lint $$(find .github/workflows -name '*.yaml' -o -name '*.yml')
 
 ##@ Apps
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,6 +18,7 @@ The following tools can be installed as part of the development workflow:
     - [benchstat](https://cs.opensource.google/go/x/perf): for human-friendly test benchmark reports
     - [mockgen](https://github.com/golang/mock): to generate mocks for tests – e.g. `./bin/mockgen -source=pkg/auth/auth.go -destination=pkg/auth/mocks/mock_auth.go`
     - [Kind](https://kind.sigs.k8s.io): for deploying a containerized Kubernetes cluster for integration testing purposes
+    - [Ratchet](https://github.com/sethvargo/ratchet): for pinning and verifying GitHub Actions versions to commit SHAs
 
 - _Other recommended tools to have installed:_
     - [jq](https://stedolan.github.io/jq/)
@@ -225,6 +226,20 @@ The following command deletes the entire Kubernetes cluster started with Kind:
 
 ```sh
 make local-cleanup
+```
+
+### Static analysis
+
+When adding or updating GitHub Actions in workflow files, pin them to commit SHAs using [Ratchet](https://github.com/sethvargo/ratchet):
+
+```sh
+make ratchet-pin
+```
+
+To verify that all actions are properly pinned:
+
+```sh
+make verify-ratchet
 ```
 
 ### Sign your commits


### PR DESCRIPTION
 ## Summary
  - Pin all GitHub Action references to commit SHAs using [ratchet](https://github.com/sethvargo/ratchet)
  - Add `ratchet-pin`, `verify-ratchet` and `verify-all` Make targets for pinning and verifying action references
  - Add  CI workflow to block PRs with unpinned action references

Part of the work on https://github.com/Kuadrant/kuadrant-operator/issues/2055

## Motivation
Tags are mutable — action maintainers can force-push them, silently changing the code our CI runs. Pinning to commit SHAs makes each reference immutable, mitigating supply-chain attacks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Ratchet Check” workflow to validate pinned versions for GitHub Actions in workflow files.
  * Added locally installable `ratchet` tooling with `make` targets to pin and verify workflow action versions.
* **Bug Fixes**
  * Updated multiple CI workflows to use commit-pinned action versions for more consistent builds and test runs.
  * Normalised minor workflow formatting (such as inline arrays/whitespace) without changing behaviour.
* **Documentation**
  * Documented the new ratchet-based pinning and verification steps in contribution guidance and agent setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->