### PR TITLE
Pin yq installation to a specific version via a shared composite action

### DIFF
--- a/.github/actions/install-yq/action.yaml
+++ b/.github/actions/install-yq/action.yaml
@@ -1,0 +1,18 @@
+name: Install yq
+description: Install mikefarah/yq at a pinned version
+
+inputs:
+  version:
+    description: "yq version to install"
+    required: false
+    default: "4.53.3"
+
+runs:
+  using: composite
+  steps:
+    - name: Install yq v${{ inputs.version }}
+      shell: bash
+      run: |
+        sudo wget -qO /usr/local/bin/yq \
+          "https://github.com/mikefarah/yq/releases/download/v${{ inputs.version }}/yq_linux_amd64"
+        sudo chmod +x /usr/local/bin/yq

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -73,6 +73,8 @@ jobs:
           fi
           git checkout -b "${PRE_RELEASE_BRANCH}"
 
+      - uses: ./.github/actions/install-yq
+
       - name: Update release.yaml
         run: |
           VERSION="${{ needs.setup.outputs.version }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,11 +23,7 @@ jobs:
         with:
           ref: ${{ inputs.release-branch }}
 
-      - name: Install yq
-        run: |
-          sudo wget -qO /usr/local/bin/yq \
-            https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          sudo chmod +x /usr/local/bin/yq
+      - uses: ./.github/actions/install-yq
 
       - name: Parse version from release.yaml
         id: parse

--- a/.github/workflows/version-gate.yaml
+++ b/.github/workflows/version-gate.yaml
@@ -16,11 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
 
-      - name: Install yq
-        run: |
-          sudo wget -qO /usr/local/bin/yq \
-            https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          sudo chmod +x /usr/local/bin/yq
+      - uses: ./.github/actions/install-yq
 
       - name: Validate release.yaml
         env:


### PR DESCRIPTION
# Summary

Replaces inline yq installation steps across CI workflows with a shared composite action (`.github/actions/install-yq`) that pins yq to a specific version (`4.53.3`) instead of pulling from `latest`.

This change was prompted by [review feedback](https://github.com/Kuadrant/authorino/pull/634#discussion_r3587921508) suggesting that yq should be pinned to a specific version to avoid potentially breaking CI on external updates. Branch protections on `release_process` prevent pushing directly, so this is submitted as a separate PR.

# Changes

- Introduced a reusable composite action that downloads and installs a pinned version of `mikefarah/yq`, with the version configurable via an input parameter
- Updated the `release.yaml`, `version-gate.yaml`, and `pre-release.yaml` workflows to use the new composite action instead of inline installation steps
- Fixed a missing yq installation step in `pre-release.yaml` which used yq without installing it first

# Notes

- The default version is pinned to `4.53.3` and can be overridden per-caller via the `version` input
- All three workflows that depend on yq now use a single source of truth for installation
