### PR TITLE
Add test to verify otel schema and sdk versions match

### DIFF
--- a/pkg/trace/exporter_test.go
+++ b/pkg/trace/exporter_test.go
@@ -1,0 +1,22 @@
+package trace
+
+import (
+	"errors"
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+func TestNewResourceSchemaURLConsistency(t *testing.T) {
+	// newResource merges our semconv attributes with resource.Default() via
+	// resource.Merge, which returns ErrSchemaURLConflict if the schema URLs
+	// differ. This catches the case where the SDK's semconv version drifts
+	// from the one imported in exporter.go (e.g. via a dependabot bump).
+	_, err := newResource("test", nil)
+	if errors.Is(err, resource.ErrSchemaURLConflict) {
+		t.Fatalf("semconv schema URL in exporter.go conflicts with the SDK's resource.Default(): %v", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected error creating resource: %v", err)
+	}
+}


### PR DESCRIPTION
To avoid the otel schema mismatches which keep happening I've added a unit test that does a simple merge here to catch them up front. If you go to the `exporter.go` and change the `semconv` version and rerun the test you'll see it'll fail

Related to:

- #611
- #532
- #455 
- https://github.com/Kuadrant/authorino/pull/636#discussion_r3674022113


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify schema URL consistency when creating tracing resources.
  * Added checks to distinguish expected schema conflicts from unexpected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->