### PR TITLE
Backport CVE fixes for v0.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino
 
-go 1.25.9
+go 1.26.4
 
 require (
 	github.com/authzed/authzed-go v0.7.0


### PR DESCRIPTION
Bump Go to 1.26.4 (CVE-2026-27145), golang.org/x/net to v0.55.0 (CVE-2026-33811), and go-jose to v4.1.4 (CVE-2026-34986). Minimal dependency-only change.