### PR TITLE
Add cosigning and provenance attestation to image builds

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -96,6 +96,10 @@ jobs:
   merge:
     name: Create multi-platform manifest
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     needs: [ prepare, build ]
     steps:
       - name: Download digests
@@ -130,5 +134,23 @@ jobs:
             $(printf '${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino@sha256:%s ' *)
       - name: Inspect image
         if: ${{ !env.ACT }}
+        id: inspect
         run: |
           docker buildx imagetools inspect ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino:${{ needs.prepare.outputs.version_tag }}
+
+          digest=$(docker buildx imagetools inspect ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino:${{ needs.prepare.outputs.version_tag }} --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest=$digest" >> $GITHUB_OUTPUT
+      - name: Install cosign
+        if: ${{ !env.ACT }}
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # ratchet:sigstore/cosign-installer@v3
+      - name: Sign image with cosign
+        if: ${{ !env.ACT }}
+        run: |
+          cosign sign --yes ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino@${{ steps.inspect.outputs.digest }}
+      - name: Attest build provenance
+        if: ${{ !env.ACT }}
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # ratchet:actions/attest@v4
+        with:
+          subject-name: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino
+          subject-digest: ${{ steps.inspect.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
## Summary
  - Sign all container images (operator, bundle, catalog) with cosign (https://github.com/sigstore/cosign) keyless
  signing using the GitHub OIDC identity
  - Enable SLSA build provenance for Docker Buildx workflows (`provenance: true`)
  - New actions are pinned by commit SHA using ratchet (https://github.com/sethvargo/ratchet) format comments, consistent with action pinning being added in https://github.com/Kuadrant/authorino/pull/642

Part of the work on https://github.com/Kuadrant/kuadrant-operator/issues/2038

## Context

This improves the Signed-Releases (https://github.com/ossf/scorecard/blob/main/docs/checks.md#signed-releases) check from the OpenSSF Scorecard (https://scorecard.dev/). Merging this should bring this section score from current 0 to 10.

## Verification

Image builds cosigning and attestation was verified with the kuadrant-operator image builds (https://github.com/Kuadrant/kuadrant-operator/pull/2073), the successful run of which can be found [here](https://github.com/averevki/kuadrant-operator/actions/runs/28458948292), with the images pushed [here](https://quay.io/repository/averevki/kuadrant-operator-catalog?tab=tags). 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security / Trust Enhancements**
  * Image releases now include digital signing and build provenance attestation for improved trust and traceability.
  * Published images are now verified using the image digest during release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->