### PR TITLE
Prevent OAuth2 token introspection from crashing Authorino

### DIFF
--- a/pkg/evaluators/identity/oauth2.go
+++ b/pkg/evaluators/identity/oauth2.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 
 	"github.com/kuadrant/authorino/pkg/auth"
@@ -84,12 +85,28 @@ func (oauth *OAuth2) Call(pipeline auth.AuthPipeline, ctx gocontext.Context) (in
 		_ = Body.Close()
 	}(resp.Body)
 
+	// a non-200 response (e.g. invalid client credentials) is not a valid introspection
+	// result and may not carry the RFC 7662 "active" field; treat it as an error instead
+	// of attempting to parse it as a successful introspection response.
+	// The returned error only carries the status, since it is surfaced to the client (via
+	// the X-Ext-Auth-Reason header) and logged; the response body may contain data from the
+	// auth server and is only logged at debug level.
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		log.FromContext(ctx).WithName("oauth2").V(1).Info("token introspection request failed", "status", resp.Status, "response", string(body))
+		return nil, fmt.Errorf("token introspection request failed: %s", resp.Status)
+	}
+
 	// parse the response
 	var claims map[string]interface{}
 	if err := json.NewDecoder(resp.Body).Decode(&claims); err != nil {
 		return nil, err
 	} else {
-		if claims["active"].(bool) {
+		active, ok := claims["active"].(bool)
+		if !ok {
+			return nil, fmt.Errorf("invalid token introspection response: missing or non-boolean \"active\" field")
+		}
+		if active {
 			return claims, nil
 		} else {
 			return nil, fmt.Errorf("token is not active")

--- a/pkg/evaluators/identity/oauth2_test.go
+++ b/pkg/evaluators/identity/oauth2_test.go
@@ -22,6 +22,14 @@ func TestOAuth2Call(t *testing.T) {
 		"/introspect-inactive": func() httptest.HttpServerMockResponse {
 			return httptest.HttpServerMockResponse{Status: 200, Body: `{ "active": false }`}
 		},
+		// RFC 6749 error response returned e.g. on invalid client credentials: valid JSON, non-200, no "active".
+		"/introspect-error": func() httptest.HttpServerMockResponse {
+			return httptest.HttpServerMockResponse{Status: 401, Body: `{"error":"invalid_request","error_description":"Authentication failed."}`}
+		},
+		// 200 response that omits the "active" field.
+		"/introspect-missing-active": func() httptest.HttpServerMockResponse {
+			return httptest.HttpServerMockResponse{Status: 200, Body: `{ "sub": "1234" }`}
+		},
 	})
 	defer authServer.Close()
 
@@ -48,6 +56,23 @@ func TestOAuth2Call(t *testing.T) {
 		oauthEvaluator := NewOAuth2Identity(fmt.Sprintf("http://%v/introspect-inactive", oauthServerHost), "access_token", "client-id", "client-secret", authCredMock)
 		_, err := oauthEvaluator.Call(pipelineMock, ctx)
 		assert.Error(t, err, "token is not active")
+	}
+
+	// A non-200 introspection response (e.g. invalid client credentials) must return a clean
+	// error instead of panicking on the missing "active" field. See issue #651.
+	{
+		oauthEvaluator := NewOAuth2Identity(fmt.Sprintf("http://%v/introspect-error", oauthServerHost), "access_token", "client-id", "wrong-secret", authCredMock)
+		obj, err := oauthEvaluator.Call(pipelineMock, ctx)
+		assert.Assert(t, obj == nil)
+		assert.ErrorContains(t, err, "token introspection request failed")
+	}
+
+	// A 200 response that omits "active" must also return a clean error rather than panicking.
+	{
+		oauthEvaluator := NewOAuth2Identity(fmt.Sprintf("http://%v/introspect-missing-active", oauthServerHost), "access_token", "client-id", "client-secret", authCredMock)
+		obj, err := oauthEvaluator.Call(pipelineMock, ctx)
+		assert.Assert(t, obj == nil)
+		assert.ErrorContains(t, err, "missing or non-boolean")
 	}
 }
 


### PR DESCRIPTION
While poking at the OAuth2 introspection flow, I rotated a client secret the way anyone would in the real world.., and Authorino fell over. Not the request. The whole pod. `exitCode 2`, then a crash loop, and every other service that instance was protecting went down with it.

Here's the story. When a token comes in, the OAuth2 evaluator calls the introspection endpoint and reads back the `active` field to decide if the token is good. The trouble is it trusts that response completely: it never looks at the HTTP status code, and it does a bare `claims["active"].(bool)`. That's fine on a happy-path 200. But when the introspection call itself gets rejected; say the `clientSecret` is wrong or was just rotated; Keycloak (and friends) answer with a perfectly valid JSON body that says `{"error":"invalid_request",...}` and a 401. No `active` field. So `claims["active"]` is `nil`, the assertion panics, and because evaluators run in their own goroutines with nobody to `recover()`, the panic takes the entire process with it.

So a routine ops event, a mistyped or rotated secret on *one* AuthConfig; becomes a full outage for *every* host that instance serves. That felt worth fixing.

The fix is small and boring, which is what you want here: bail out cleanly on any non-200 introspection response, and switch to a comma-ok `active, ok := claims["active"].(bool)` so a missing/odd `active` returns an error instead of a panic. The result is what you'd expect all along.., that request gets a clean `UNAUTHENTICATED` (401 with a `WWW-Authenticate` challenge), and Authorino keeps happily serving everyone else.

I confirmed it end to end on a local Kind cluster with Envoy + Keycloak: on the old build the pod crash-looped; with this change it stays up and just denies the request. Added regression tests for both the non-200 error body and a 200 that omits `active`.

Fixes #651.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth2 token introspection error handling, including non-success HTTP responses with clearer error details.
  * Added explicit validation for the `active` status, returning clean failures when it is missing or non-boolean.
  * Ensured inactive tokens continue to be rejected with a dedicated “token is not active” error.
* **Tests**
  * Expanded OAuth2 introspection test coverage for error responses and missing/invalid `active` field scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->