### PR TITLE
Change docs to use the OPA v1 syntax

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -888,7 +888,8 @@ spec:
       priority: 1
       opa:
         rego: |
-          allow { true }
+          allow := true
+        version: v1
   response:
     success:
       headers:
@@ -1061,7 +1062,8 @@ spec:
       - patternRef: a-pet
       opa:
         rego: |
-          allow { input.metadata["pets-info"].ownerid == input.auth.identity.userid }
+          allow if input.metadata["pets-info"].ownerid == input.auth.identity.userid
+        version: v1
 ```
 
 x) combining literals and refs – concrete case: authentication required for selected operations:

--- a/docs/user-guides/caching.md
+++ b/docs/user-guides/caching.md
@@ -170,9 +170,10 @@ spec:
     "cached-authz":
       opa:
         rego: |
-          now = time.now_ns()
-          allow = true
+          now := time.now_ns()
+          allow := true
         allValues: true
+        version: v1
       cache:
         key:
           selector: context.request.http.path

--- a/docs/user-guides/external-metadata.md
+++ b/docs/user-guides/external-metadata.md
@@ -164,11 +164,12 @@ spec:
         rego: |
           import input.context.request.http
 
-          allow {
-            http.method = "GET"
-            split(http.path, "/") = [_, requested_country, _]
+          allow if {
+            http.method == "GET"
+            [_, requested_country, _] := split(http.path, "/")
             lower(requested_country) == lower(object.get(input.auth.metadata.geo, "countryCode", ""))
           }
+        version: v1
 EOF
 ```
 

--- a/docs/user-guides/keycloak-authorization-services.md
+++ b/docs/user-guides/keycloak-authorization-services.md
@@ -170,20 +170,22 @@ spec:
           scope := lower(input.context.request.http.method)
           access_token := trim_prefix(input.context.request.http.headers.authorization, "Bearer ")
 
