### PR TITLE
Fix authorization failing open on context timeout

### DIFF
--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -55,6 +55,7 @@ var (
 		rpc.NOT_FOUND:           envoy_type.StatusCode_NotFound,
 		rpc.UNAUTHENTICATED:     envoy_type.StatusCode_Unauthorized,
 		rpc.PERMISSION_DENIED:   envoy_type.StatusCode_Forbidden,
+		rpc.UNAVAILABLE:         envoy_type.StatusCode_ServiceUnavailable,
 	}
 
 	authServerResponseStatusMetric = metrics.NewDynamicCounter("auth_server_response_status", "Response status of authconfigs sent by the auth server.")
@@ -298,6 +299,14 @@ func (a *AuthService) Check(parentContext gocontext.Context, req *envoy_auth.Che
 
 	pipeline := NewAuthPipeline(log.IntoContext(ctx, requestLogger), req, *authConfig)
 	result := pipeline.Evaluate()
+
+	// Re-check context after evaluation - if context was cancelled during pipeline execution,
+	// the result may be incorrectly successful (empty authorization result). Fail closed instead.
+	if err := context.CheckContext(ctx); err != nil {
+		result = auth.AuthResult{Code: rpc.UNAVAILABLE}
+		span.RecordError(err)
+		span.SetStatus(otel_codes.Error, err.Error())
+	}
 
 	a.logAuthResult(result, ctx)
 

--- a/pkg/service/auth_test.go
+++ b/pkg/service/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	gohttptest "net/http/httptest"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/kuadrant/authorino/pkg/evaluators"
 	"github.com/kuadrant/authorino/pkg/evaluators/authorization"
 	"github.com/kuadrant/authorino/pkg/evaluators/identity"
+	"github.com/kuadrant/authorino/pkg/evaluators/metadata"
 	"github.com/kuadrant/authorino/pkg/evaluators/response"
 	"github.com/kuadrant/authorino/pkg/index"
 	mock_index "github.com/kuadrant/authorino/pkg/index/mocks"
@@ -306,6 +308,71 @@ func TestAuthServiceRawHTTPAuthorization_K8sAdmissionReviewForbidden(t *testing.
 	assert.Equal(t, response.Code, 200)
 	assert.Equal(t, response.Body.String(), `{"kind":"AdmissionReview","apiVersion":"admission.k8s.io/v1","response":{"uid":"2868ade4-a649-4812-b969-3662a7963535","allowed":false,"status":{"metadata":{},"message":"Unauthorized","code":403}}}`)
 	assert.Equal(t, response.Header().Get("Content-Type"), "application/json")
+}
+
+func TestCheckFailsClosedOnContextTimeout(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	// Create a slow HTTP server that delays response - simulates slow metadata endpoint
+	server := gohttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond) // Slow endpoint
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"slow":"data"}`))
+	}))
+	defer server.Close()
+
+	// Create an AuthConfig with:
+	// - Fast anonymous auth (succeeds immediately)
+	// - Slow HTTP metadata fetch (will hit timeout)
+	// - Authorization policy that would allow (but never runs due to timeout)
+	authCred := auth.NewAuthCredential("", "")
+	identityConfig := &evaluators.IdentityConfig{Name: "anonymous", Noop: &identity.Noop{AuthCredentials: authCred}}
+
+	// Add slow HTTP metadata
+	metadataConfig := &evaluators.MetadataConfig{
+		Name: "slow-metadata",
+		GenericHTTP: &metadata.GenericHttp{
+			Endpoint: server.URL,
+			Method:   "GET",
+		},
+	}
+
+	// Authorization that would allow - but will be skipped due to context timeout
+	authorizationPolicy, _ := authorization.NewOPAAuthorization("allow-all", `allow := true`, nil, false, opaParser.RegoV1, 0, context.TODO())
+	authorizationConfig := &evaluators.AuthorizationConfig{Name: "allow-all", OPA: authorizationPolicy}
+
+	authConfig := &evaluators.AuthConfig{
+		IdentityConfigs:      []auth.AuthConfigEvaluator{identityConfig},
+		MetadataConfigs:      []auth.AuthConfigEvaluator{metadataConfig},
+		AuthorizationConfigs: []auth.AuthConfigEvaluator{authorizationConfig},
+	}
+
+	indexMock := mock_index.NewMockIndex(mockController)
+	indexMock.EXPECT().Get("myapp.io").Return(authConfig)
+
+	// Use a short server timeout (20ms) - will expire during the slow metadata fetch (50ms)
+	authService := &AuthService{Index: indexMock, Timeout: 20 * time.Millisecond}
+
+	resp, err := authService.Check(context.Background(), &envoy_auth.CheckRequest{
+		Attributes: &envoy_auth.AttributeContext{
+			Request: &envoy_auth.AttributeContext_Request{
+				Http: &envoy_auth.AttributeContext_HttpRequest{
+					Host:   "myapp.io",
+					Method: "GET",
+					Path:   "/",
+				},
+			},
+		},
+	})
+
+	assert.NilError(t, err)
+	// Should fail closed with UNAVAILABLE when context times out during pipeline
+	// Without the fix, this would return OK (empty authorization = success)
+	assert.Equal(t, resp.Status.Code, int32(rpc.UNAVAILABLE))
+	denied := resp.GetDeniedResponse()
+	assert.Check(t, denied != nil, "Expected denied response")
 }
 
 func mockAnonymousAccessAuthConfig() *evaluators.AuthConfig {


### PR DESCRIPTION
## Description

This PR fixes a critical security vulnerability where Authorino incorrectly **fails open** (returns `OK`/`ALLOW`) when a request context times out during pipeline execution, instead of **failing closed** (returning `UNAVAILABLE`/`DENY`).

## The Bug

When a context timeout occurs mid-pipeline—for example, during metadata fetching or authorization policy evaluation—Authorino was allowing requests through that should have been denied. This happened because:

1. **`evaluateAuthConfig` returns early silently**: When the context deadline is exceeded at [auth_pipeline.go:117-120](https://github.com/Kuadrant/authorino/blob/main/pkg/service/auth_pipeline.go#L117-L120), the function logs "skipping config" and returns without writing to the response channel.

2. **Empty channel interpreted as success**: `evaluateAuthorizationConfigs` loops through responses from the channel. When all evaluators return early due to context cancellation, the channel is empty, and the function falls through to [line 324](https://github.com/Kuadrant/authorino/blob/main/pkg/service/auth_pipeline.go#L324): `return EvaluationResponse{}` (empty `Error` = success).

3. **No post-evaluation context check**: The `Check()` function only verified the context *before* calling `pipeline.Evaluate()` (line 290), never after. So when the pipeline returns an incorrectly successful result, it gets sent straight to Envoy.

### Attack Scenario

An attacker could exploit this by:
- Configuring slow metadata endpoints that trigger server-side timeouts
- Making requests during periods of high system load
- Leveraging any scenario where the authorization policies don't complete within the timeout budget

The result: **requests that should be denied get silently allowed through**.

## The Fix

Added a post-evaluation context check in [auth.go:302-308](https://github.com/Kuadrant/authorino/blob/main/pkg/service/auth.go#L302-L308) that overrides the pipeline result with `UNAVAILABLE` if the context was cancelled during execution:

```go
// Re-check context after evaluation - if context was cancelled during pipeline execution,
// the result may be incorrectly successful (empty authorization result). Fail closed instead.
if err := context.CheckContext(ctx); err != nil {
    result = auth.AuthResult{Code: rpc.UNAVAILABLE}
    span.RecordError(err)
    span.SetStatus(otel_codes.Error, err.Error())
}
```

This ensures Authorino **always fails closed** on timeout, matching the behavior of the identity phase and preventing unauthorized access.

## Test Coverage

Added `TestCheckFailsClosedOnContextTimeout` to verify that when a context times out during pipeline execution, Authorino correctly returns `UNAVAILABLE` (503) instead of `OK` (200).

All existing tests continue to pass.

## Verification Steps

### Setup

1. **Create a local cluster and deploy Authorino with a 500ms timeout:**

```bash
make cluster local-build install-operator install namespace deploy TLS_ENABLED=false FF=1

