### PR TITLE
Add OPA Rego v1 evaluator

### DIFF
--- a/api/v1beta3/auth_config_types.go
+++ b/api/v1beta3/auth_config_types.go
@@ -742,6 +742,13 @@ type OpaAuthorizationSpec struct {
 	// Returning all Rego rules can affect performance of OPA policies during reconciliation (policy precompile) and at runtime.
 	// +kubebuilder:default:=false
 	AllValues bool `json:"allValues,omitempty"`
+
+	// Version of the OPA Rego language syntax used in the policy.
+	// Defaults to "v0" for backward compatibility with existing policies, use "v1" to enable OPA v1.0 Rego syntax.
+	// It is recommended to upgrade your policies and use v1 syntax (https://www.openpolicyagent.org/docs/v0-upgrade#changes-to-rego-in-opa-v10), as v0 syntax is deprecated and may be removed in future releases of Authorino.
+	// +kubebuilder:validation:Enum=v0;v1
+	// +kubebuilder:default:="v0"
+	Version string `json:"version,omitempty"`
 }
 
 // ExternalOpaPolicy sets the configs for fetching OPA policies from an external source.

--- a/controllers/auth_config_controller.go
+++ b/controllers/auth_config_controller.go
@@ -40,6 +40,7 @@ import (
 	"github.com/kuadrant/authorino/pkg/oauth2"
 	"github.com/kuadrant/authorino/pkg/trace"
 	"github.com/kuadrant/authorino/pkg/utils"
+	opaParser "github.com/open-policy-agent/opa/v1/ast"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 
@@ -547,6 +548,7 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 	ctxWithLogger = log.IntoContext(ctx, log.FromContext(ctx).WithName("authorization"))
 
 	authzIndex := 0
+	regoV0DeprecationLogged := false
 	for authzName, authorization := range authConfig.Spec.Authorization {
 		predicates, err := buildPredicates(authConfig, authorization.Conditions, jsonexp.All)
 		if err != nil {
@@ -581,6 +583,15 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 			opa := authorization.Opa
 			secret := &v1.Secret{}
 
+			regoVersion, err := authorization_evaluators.RegoVersionFromString(opa.Version)
+			if err != nil {
+				return nil, err
+			}
+			if regoVersion == opaParser.RegoV0 && !regoV0DeprecationLogged {
+				log.FromContext(ctxWithLogger).Info("AuthConfig contains OPA policies using deprecated Rego v0 syntax. Consider upgrading to v1 syntax as soon as possible, since v0 syntax is deprecated and may be removed in future releases of Authorino")
+				regoV0DeprecationLogged = true
+			}
+
 			var (
 				sharedSecret   string
 				externalSource *authorization_evaluators.OPAExternalSource
@@ -607,8 +618,7 @@ func (r *AuthConfigReconciler) translateAuthConfig(ctx context.Context, authConf
 				}
 			}
 
-			var err error
-			translatedAuthorization.OPA, err = authorization_evaluators.NewOPAAuthorization(policyName, opa.Rego, externalSource, opa.AllValues, authzIndex, ctxWithLogger)
+			translatedAuthorization.OPA, err = authorization_evaluators.NewOPAAuthorization(policyName, opa.Rego, externalSource, opa.AllValues, regoVersion, authzIndex, ctxWithLogger)
 			if err != nil {
 				return nil, err
 			}

--- a/controllers/auth_config_controller_test.go
+++ b/controllers/auth_config_controller_test.go
@@ -79,13 +79,14 @@ func newTestAuthConfig(authConfigLabels map[string]string) api.AuthConfig {
 			"main-policy": {
 				AuthorizationMethodSpec: api.AuthorizationMethodSpec{
 					Opa: &api.OpaAuthorizationSpec{
+						Version: "v1",
 						Rego: `
-			method = object.get(input.context.request.http, "method", "")
-			path = object.get(input.context.request.http, "path", "")
+			method := input.context.request.http.method
+			path := input.context.request.http.path
 
-			allow {
+			allow if {
               method == "GET"
-              path = "/allow"
+              path == "/allow"
           }`,
 					},
 				},

--- a/install/crd/authorino.kuadrant.io_authconfigs.yaml
+++ b/install/crd/authorino.kuadrant.io_authconfigs.yaml
@@ -3359,6 +3359,16 @@ spec:
                             The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed).
                             The Rego document must NOT include the "package" declaration in line 1.
                           type: string
+                        version:
+                          default: v0
+                          description: |-
+                            Version of the OPA Rego language syntax used in the policy.
+                            Defaults to "v0" for backward compatibility with existing policies, use "v1" to enable OPA v1.0 Rego syntax.
+                            It is recommended to upgrade your policies and use v1 syntax (https://www.openpolicyagent.org/docs/v0-upgrade#changes-to-rego-in-opa-v10), as v0 syntax is deprecated and may be removed in future releases of Authorino.
+                          enum:
+                          - v0
+                          - v1
+                          type: string
                       type: object
                       x-kubernetes-validations:
                       - message: 'Use exactly one of: rego, externalPolicy'

--- a/install/manifests.yaml
+++ b/install/manifests.yaml
@@ -3620,6 +3620,16 @@ spec:
                             The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed).
                             The Rego document must NOT include the "package" declaration in line 1.
                           type: string
+                        version:
+                          default: v0
+                          description: |-
+                            Version of the OPA Rego language syntax used in the policy.
+                            Defaults to "v0" for backward compatibility with existing policies, use "v1" to enable OPA v1.0 Rego syntax.
+                            It is recommended to upgrade your policies and use v1 syntax (https://www.openpolicyagent.org/docs/v0-upgrade#changes-to-rego-in-opa-v10), as v0 syntax is deprecated and may be removed in future releases of Authorino.
+                          enum:
+                          - v0
+                          - v1
+                          type: string
                       type: object
                       x-kubernetes-validations:
                       - message: 'Use exactly one of: rego, externalPolicy'

--- a/pkg/evaluators/authorization/opa.go
+++ b/pkg/evaluators/authorization/opa.go
@@ -17,14 +17,17 @@ import (
 	"github.com/kuadrant/authorino/pkg/log"
 	"github.com/kuadrant/authorino/pkg/workers"
 
-	opaParser "github.com/open-policy-agent/opa/ast" //nolint:staticcheck // ignore until a migration path is decided - https://github.com/Kuadrant/authorino/issues/546
-	"github.com/open-policy-agent/opa/rego"          //nolint:staticcheck // ignore until a migration path is decided - https://github.com/Kuadrant/authorino/issues/546
+	opaParser "github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/rego"
 
 	"go.opentelemetry.io/otel"
 	otel_propagation "go.opentelemetry.io/otel/propagation"
 )
 
 const (
+	RegoVersionV0 = "v0"
+	RegoVersionV1 = "v1"
+
 	policyTemplate = `package %s
 default allow = false
 %s`
@@ -40,7 +43,18 @@ default allow = false
 	msg_opaPolicyRefreshFromRegistryDisabled = "auto-refresh of external policy disabled"
 )
 
-func NewOPAAuthorization(policyName string, rego string, externalSource *OPAExternalSource, allValues bool, nonce int, ctx context.Context) (*OPA, error) {
+func RegoVersionFromString(version string) (opaParser.RegoVersion, error) {
+	switch version {
+	case RegoVersionV0:
+		return opaParser.RegoV0, nil
+	case RegoVersionV1:
+		return opaParser.RegoV1, nil
+	default:
+		return 0, fmt.Errorf("unsupported OPA Rego version: %s", version)
+	}
+}
+
+func NewOPAAuthorization(policyName string, rego string, externalSource *OPAExternalSource, allValues bool, regoVersion opaParser.RegoVersion, nonce int, ctx context.Context) (*OPA, error) {
 	logger := log.FromContext(ctx).WithName("opa")
 
 	pullFromRegistry := rego == "" && externalSource != nil && externalSource.Endpoint != ""
@@ -57,6 +71,7 @@ func NewOPAAuthorization(policyName string, rego string, externalSource *OPAExte
 	o := &OPA{
 		ExternalSource: externalSource,
 		AllValues:      allValues,
+		regoVersion:    regoVersion,
 		policyName:     policyName,
 		policyUID:      generatePolicyUID(policyName, rego, nonce),
 		opaContext:     context.TODO(),
@@ -77,10 +92,11 @@ type OPA struct {
 	ExternalSource *OPAExternalSource
 	AllValues      bool
 
-	opaContext context.Context
-	policy     *rego.PreparedEvalQuery
-	policyName string
-	policyUID  string
+	regoVersion opaParser.RegoVersion
+	opaContext  context.Context
+	policy      *rego.PreparedEvalQuery
+	policyName  string
+	policyUID   string
 
 	mu sync.RWMutex
 }
@@ -137,7 +153,7 @@ func (opa *OPA) updateRego(rego string, ctx context.Context, force bool) (bool, 
 
 	opa.Rego = newRego
 
-	if policy, err := precompilePolicy(opa.opaContext, opa.policyUID, opa.Rego, opa.AllValues); err != nil {
+	if policy, err := precompilePolicy(opa.opaContext, opa.policyUID, opa.Rego, opa.AllValues, opa.regoVersion); err != nil {
 		opa.Rego = currentRego
 		log.FromContext(ctx).Error(err, msg_OpaPolicyPrecompileError, "policy", opa.policyName)
 		return false, err
@@ -147,7 +163,7 @@ func (opa *OPA) updateRego(rego string, ctx context.Context, force bool) (bool, 
 	}
 }
 
-func precompilePolicy(ctx context.Context, policyUID, policyRego string, allValues bool) (*rego.PreparedEvalQuery, error) {
+func precompilePolicy(ctx context.Context, policyUID, policyRego string, allValues bool, regoVersion opaParser.RegoVersion) (*rego.PreparedEvalQuery, error) {
 	policyName := fmt.Sprintf(`authorino.authz["%s"]`, policyUID)
 	policyContent := fmt.Sprintf(policyTemplate, policyName, policyRego)
 	policyFileName := policyUID + ".rego"
@@ -157,7 +173,9 @@ func precompilePolicy(ctx context.Context, policyUID, policyRego string, allValu
 	queries := []string{fmt.Sprintf(queryTemplate, allowQuery, allowQuery)}
 	var err error
 
-	if module, err = opaParser.ParseModule(policyFileName, policyContent); err != nil {
+	if module, err = opaParser.ParseModuleWithOpts(policyFileName, policyContent, opaParser.ParserOptions{
+		RegoVersion: regoVersion,
+	}); err != nil {
 		return nil, err
 	}
 
@@ -175,6 +193,7 @@ func precompilePolicy(ctx context.Context, policyUID, policyRego string, allValu
 	r := rego.New(
 		rego.Query(strings.Join(queries, ";")),
 		rego.ParsedModule(module),
+		rego.SetRegoVersion(regoVersion),
 	)
 
 	if regoPolicy, err := r.PrepareForEval(ctx); err != nil {

--- a/pkg/evaluators/authorization/opa_test.go
+++ b/pkg/evaluators/authorization/opa_test.go
@@ -14,30 +14,56 @@ import (
 	mock_workers "github.com/kuadrant/authorino/pkg/workers/mocks"
 
 	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
-	"github.com/open-policy-agent/opa/rego" //nolint:staticcheck // ignore until a migration path is decided - https://github.com/Kuadrant/authorino/issues/546
+	opaParser "github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/rego"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/assert"
 )
 
 const (
 	opaExtHttpServerMockAddr string = "127.0.0.1:9007"
-	opaInlineRegoDataMock    string = `
+	opaInlineRegoV1DataMock  string = `
+		method := object.get(input.context.request.http, "method", "")
+		path := object.get(input.context.request.http, "path", "")
+		allow if { method == "GET"; path == "/allow" }`
+	opaInlineRegoV0DataMock string = `
 		method = object.get(input.context.request.http, "method", "")
 		path = object.get(input.context.request.http, "path", "")
 		allow { method == "GET"; path = "/allow" }`
 )
 
 func TestOPAInlineRego(t *testing.T) {
-	opa, err := NewOPAAuthorization("test-opa", opaInlineRegoDataMock, &OPAExternalSource{}, false, 0, context.TODO())
+	opa, err := NewOPAAuthorization("test-opa", opaInlineRegoV1DataMock, &OPAExternalSource{}, false, opaParser.RegoV1, 0, context.TODO())
 
 	assert.NilError(t, err)
 	assertOPAAuthorization(t, opa)
 }
 
+func TestOPAInlineRegoV0(t *testing.T) {
+	opa, err := NewOPAAuthorization("test-opa-v0", opaInlineRegoV0DataMock, &OPAExternalSource{}, false, opaParser.RegoV0, 0, context.TODO())
+
+	assert.NilError(t, err)
+	assertOPAAuthorization(t, opa)
+}
+
+func TestOPAV1SyntaxFailsWithV0(t *testing.T) {
+	opa, err := NewOPAAuthorization("test-opa-v1-as-v0", opaInlineRegoV1DataMock, &OPAExternalSource{}, false, opaParser.RegoV0, 0, context.TODO())
+
+	assert.Assert(t, err != nil)
+	assert.Assert(t, opa == nil)
+}
+
+func TestOPAV0SyntaxFailsWithV1(t *testing.T) {
+	opa, err := NewOPAAuthorization("test-opa-v0-as-v1", opaInlineRegoV0DataMock, &OPAExternalSource{}, false, opaParser.RegoV1, 0, context.TODO())
+
+	assert.Assert(t, err != nil)
+	assert.Assert(t, opa == nil)
+}
+
 func TestOPAExternalUrl(t *testing.T) {
 	extHttpMetadataServer := httptest.NewHttpServerMock(opaExtHttpServerMockAddr, map[string]httptest.HttpServerMockResponseFunc{
 		"/rego": func() httptest.HttpServerMockResponse {
-			return httptest.HttpServerMockResponse{Status: 200, Body: opaInlineRegoDataMock}
+			return httptest.HttpServerMockResponse{Status: 200, Body: opaInlineRegoV1DataMock}
 		},
 	})
 	defer extHttpMetadataServer.Close()
@@ -47,7 +73,7 @@ func TestOPAExternalUrl(t *testing.T) {
 		AuthCredentials: auth.NewAuthCredential("", ""),
 	}
 
-	opa, err := NewOPAAuthorization("test-opa", "", externalSource, false, 0, context.TODO())
+	opa, err := NewOPAAuthorization("test-opa", "", externalSource, false, opaParser.RegoV1, 0, context.TODO())
 
 	assert.NilError(t, err)
 	assertOPAAuthorization(t, opa)
@@ -66,15 +92,15 @@ func TestOPAInlineRegoAndExternalUrl(t *testing.T) {
 		AuthCredentials: auth.NewAuthCredential("", ""),
 	}
 
-	opa, err := NewOPAAuthorization("test-opa", opaInlineRegoDataMock, externalSource, false, 0, context.TODO())
+	opa, err := NewOPAAuthorization("test-opa", opaInlineRegoV1DataMock, externalSource, false, opaParser.RegoV1, 0, context.TODO())
 
 	assert.NilError(t, err)
 	assertOPAAuthorization(t, opa)
 }
 
 func TestOPAWithPackageInRego(t *testing.T) {
-	inlineRego := fmt.Sprintf("package my-rego-123\n%s", opaInlineRegoDataMock)
-	opa, err := NewOPAAuthorization("test-opa", inlineRego, &OPAExternalSource{}, false, 0, context.TODO())
+	inlineRego := fmt.Sprintf("package my-rego-123\n%s", opaInlineRegoV1DataMock)
+	opa, err := NewOPAAuthorization("test-opa", inlineRego, &OPAExternalSource{}, false, opaParser.RegoV1, 0, context.TODO())
 
 	assert.NilError(t, err)
 	assert.Assert(t, !strings.Contains(opa.Rego, "package"))
@@ -83,7 +109,7 @@ func TestOPAWithPackageInRego(t *testing.T) {
 }
 
 func TestOPAExternalUrlJsonResponse(t *testing.T) {
-	jsonData := `{"result": {"id": "empty","raw":"package my-rego-123\n\nmethod = object.get(input.context.request.http, \"method\", \"\")\npath = object.get(input.context.request.http, \"path\", \"\")\n\nallow { method == \"GET\"; path = \"/allow\" }"}}`
+	jsonData := `{"result": {"id": "empty","raw":"package my-rego-123\n\nmethod := object.get(input.context.request.http, \"method\", \"\")\npath := object.get(input.context.request.http, \"path\", \"\")\n\nallow if { method == \"GET\"; path == \"/allow\" }"}}`
 
 	extHttpMetadataServer := httptest.NewHttpServerMock(opaExtHttpServerMockAddr, map[string]httptest.HttpServerMockResponseFunc{
 		"/rego": func() httptest.HttpServerMockResponse {
@@ -97,7 +123,7 @@ func TestOPAExternalUrlJsonResponse(t *testing.T) {
 		AuthCredentials: auth.NewAuthCredential("", ""),
 	}
 
-	opa, err := NewOPAAuthorization("test-opa", "", externalSource, false, 0, context.TODO())
+	opa, err := NewOPAAuthorization("test-opa", "", externalSource, false, opaParser.RegoV1, 0, context.TODO())
 
 	assert.NilError(t, err)
 	assert.Assert(t, !strings.Contains(opa.Rego, "package"))
@@ -108,7 +134,7 @@ func TestOPAExternalUrlJsonResponse(t *testing.T) {
 func TestOPAExternalUrlMissingContentType(t *testing.T) {
 	extHttpMetadataServer := httptest.NewHttpServerMock(opaExtHttpServerMockAddr, map[string]httptest.HttpServerMockResponseFunc{
 		"/rego": func() httptest.HttpServerMockResponse {
-			return httptest.HttpServerMockResponse{Status: 200, Body: opaInlineRegoDataMock, Headers: map[string]string{"Content-Type": ""}}
+			return httptest.HttpServerMockResponse{Status: 200, Body: opaInlineRegoV1DataMock, Headers: map[string]string{"Content-Type": ""}}
 		},
 	})
 	defer extHttpMetadataServer.Close()
@@ -118,7 +144,7 @@ func TestOPAExternalUrlMissingContentType(t *testing.T) {
 		AuthCredentials: auth.NewAuthCredential("", ""),
 	}
 
-	opa, err := NewOPAAuthorization("test-opa", "", externalSource, false, 0, context.TODO())
+	opa, err := NewOPAAuthorization("test-opa", "", externalSource, false, opaParser.RegoV1, 0, context.TODO())
 
 	assert.NilError(t, err)
 	assertOPAAuthorization(t, opa)
@@ -130,9 +156,9 @@ func TestOPAExternalUrlWithTTL(t *testing.T) {
 		"/rego": func() httptest.HttpServerMockResponse {
 			var rego string
 			if changed {
-				rego = opaInlineRegoDataMock + `allow { method == "POST"; path = "/allow" }`
+				rego = opaInlineRegoV1DataMock + `allow if { method == "POST"; path == "/allow" }`
 			} else {
-				rego = opaInlineRegoDataMock
+				rego = opaInlineRegoV1DataMock
 				changed = true
 			}
 
@@ -147,7 +173,7 @@ func TestOPAExternalUrlWithTTL(t *testing.T) {
 		TTL:             3,
 	}
 
-	opa, err := NewOPAAuthorization("test-opa", "", externalSource, false, 0, context.TODO())
+	opa, err := NewOPAAuthorization("test-opa", "", externalSource, false, opaParser.RegoV1, 0, context.TODO())
 	defer func(opa *OPA) {
 		_ = opa.Clean(context.Background())
 	}(opa)
@@ -165,7 +191,7 @@ func TestOPAClean(t *testing.T) {
 	defer ctrl.Finish()
 
 	refresher := mock_workers.NewMockWorker(ctrl)
-	opa, _ := NewOPAAuthorization("test-opa", "", nil, false, 0, context.TODO())
+	opa, _ := NewOPAAuthorization("test-opa", "", nil, false, opaParser.RegoV1, 0, context.TODO())
 	opa.ExternalSource = &OPAExternalSource{
 		Endpoint:        "http://" + opaExtHttpServerMockAddr + "/rego",
 		AuthCredentials: auth.NewAuthCredential("", ""),
@@ -183,7 +209,7 @@ func TestOPAAllValues(t *testing.T) {
 	pipelineMock := mock_auth.NewMockAuthPipeline(ctrl)
 	pipelineMock.EXPECT().GetAuthorizationJSON().Return(opaAuthDataMock("/allow", "GET")).Times(1)
 
-	opa, _ := NewOPAAuthorization("test-opa", opaInlineRegoDataMock, &OPAExternalSource{}, true, 0, context.TODO())
+	opa, _ := NewOPAAuthorization("test-opa", opaInlineRegoV1DataMock, &OPAExternalSource{}, true, opaParser.RegoV1, 0, context.TODO())
 
 	results, err := opa.Call(pipelineMock, nil)
 	resultSet, _ := results.(rego.Vars)
@@ -206,7 +232,7 @@ func TestOPANonBooleanAllowed(t *testing.T) {
 	pipelineMock := mock_auth.NewMockAuthPipeline(ctrl)
 	pipelineMock.EXPECT().GetAuthorizationJSON().Return(opaAuthDataMock("/allow", "GET")).Times(1)
 
-	opa, _ := NewOPAAuthorization("test-opa", `allow = "foo"`, &OPAExternalSource{}, false, 0, context.TODO())
+	opa, _ := NewOPAAuthorization("test-opa", `allow := "foo"`, &OPAExternalSource{}, false, opaParser.RegoV1, 0, context.TODO())
 
 	results, err := opa.Call(pipelineMock, nil)
 	resultSet, _ := results.(rego.Vars)
@@ -269,7 +295,7 @@ func BenchmarkOPAAuthz(b *testing.B) {
 
 	pipelineMock := mock_auth.NewMockAuthPipeline(ctrl)
 	pipelineMock.EXPECT().GetAuthorizationJSON().Return(opaAuthDataMock("/allow", "GET")).MinTimes(1)
-	opa, _ := NewOPAAuthorization("test-opa", opaInlineRegoDataMock, &OPAExternalSource{}, false, 0, context.TODO())
+	opa, _ := NewOPAAuthorization("test-opa", opaInlineRegoV1DataMock, &OPAExternalSource{}, false, opaParser.RegoV1, 0, context.TODO())
 
 	var err error
 	b.ResetTimer()

--- a/pkg/evaluators/deny_all.go
+++ b/pkg/evaluators/deny_all.go
@@ -5,13 +5,15 @@ import (
 
 	"github.com/kuadrant/authorino/pkg/auth"
 	"github.com/kuadrant/authorino/pkg/evaluators/authorization"
+
+	opaParser "github.com/open-policy-agent/opa/v1/ast"
 )
 
 func NewDenyAllAuthorization(ctx context.Context, name, policyName string) auth.AuthConfigEvaluator {
 	if policyName == "" {
 		policyName = name
 	}
-	opaDenyAll, _ := authorization.NewOPAAuthorization(policyName, "allow = false", nil, false, 0, ctx)
+	opaDenyAll, _ := authorization.NewOPAAuthorization(policyName, "allow := false", nil, false, opaParser.RegoV1, 0, ctx)
 	return &AuthorizationConfig{
 		Name:     name,
 		Priority: 0,

--- a/pkg/service/auth_test.go
+++ b/pkg/service/auth_test.go
@@ -24,6 +24,7 @@ import (
 	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/gogo/googleapis/google/rpc"
+	opaParser "github.com/open-policy-agent/opa/v1/ast"
 	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -289,7 +290,7 @@ func TestAuthServiceRawHTTPAuthorization_K8sAdmissionReviewForbidden(t *testing.
 	defer mockController.Finish()
 	authCred := auth.NewAuthCredential("", "")
 	identityConfig := &evaluators.IdentityConfig{Name: "anonymous", Noop: &identity.Noop{AuthCredentials: authCred}}
-	authorizationPolicy, _ := authorization.NewOPAAuthorization("a-policy", `allow = false`, nil, false, 0, context.TODO())
+	authorizationPolicy, _ := authorization.NewOPAAuthorization("a-policy", `allow := false`, nil, false, opaParser.RegoV1, 0, context.TODO())
 	authorizationConfig := &evaluators.AuthorizationConfig{Name: "always-deny", OPA: authorizationPolicy}
 	authConfig := &evaluators.AuthConfig{
 		IdentityConfigs:      []auth.AuthConfigEvaluator{identityConfig},


### PR DESCRIPTION
## Summary
  - Migrate OPA imports from deprecated `opa/ast` and `opa/rego` packages to `opa/v1/ast` and `opa/v1/rego` (https://www.openpolicyagent.org/docs/v0-upgrade#upgrading-for-go-integrations)
  - Add `regoVersion` field to the OPA authorization spec, allowing users to opt into [Rego v1 syntax](https://www.openpolicyagent.org/docs/v0-upgrade#changes-to-rego-in-opa-v10) per AuthConfig policy
  - New `regoVersion` field default's to `v0` for backward compatibility with existing policies
  - Update internal policies and tests to use Rego v1 syntax as the primary version
  - Log a deprecation warning during reconciliation when v0 Rego syntax is detected

Closes #546

## Future migration plan
  - Update the documentation and code snippets to use Rego v1 syntax
  - Change the CRD default from `v0` to `v1` in a later Authorino release
  - Eventually remove v0 support entirely

### OPA Rego v0 syntax deprecation warnings

A status condition warning (e.g., `type: Warning`, `reason: DeprecatedRegoVersion`) on the AuthConfig was considered to provide deprecation feedback directly on the resource, but was not implemented as it would require expanding the current status condition types beyond `Available` and `Ready`. For now, deprecation is communicated via a controller log warning during reconciliation and the `regoVersion` field description in the CRD.

## Verification steps

  ```bash
  make local-setup

  # OPA Rego v0 syntax verification steps
  kubectl apply -f -<<EOF
  apiVersion: authorino.kuadrant.io/v1beta3
  kind: AuthConfig
  metadata:
    name: opa-v0-test
  spec:
    hosts:
      - opa-v0-test.io
    authentication:
      anonymous:
        anonymous: {}
    authorization:
      my-policy:
        opa:
          rego: |
            allow {
              input.context.request.http.method == "GET"
            }
  EOF
  # Verify the deprecation warning in Authorino logs
  kubectl -n default logs deployment/authorino -c authorino | grep "deprecated"
  
  # OPA Rego v1 syntax verification steps
  # 1. Apply the v1 version config
  kubectl apply -f -<<EOF
  apiVersion: authorino.kuadrant.io/v1beta3
  kind: AuthConfig
  metadata:
    name: opa-v1-test
  spec:
    hosts:
      - opa-v1-test.io
    authentication:
      anonymous:
        anonymous: {}
    authorization:
      my-policy:
        opa:
          version: v1
          rego: |
            allow if {
              input.context.request.http.method == "GET"
            }
  EOF
  # Verify there are no errors during the precompile in Authorino logs
  kubectl -n default logs deployment/authorino -c authorino

  # 2. Apply the v1 version config, with v0 OPA Rego parser set
  kubectl apply -f -<<EOF
  apiVersion: authorino.kuadrant.io/v1beta3
  kind: AuthConfig
  metadata:
    name: opa-v1-wrong-parser
  spec:
    hosts:
      - opa-v1-wrong-parser.io
    authentication:
      anonymous:
        anonymous: {}
    authorization:
      my-policy:
        opa:
          version: v0
          rego: |
            allow if {
              input.context.request.http.method == "GET"
            }
  EOF
  #  Verify for the precompile error in Authorino logs, caused by the incorrect v0 syntax 
  kubectl -n default logs deployment/authorino -c authorino | grep "var cannot be used for rule name"
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `spec.authorization[].opa.version` to select the OPA Rego syntax version for policies (`v0` default, `v1` supported).

* **Bug Fixes**
  * Policy compilation and evaluation now use the configured Rego version.
  * Added clearer handling for Rego v0 syntax deprecation, including a deprecation notice logged once per translation.

* **Chores**
  * Updated CRD/OpenAPI schema and refreshed related authorisation and admission tests/fixtures for Rego v0/v1 compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->