-          default rpt = ""
-          rpt = access_token { object.get(input.auth.identity, "authorization", {}).permissions }
-          else = rpt_str {
+          default rpt := ""
+          rpt := access_token if object.get(input.auth.identity, "authorization", {}).permissions
+          else := rpt_str if {
             ticket := http.send({"url":"http://keycloak.keycloak.svc.cluster.local:8080/realms/kuadrant/authz/protection/permission","method":"post","headers":{"Authorization":concat("",["Bearer ",pat]),"Content-Type":"application/json"},"raw_body":concat("",["[{\"resource_id\":\"",resource_id,"\",\"resource_scopes\":[\"",scope,"\"]}]"])}).body.ticket
             rpt_str := object.get(http.send({"url":"http://keycloak.keycloak.svc.cluster.local:8080/realms/kuadrant/protocol/openid-connect/token","method":"post","headers":{"Authorization":concat("",["Bearer ",access_token]),"Content-Type":"application/x-www-form-urlencoded"},"raw_body":concat("",["grant_type=urn:ietf:params:oauth:grant-type:uma-ticket&ticket=",ticket,"&submit_request=true"])}).body, "access_token", "")
           }
 
-          allow {
+          allow if {
             permissions := object.get(io.jwt.decode(rpt)[1], "authorization", { "permissions": [] }).permissions
+            some i
             permissions[i]
-            permissions[i].rsid = resource_id
-            permissions[i].scopes[_] = scope
+            permissions[i].rsid == resource_id
+            permissions[i].scopes[_] == scope
           }
         allValues: true
+        version: v1
   response:
     success:
       headers:

--- a/docs/user-guides/opa-authorization.md
+++ b/docs/user-guides/opa-authorization.md
@@ -156,10 +156,11 @@ spec:
       opa:
         rego: |
           ips := split(input.context.request.http.headers["x-forwarded-for"], ",")
-          trusted_network { net.cidr_contains("192.168.1.1/24", ips[0]) }
+          trusted_network if net.cidr_contains("192.168.1.1/24", ips[0])
 
-          allow { trusted_network }
-          allow { not trusted_network; input.context.request.http.method == "GET" }
+          allow if trusted_network
+          allow if { not trusted_network; input.context.request.http.method == "GET" }
+        version: v1
 EOF
 ```
 

--- a/docs/user-guides/resource-level-authorization-uma.md
+++ b/docs/user-guides/resource-level-authorization-uma.md
@@ -177,42 +177,43 @@ spec:
     "owned-resources":
       opa:
         rego: |
-          COLLECTIONS = ["greetings"]
+          COLLECTIONS := ["greetings"]
 
-          http_request = input.context.request.http
-          http_method = http_request.method
-          requested_path_sections = split(trim_left(trim_right(http_request.path, "/"), "/"), "/")
+          http_request := input.context.request.http
+          http_method := http_request.method
+          requested_path_sections := split(trim_left(trim_right(http_request.path, "/"), "/"), "/")
 
-          get { http_method == "GET" }
-          post { http_method == "POST" }
-          put { http_method == "PUT" }
-          delete { http_method == "DELETE" }
+          get if http_method == "GET"
+          post if http_method == "POST"
+          put if http_method == "PUT"
+          delete if http_method == "DELETE"
 
-          valid_collection { COLLECTIONS[_] == requested_path_sections[0] }
+          valid_collection if COLLECTIONS[_] == requested_path_sections[0]
 
-          collection_endpoint {
+          collection_endpoint if {
             valid_collection
             count(requested_path_sections) == 1
           }
 
-          resource_endpoint {
+          resource_endpoint if {
             valid_collection
             some resource_id
             requested_path_sections[1] = resource_id
           }
 
-          identity_owns_the_resource {
+          identity_owns_the_resource if {
             identity := input.auth.identity
             resource_attrs := object.get(input.auth.metadata, "resource-data", [])[0]
             resource_owner := object.get(object.get(resource_attrs, "owner", {}), "id", "")
             resource_owner == identity.sub
           }
 
-          allow { get;    collection_endpoint }
-          allow { post;   collection_endpoint }
-          allow { get;    resource_endpoint; identity_owns_the_resource }
-          allow { put;    resource_endpoint; identity_owns_the_resource }
-          allow { delete; resource_endpoint; identity_owns_the_resource }
+          allow if { get;    collection_endpoint }
+          allow if { post;   collection_endpoint }
+          allow if { get;    resource_endpoint; identity_owns_the_resource }
+          allow if { put;    resource_endpoint; identity_owns_the_resource }
+          allow if { delete; resource_endpoint; identity_owns_the_resource }
+        version: v1
 EOF
 ```
 

--- a/docs/user-guides/validating-webhook.md
+++ b/docs/user-guides/validating-webhook.md
@@ -167,19 +167,20 @@ spec:
     "features":
       opa:
         rego: |
-          authconfig = json.unmarshal(input.context.request.http.body).request.object
+          authconfig := json.unmarshal(input.context.request.http.body).request.object
 
-          forbidden { count(object.get(authconfig.spec, "authentication", [])) == 0 }
-          forbidden { authconfig.spec.authentication[_].anonymous }
-          forbidden { authconfig.spec.authentication[_].kubernetesTokenReview }
-          forbidden { authconfig.spec.authentication[_].plain }
-          forbidden { authconfig.spec.authorization[_].kubernetesSubjectAccessReview }
-          forbidden { authconfig.spec.response.success.headers[_].wristband }
+          forbidden if count(object.get(authconfig.spec, "authentication", [])) == 0
+          forbidden if authconfig.spec.authentication[_].anonymous
+          forbidden if authconfig.spec.authentication[_].kubernetesTokenReview
+          forbidden if authconfig.spec.authentication[_].plain
+          forbidden if authconfig.spec.authorization[_].kubernetesSubjectAccessReview
+          forbidden if authconfig.spec.response.success.headers[_].wristband
 
-          apiKey { authconfig.spec.authentication[_].apiKey }
+          apiKey if authconfig.spec.authentication[_].apiKey
 
-          allow { count(authconfig.spec.authentication) > 0; not forbidden }
+          allow if { count(authconfig.spec.authentication) > 0; not forbidden }
         allValues: true
+        version: v1
 
     "apikey-authn-requires-k8s-role-binding":
       priority: 1
@@ -200,8 +201,9 @@ spec:
       priority: 1
       opa:
         rego: |
-          invalid_ttl = input.auth.authorization.features.authconfig.spec.metadata[_].cache.ttl != 300
-          allow { not invalid_ttl }
+          invalid_ttl := input.auth.authorization.features.authconfig.spec.metadata[_].cache.ttl != 300
+          allow if not invalid_ttl
+        version: v1
 EOF
 ```
 

--- a/tests/v1beta3/authconfig-invalid.yaml
+++ b/tests/v1beta3/authconfig-invalid.yaml
@@ -25,6 +25,7 @@ spec:
   authorization:
     multiple-authorization-methods:
       opa:
-        rego: allow = true
+        rego: allow := true
+        version: v1
       patternMatching:
         patterns: []

--- a/tests/v1beta3/authconfig.yaml
+++ b/tests/v1beta3/authconfig.yaml
@@ -109,11 +109,12 @@ spec:
       opa:
         allValues: true
         rego: |
-          country = object.get(object.get(input.auth.metadata, "geo-info", {}), "country_iso_code", null)
-          allow {
+          country := object.get(object.get(input.auth.metadata, "geo-info", {}), "country_iso_code", null)
+          allow if {
             allowed_countries := ["ES", "FR", "IT"]
             allowed_countries[_] == country
           }
+        version: v1
     admin-kubernetes-rbac:
       when:
       - predicate: request.path.matches("^/admin(/.*)?$")
@@ -133,17 +134,19 @@ spec:
       - predicate: request.path.matches("^/greetings/\\d+$")
       opa:
         rego: |
-          allow {
+          allow if {
             resource_attrs := object.get(input.auth.metadata, "resource-info", [])[0]
             resource_owner := object.get(object.get(resource_attrs, "owner", {}), "id", "")
             resource_owner == input.auth.identity.sub
           }
+        version: v1
     timestamp:
       opa:
         rego: |
-          now = time.now_ns() / 1000000000
-          allow = true
+          now := time.now_ns() / 1000000000
+          allow := true
         allValues: true
+        version: v1
       priority: 1
 
   response:


### PR DESCRIPTION
The continuation of https://github.com/Kuadrant/authorino/pull/646, updating the docs to use the new OPA Rego v1 syntax. 

I verified the new syntax with the OPA CLI, and also simplified some of the conditions where it was possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated policy examples across user guides to use newer Rego syntax and explicit version declarations.
  * Clarified several authorization, caching, webhook, and validation examples with the latest rule style.

* **Tests**
  * Refreshed policy test fixtures to match the updated Rego format.
  * Aligned example configurations with the newer syntax while keeping the same expected behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->