kubectl patch authorino/authorino --type=merge -p '{"spec":{"listener":{"timeout":500}}}'
```

2. **Deploy httpbin backend:**

```bash
kubectl apply -f https://raw.githubusercontent.com/Kuadrant/kuadrant-operator/refs/heads/main/examples/x509-authentication/httpbin.yaml
```

3. **Deploy Envoy proxy:**

```bash
kubectl apply -f -<<EOF
apiVersion: v1
kind: ConfigMap
metadata:
  name: envoy
  namespace: default
data:
  envoy.yaml: |
    static_resources:
      listeners:
      - name: listener_0
        address:
          socket_address:
            address: 0.0.0.0
            port_value: 8000
        filter_chains:
        - filters:
          - name: envoy.filters.network.http_connection_manager
            typed_config:
              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
              stat_prefix: ingress_http
              route_config:
                name: local_route
                virtual_hosts:
                - name: backend
                  domains:
                  - "*"
                  routes:
                  - match:
                      prefix: "/"
                    route:
                      cluster: httpbin
              http_filters:
              - name: envoy.filters.http.ext_authz
                typed_config:
                  "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
                  transport_api_version: V3
                  grpc_service:
                    envoy_grpc:
                      cluster_name: authorino
                    timeout: 30s
              - name: envoy.filters.http.router
                typed_config:
                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
      clusters:
      - name: httpbin
        connect_timeout: 0.25s
        type: STRICT_DNS
        lb_policy: ROUND_ROBIN
        load_assignment:
          cluster_name: httpbin
          endpoints:
          - lb_endpoints:
            - endpoint:
                address:
                  socket_address:
                    address: httpbin
                    port_value: 80
      - name: authorino
        connect_timeout: 0.25s
        type: STRICT_DNS
        lb_policy: ROUND_ROBIN
        http2_protocol_options: {}
        load_assignment:
          cluster_name: authorino
          endpoints:
          - lb_endpoints:
            - endpoint:
                address:
                  socket_address:
                    address: authorino-authorino-authorization
                    port_value: 50051
    admin:
      address:
        socket_address:
          address: 0.0.0.0
          port_value: 8001
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: envoy
  name: envoy
