### PR TITLE
Backport patch-safe fixes for v0.26.2

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -99,6 +99,10 @@ jobs:
   merge:
     name: Create multi-platform manifest
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     needs: [ prepare, build ]
     steps:
       - name: Download digests
@@ -133,5 +137,23 @@ jobs:
             $(printf '${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino@sha256:%s ' *)
       - name: Inspect image
         if: ${{ !env.ACT }}
+        id: inspect
         run: |
           docker buildx imagetools inspect ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino:${{ needs.prepare.outputs.version_tag }}
+
+          digest=$(docker buildx imagetools inspect ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino:${{ needs.prepare.outputs.version_tag }} --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest=$digest" >> $GITHUB_OUTPUT
+      - name: Install cosign
+        if: ${{ !env.ACT }}
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # ratchet:sigstore/cosign-installer@v3
+      - name: Sign image with cosign
+        if: ${{ !env.ACT }}
+        run: |
+          cosign sign --yes ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino@${{ steps.inspect.outputs.digest }}
+      - name: Attest build provenance
+        if: ${{ !env.ACT }}
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # ratchet:actions/attest@v4
+        with:
+          subject-name: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino
+          subject-digest: ${{ steps.inspect.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -13,6 +13,9 @@ env:
   IMG_REGISTRY_ORG: kuadrant
   MAIN_BRANCH_NAME: main
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     name: Prepare build info

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -24,6 +24,9 @@ on:
   merge_group:
     types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 jobs:
 
   autoformat:
@@ -87,6 +90,9 @@ jobs:
           echo "${{ github.repository }} is formatted correctly."
 
   lint:
+    permissions:
+      checks: write  # for reviewdog to create check
+      contents: read  # for actions/checkout to fetch code
     name: Lint
     runs-on: ubuntu-latest
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+# generated from the template https://github.com/actions/starter-workflows/blob/1035244887e26fbbd4f1017d919fb5995cc521c4/code-scanning/codeql.yml
+name: CodeQL
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  merge_group:
+    types: ["checks_requested"]
+  schedule:
+    - cron: '40 15 * * 6' # random schedule to avoid hitting the rate limit of the CodeQL and GitHub Actions API
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: go
+            build-mode: autobuild
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # ratchet:github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # ratchet:github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -8,6 +8,9 @@ on:
         required: true
         default: latest
 
+permissions:
+  contents: read
+
 jobs:
   e2e-tests:
     name: End-to-end Tests

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -10,6 +10,9 @@ on:
   merge_group:
     types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/issues-workflow.yaml
+++ b/.github/workflows/issues-workflow.yaml
@@ -8,6 +8,9 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     name: Add issue to project

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -7,6 +7,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   on-success:
     name: Smoke Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build the authorino binary
 # https://catalog.redhat.com/software/containers/ubi10/go-toolset
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi10/go-toolset:1.25 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi10/go-toolset:1.26 AS builder
 WORKDIR /usr/src/authorino
 COPY ./ ./
 ARG version

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,7 +4,7 @@
 
 Minimum requirements to contribute to Authorino are:
 
-- [Golang v1.25+](https://golang.org)
+- [Golang](https://golang.org) (version per `go.mod`)
 - [Docker](https://docker.com) or [Podman](https://podman.io)
 
 Authorino's code was originally bundled using the [Operator SDK](https://sdk.operatorframework.io/) (v1.9.0).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/authzed/authzed-go v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/authzed/authzed-go v0.7.0

--- a/main.go
+++ b/main.go
@@ -355,6 +355,7 @@ func runAuthorizationServer(cmd *cobra.Command, _ []string) {
 	statusUpdaterOptions := baseManagerOptions
 	statusUpdaterOptions.Metrics.BindAddress = "0"    // disabled so it does not clash with the reconciliation manager
 	statusUpdaterOptions.HealthProbeBindAddress = "0" // disabled so it does not clash with the reconciliation manager
+	statusUpdaterOptions.PprofBindAddress = "0"       // disabled so it does not clash with the reconciliation manager
 	statusUpdaterOptions.LeaderElection = opts.enableLeaderElection
 	statusUpdaterOptions.LeaderElectionID = fmt.Sprintf("%v.%v", hex.EncodeToString(leaderElectionId[:4]), leaderElectionIDSuffix)
 	statusUpdateManager, err := setupManager(restConfig, statusUpdaterOptions)

--- a/pkg/evaluators/callbacks_test.go
+++ b/pkg/evaluators/callbacks_test.go
@@ -14,7 +14,7 @@ import (
 	"gotest.tools/assert"
 )
 
-const testCallbackServerHost string = "127.0.0.1:9010"
+const testCallbackServerHost string = "127.0.0.1:9012"
 
 func TestCallbacks(t *testing.T) {
 	var called bool

--- a/pkg/evaluators/identity/oauth2.go
+++ b/pkg/evaluators/identity/oauth2.go
@@ -82,12 +82,28 @@ func (oauth *OAuth2) Call(pipeline auth.AuthPipeline, ctx gocontext.Context) (in
 		_ = Body.Close()
 	}(resp.Body)
 
+	// a non-200 response (e.g. invalid client credentials) is not a valid introspection
+	// result and may not carry the RFC 7662 "active" field; treat it as an error instead
+	// of attempting to parse it as a successful introspection response.
+	// The returned error only carries the status, since it is surfaced to the client (via
+	// the X-Ext-Auth-Reason header) and logged; the response body may contain data from the
+	// auth server and is only logged at debug level.
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		log.FromContext(ctx).WithName("oauth2").V(1).Info("token introspection request failed", "status", resp.Status, "response", string(body))
+		return nil, fmt.Errorf("token introspection request failed: %s", resp.Status)
+	}
+
 	// parse the response
 	var claims map[string]interface{}
 	if err := json.NewDecoder(resp.Body).Decode(&claims); err != nil {
 		return nil, err
 	} else {
-		if claims["active"].(bool) {
+		active, ok := claims["active"].(bool)
+		if !ok {
+			return nil, fmt.Errorf("invalid token introspection response: missing or non-boolean \"active\" field")
+		}
+		if active {
 			return claims, nil
 		} else {
 			return nil, fmt.Errorf("token is not active")

--- a/pkg/evaluators/identity/oauth2_test.go
+++ b/pkg/evaluators/identity/oauth2_test.go
@@ -22,6 +22,14 @@ func TestOAuth2Call(t *testing.T) {
 		"/introspect-inactive": func() httptest.HttpServerMockResponse {
 			return httptest.HttpServerMockResponse{Status: 200, Body: `{ "active": false }`}
 		},
+		// RFC 6749 error response returned e.g. on invalid client credentials: valid JSON, non-200, no "active".
+		"/introspect-error": func() httptest.HttpServerMockResponse {
+			return httptest.HttpServerMockResponse{Status: 401, Body: `{"error":"invalid_request","error_description":"Authentication failed."}`}
+		},
+		// 200 response that omits the "active" field.
+		"/introspect-missing-active": func() httptest.HttpServerMockResponse {
+			return httptest.HttpServerMockResponse{Status: 200, Body: `{ "sub": "1234" }`}
+		},
 	})
 	defer authServer.Close()
 
@@ -48,6 +56,23 @@ func TestOAuth2Call(t *testing.T) {
 		oauthEvaluator := NewOAuth2Identity(fmt.Sprintf("http://%v/introspect-inactive", oauthServerHost), "access_token", "client-id", "client-secret", authCredMock)
 		_, err := oauthEvaluator.Call(pipelineMock, ctx)
 		assert.Error(t, err, "token is not active")
+	}
+
+	// A non-200 introspection response (e.g. invalid client credentials) must return a clean
+	// error instead of panicking on the missing "active" field. See issue #651.
+	{
+		oauthEvaluator := NewOAuth2Identity(fmt.Sprintf("http://%v/introspect-error", oauthServerHost), "access_token", "client-id", "wrong-secret", authCredMock)
+		obj, err := oauthEvaluator.Call(pipelineMock, ctx)
+		assert.Assert(t, obj == nil)
+		assert.ErrorContains(t, err, "token introspection request failed")
+	}
+
+	// A 200 response that omits "active" must also return a clean error rather than panicking.
+	{
+		oauthEvaluator := NewOAuth2Identity(fmt.Sprintf("http://%v/introspect-missing-active", oauthServerHost), "access_token", "client-id", "client-secret", authCredMock)
+		obj, err := oauthEvaluator.Call(pipelineMock, ctx)
+		assert.Assert(t, obj == nil)
+		assert.ErrorContains(t, err, "missing or non-boolean")
 	}
 }
 

--- a/pkg/evaluators/metadata/uma.go
+++ b/pkg/evaluators/metadata/uma.go
@@ -142,8 +142,8 @@ func (pat *PAT) Get(rawurl string, ctx gocontext.Context, v interface{}) error {
 	if err != nil {
 		return err
 	}
-	defer func(Body io.ReadCloser) {
-		_ = Body.Close()
+	defer func(body io.ReadCloser) {
+		_ = body.Close()
 	}(resp.Body)
 
 	return json.UnmashalJSONResponse(resp, &v, nil)
@@ -178,8 +178,8 @@ func (uma *UMA) discover() error {
 	if resp, err := http.Get(uma.wellKnownConfigEndpoint()); err != nil {
 		return fmt.Errorf("failed to fetch uma config: %v", err)
 	} else {
-		defer func(Body io.ReadCloser) {
-			_ = Body.Close()
+		defer func(body io.ReadCloser) {
+			_ = body.Close()
 		}(resp.Body)
 
 		var p providerJSON
@@ -256,6 +256,9 @@ func (uma *UMA) requestPAT(ctx gocontext.Context, pat *PAT) error {
 	if err != nil {
 		return err
 	}
+	defer func(body io.ReadCloser) {
+		_ = body.Close()
+	}(resp.Body)
 
 	// parse the pat
 	if err := json.UnmashalJSONResponse(resp, pat, nil); err != nil {

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -55,6 +55,7 @@ var (
 		rpc.NOT_FOUND:           envoy_type.StatusCode_NotFound,
 		rpc.UNAUTHENTICATED:     envoy_type.StatusCode_Unauthorized,
 		rpc.PERMISSION_DENIED:   envoy_type.StatusCode_Forbidden,
+		rpc.UNAVAILABLE:         envoy_type.StatusCode_ServiceUnavailable,
 	}
 
 	authServerResponseStatusMetric = metrics.NewDynamicCounter("auth_server_response_status", "Response status of authconfigs sent by the auth server.")
@@ -298,6 +299,14 @@ func (a *AuthService) Check(parentContext gocontext.Context, req *envoy_auth.Che
 
 	pipeline := NewAuthPipeline(log.IntoContext(ctx, requestLogger), req, *authConfig)
 	result := pipeline.Evaluate()
+
+	// Re-check context after evaluation - if context was cancelled during pipeline execution,
+	// the result may be incorrectly successful (empty authorization result). Fail closed instead.
+	if err := context.CheckContext(ctx); err != nil {
+		result = auth.AuthResult{Code: rpc.UNAVAILABLE}
+		span.RecordError(err)
+		span.SetStatus(otel_codes.Error, err.Error())
+	}
 
 	a.logAuthResult(result, ctx)
 

--- a/pkg/service/auth_test.go
+++ b/pkg/service/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	gohttptest "net/http/httptest"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/kuadrant/authorino/pkg/evaluators"
 	"github.com/kuadrant/authorino/pkg/evaluators/authorization"
 	"github.com/kuadrant/authorino/pkg/evaluators/identity"
+	"github.com/kuadrant/authorino/pkg/evaluators/metadata"
 	"github.com/kuadrant/authorino/pkg/evaluators/response"
 	"github.com/kuadrant/authorino/pkg/index"
 	mock_index "github.com/kuadrant/authorino/pkg/index/mocks"
@@ -305,6 +307,71 @@ func TestAuthServiceRawHTTPAuthorization_K8sAdmissionReviewForbidden(t *testing.
 	assert.Equal(t, response.Code, 200)
 	assert.Equal(t, response.Body.String(), `{"kind":"AdmissionReview","apiVersion":"admission.k8s.io/v1","response":{"uid":"2868ade4-a649-4812-b969-3662a7963535","allowed":false,"status":{"metadata":{},"message":"Unauthorized","code":403}}}`)
 	assert.Equal(t, response.Header().Get("Content-Type"), "application/json")
+}
+
+func TestCheckFailsClosedOnContextTimeout(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	// Create a slow HTTP server that delays response - simulates slow metadata endpoint
+	server := gohttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond) // Slow endpoint
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"slow":"data"}`))
+	}))
+	defer server.Close()
+
+	// Create an AuthConfig with:
+	// - Fast anonymous auth (succeeds immediately)
+	// - Slow HTTP metadata fetch (will hit timeout)
+	// - Authorization policy that would allow (but never runs due to timeout)
+	authCred := auth.NewAuthCredential("", "")
+	identityConfig := &evaluators.IdentityConfig{Name: "anonymous", Noop: &identity.Noop{AuthCredentials: authCred}}
+
+	// Add slow HTTP metadata
+	metadataConfig := &evaluators.MetadataConfig{
+		Name: "slow-metadata",
+		GenericHTTP: &metadata.GenericHttp{
+			Endpoint: server.URL,
+			Method:   "GET",
+		},
+	}
+
+	// Authorization that would allow - but will be skipped due to context timeout
+	authorizationPolicy, _ := authorization.NewOPAAuthorization("allow-all", `allow := true`, nil, false, opaParser.RegoV1, 0, context.TODO())
+	authorizationConfig := &evaluators.AuthorizationConfig{Name: "allow-all", OPA: authorizationPolicy}
+
+	authConfig := &evaluators.AuthConfig{
+		IdentityConfigs:      []auth.AuthConfigEvaluator{identityConfig},
+		MetadataConfigs:      []auth.AuthConfigEvaluator{metadataConfig},
+		AuthorizationConfigs: []auth.AuthConfigEvaluator{authorizationConfig},
+	}
+
+	indexMock := mock_index.NewMockIndex(mockController)
+	indexMock.EXPECT().Get("myapp.io").Return(authConfig)
+
+	// Use a short server timeout (20ms) - will expire during the slow metadata fetch (50ms)
+	authService := &AuthService{Index: indexMock, Timeout: 20 * time.Millisecond}
+
+	resp, err := authService.Check(context.Background(), &envoy_auth.CheckRequest{
+		Attributes: &envoy_auth.AttributeContext{
+			Request: &envoy_auth.AttributeContext_Request{
+				Http: &envoy_auth.AttributeContext_HttpRequest{
+					Host:   "myapp.io",
+					Method: "GET",
+					Path:   "/",
+				},
+			},
+		},
+	})
+
+	assert.NilError(t, err)
+	// Should fail closed with UNAVAILABLE when context times out during pipeline
+	// Without the fix, this would return OK (empty authorization = success)
+	assert.Equal(t, resp.Status.Code, int32(rpc.UNAVAILABLE))
+	denied := resp.GetDeniedResponse()
+	assert.Check(t, denied != nil, "Expected denied response")
 }
 
 func mockAnonymousAccessAuthConfig() *evaluators.AuthConfig {

--- a/pkg/service/auth_test.go
+++ b/pkg/service/auth_test.go
@@ -339,7 +339,7 @@ func TestCheckFailsClosedOnContextTimeout(t *testing.T) {
 	}
 
 	// Authorization that would allow - but will be skipped due to context timeout
-	authorizationPolicy, _ := authorization.NewOPAAuthorization("allow-all", `allow := true`, nil, false, opaParser.RegoV1, 0, context.TODO())
+	authorizationPolicy, _ := authorization.NewOPAAuthorization("allow-all", `allow = true`, nil, false, 0, context.TODO())
 	authorizationConfig := &evaluators.AuthorizationConfig{Name: "allow-all", OPA: authorizationPolicy}
 
 	authConfig := &evaluators.AuthConfig{


### PR DESCRIPTION
## Summary

Cherry-picked patch-safe fixes from main for a v0.26.2 release. All changes are backward-compatible bug fixes, CI hardening, toolchain upgrades, and docs.

**Key fixes:**
- Fix authorization failing open on context timeout (#650) — security fix
- Fix OAuth2 introspection panic on non-200 / missing "active" response
- Fix pprof port clash on status update manager
- Fix UMA PAT response body resource leak
- Go 1.26.3 → 1.26.4 toolchain upgrade
- CI hardening: StepSecurity, CodeQL, cosigning, action version pinning

**Not included** (depend on feature commits not suitable for patch release):
- Credential query string URL-encoding fixes (depend on SSRF validation feature)
- OPA context propagation fixes (depend on SSRF validation feature)
- UMA/OAuth2 timeout refactors (depend on new Timeout API fields)
- Plain identity pattern reuse fix (depends on refactored credentials.go)

**Test adaptation:**
- Context timeout test adapted to use Rego v0 syntax (`allow = true`) since the OPA Rego v1 evaluator is a feature not present in v0.26.x
- Two commits (OAuth2 timeout in ClientCredentials, OAuth2 timeout in GenericHttp) were cherry-picked then reverted after discovering they import `pkg/http` which was introduced by the SSRF feature

## Test plan
- [x] `go build ./...` passes
- [x] All unit tests pass (`go test ./...` excluding envtest-dependent CEL tests)
- [ ] CI passes on this PR