spec:
  replicas: 1
  selector:
    matchLabels:
      app: envoy
  template:
    metadata:
      labels:
        app: envoy
    spec:
      containers:
      - args:
        - --config-path /usr/local/etc/envoy/envoy.yaml
        - --service-cluster front-proxy
        - --log-level info
        - --component-log-level filter:trace,http:debug,router:debug
        command:
        - /usr/local/bin/envoy
        image: envoyproxy/envoy:v1.25-latest
        name: envoy
        ports:
        - containerPort: 8000
          name: web
        - containerPort: 8001
          name: admin
        volumeMounts:
        - mountPath: /usr/local/etc/envoy
          name: config
          readOnly: true
      volumes:
      - configMap:
          items:
          - key: envoy.yaml
            path: envoy.yaml
          name: envoy
        name: config
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: envoy
  name: envoy
spec:
  ports:
  - name: web
    port: 8000
    protocol: TCP
  selector:
    app: envoy
EOF

kubectl wait --for=condition=Available deployment/envoy --timeout=120s
kubectl port-forward deployment/envoy 8000:8000 2>&1 >/dev/null &
```

4. **Create an AuthConfig with a slow metadata endpoint and a deny-all policy:**

```bash
kubectl apply -f -<<EOF
apiVersion: authorino.kuadrant.io/v1beta3
kind: AuthConfig
metadata:
  name: httpbin-protection
spec:
  hosts:
  - httpbin.127.0.0.1.nip.io
  authentication:
    "anonymous":
      anonymous: {}
  metadata:
    "long-timeout":
      http:
        url: http://httpbin/get
    "short-timeout":
      http:
        url: http://httpbin/delay/10  # Takes 10 seconds
        timeout: 4000
  authorization:
    "deny-all":
      opa:
        rego: allow := false
        version: v1
EOF
```

### Test the Fix

5. **Send a test request:**

```bash
curl http://httpbin.127.0.0.1.nip.io:8000/get -i
```

**Before this fix:**
```
HTTP/1.1 200 OK
```
❌ **WRONG** - Request was allowed despite the deny-all policy never evaluating due to timeout

**After this fix:**
```
HTTP/1.1 403 Forbidden
x-ext-auth-reason: Unauthorized
```
✅ **CORRECT** - Request is denied (failed closed) when context times out

### What's Happening

The AuthConfig above has:
- **Anonymous authentication** (always succeeds)
- **Two metadata fetchers**:
  - `long-timeout`: fast endpoint that succeeds
  - `short-timeout`: endpoint that sleeps 10 seconds (with 4s timeout, so it fails)
- **Authorization policy**: `deny-all` that should deny every request

With a 500ms server timeout, the metadata phase hits the timeout budget during the slow fetch. Before the fix, the authorization policy never ran (context was dead), the empty result was treated as success, and the request was allowed. After the fix, the post-evaluation context check detects the cancelled context and returns `UNAVAILABLE`, which Envoy treats as a denial.

## Related Issue

Fixes #649

## Checklist

- [x] Tests added to verify the fix
- [x] All existing tests pass
- [x] Commit is properly signed
- [x] Security vulnerability is addressed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorisation handling so requests are denied if the request context expires during evaluation.
  * Added coverage to confirm metadata timeout and related context cancellation result in an unavailable status (fail-closed) instead of potentially allowing access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->