### PR TITLE
feat: enrich Check span with auth decision attributes

### DIFF
--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kuadrant/authorino/pkg/auth"
 	"github.com/kuadrant/authorino/pkg/context"
+	"github.com/kuadrant/authorino/pkg/evaluators"
 	"github.com/kuadrant/authorino/pkg/index"
 	"github.com/kuadrant/authorino/pkg/log"
 	"github.com/kuadrant/authorino/pkg/metrics"
@@ -23,7 +24,9 @@ import (
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/gogo/googleapis/google/rpc"
 	"github.com/google/uuid"
+	otel_attr "go.opentelemetry.io/otel/attribute"
 	otel_codes "go.opentelemetry.io/otel/codes"
+	otel_trace "go.opentelemetry.io/otel/trace"
 	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 	v1 "k8s.io/api/admission/v1"
@@ -251,6 +254,7 @@ func (a *AuthService) Check(parentContext gocontext.Context, req *envoy_auth.Che
 		span.RecordError(err)
 		span.SetStatus(otel_codes.Error, err.Error())
 		result := auth.AuthResult{Code: rpc.INVALID_ARGUMENT, Message: RESPONSE_MESSAGE_INVALID_REQUEST}
+		setAuthResultSpanAttrs(span, result)
 		return a.deniedResponse(result), nil
 	}
 
@@ -284,12 +288,19 @@ func (a *AuthService) Check(parentContext gocontext.Context, req *envoy_auth.Che
 	// If we couldn't find the AuthConfig in the config, we return and deny.
 	if authConfig == nil {
 		result := auth.AuthResult{Code: rpc.NOT_FOUND, Message: RESPONSE_MESSAGE_SERVICE_NOT_FOUND}
+		setAuthResultSpanAttrs(span, result)
 		a.logAuthResult(result, ctx)
 		return a.deniedResponse(result), nil
 	}
 
+	span.SetAttributes(
+		otel_attr.String(trace.AuthConfigNameAttr, authConfig.Labels["authconfig"]),
+		otel_attr.String(trace.AuthConfigNamespaceAttr, authConfig.Labels["namespace"]),
+	)
+
 	if err := context.CheckContext(ctx); err != nil {
 		result := auth.AuthResult{Code: rpc.UNAVAILABLE}
+		setAuthResultSpanAttrs(span, result)
 		a.logAuthResult(result, ctx)
 		context.Cancel(ctx)
 		span.RecordError(err)
@@ -306,6 +317,17 @@ func (a *AuthService) Check(parentContext gocontext.Context, req *envoy_auth.Che
 		result = auth.AuthResult{Code: rpc.UNAVAILABLE}
 		span.RecordError(err)
 		span.SetStatus(otel_codes.Error, err.Error())
+	}
+
+	setAuthResultSpanAttrs(span, result)
+
+	if idConfig, _ := pipeline.GetResolvedIdentity(); idConfig != nil {
+		if ic, ok := idConfig.(*evaluators.IdentityConfig); ok {
+			span.SetAttributes(
+				otel_attr.String(trace.IdentitySourceAttr, ic.GetName()),
+				otel_attr.String(trace.IdentityTypeAttr, ic.GetType()),
+			)
+		}
 	}
 
 	a.logAuthResult(result, ctx)
@@ -497,6 +519,18 @@ func closeWithStatus(respStatusCode envoy_type.StatusCode, response http.Respons
 		closingFunc()
 	}
 	context.Cancel(ctx)
+}
+
+func setAuthResultSpanAttrs(span otel_trace.Span, result auth.AuthResult) {
+	if result.Success() {
+		span.SetAttributes(otel_attr.String(trace.AuthResultAttr, "ALLOW"))
+	} else {
+		span.SetAttributes(otel_attr.String(trace.AuthResultAttr, "DENY"))
+		if result.Message != "" {
+			span.SetAttributes(otel_attr.String(trace.AuthDenialReasonAttr, result.Message))
+		}
+	}
+	span.SetAttributes(otel_attr.String(trace.AuthResponseCodeAttr, result.Code.String()))
 }
 
 func ensureRequestId(requestIdCandidates ...string) string {

--- a/pkg/service/auth_test.go
+++ b/pkg/service/auth_test.go
@@ -27,8 +27,14 @@ import (
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/gogo/googleapis/google/rpc"
 	opaParser "github.com/open-policy-agent/opa/v1/ast"
+	"go.opentelemetry.io/otel"
+	otel_attr "go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kuadrant/authorino/pkg/trace"
 )
 
 const (
@@ -373,6 +379,172 @@ func TestCheckFailsClosedOnContextTimeout(t *testing.T) {
 	assert.Equal(t, resp.Status.Code, int32(rpc.UNAVAILABLE))
 	denied := resp.GetDeniedResponse()
 	assert.Check(t, denied != nil, "Expected denied response")
+}
+
+func setupTestTracer(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		tp.Shutdown(context.Background())
+	})
+	return exporter
+}
+
+func findSpanAttr(spans tracetest.SpanStubs, attrKey string) (otel_attr.Value, bool) {
+	for _, s := range spans {
+		for _, a := range s.Attributes {
+			if string(a.Key) == attrKey {
+				return a.Value, true
+			}
+		}
+	}
+	return otel_attr.Value{}, false
+}
+
+func TestCheckSpanAttributes_AllowedRequest(t *testing.T) {
+	exporter := setupTestTracer(t)
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	authConfig := mockAnonymousAccessAuthConfig()
+	authConfig.Labels = map[string]string{"authconfig": "my-config", "namespace": "my-ns"}
+
+	indexMock := mock_index.NewMockIndex(mockController)
+	indexMock.EXPECT().Get("myapp.io").Return(authConfig)
+
+	service := &AuthService{Index: indexMock}
+	_, err := service.Check(context.Background(), &envoy_auth.CheckRequest{
+		Attributes: &envoy_auth.AttributeContext{
+			Request: &envoy_auth.AttributeContext_Request{
+				Http: &envoy_auth.AttributeContext_HttpRequest{Host: "myapp.io", Method: "GET", Path: "/"},
+			},
+		},
+	})
+	assert.NilError(t, err)
+
+	spans := exporter.GetSpans()
+	val, ok := findSpanAttr(spans, trace.AuthResultAttr)
+	assert.Assert(t, ok, "expected authorino.auth.result attribute")
+	assert.Equal(t, val.AsString(), "ALLOW")
+
+	val, ok = findSpanAttr(spans, trace.AuthResponseCodeAttr)
+	assert.Assert(t, ok)
+	assert.Equal(t, val.AsString(), "OK")
+
+	val, ok = findSpanAttr(spans, trace.AuthConfigNameAttr)
+	assert.Assert(t, ok)
+	assert.Equal(t, val.AsString(), "my-config")
+
+	val, ok = findSpanAttr(spans, trace.AuthConfigNamespaceAttr)
+	assert.Assert(t, ok)
+	assert.Equal(t, val.AsString(), "my-ns")
+
+	val, ok = findSpanAttr(spans, trace.IdentitySourceAttr)
+	assert.Assert(t, ok)
+	assert.Equal(t, val.AsString(), "anonymous")
+
+	_, ok = findSpanAttr(spans, trace.AuthDenialReasonAttr)
+	assert.Assert(t, !ok, "denial reason should not be set on allowed request")
+}
+
+func TestCheckSpanAttributes_DeniedRequest(t *testing.T) {
+	exporter := setupTestTracer(t)
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	authCred := auth.NewAuthCredential("", "")
+	identityConfig := &evaluators.IdentityConfig{Name: "anonymous", Noop: &identity.Noop{AuthCredentials: authCred}}
+	authorizationPolicy, _ := authorization.NewOPAAuthorization("deny-policy", `allow := false`, nil, false, opaParser.RegoV1, 0, context.TODO())
+	authorizationConfig := &evaluators.AuthorizationConfig{Name: "always-deny", OPA: authorizationPolicy}
+	authConfig := &evaluators.AuthConfig{
+		Labels:               map[string]string{"authconfig": "protected-api", "namespace": "prod"},
+		IdentityConfigs:      []auth.AuthConfigEvaluator{identityConfig},
+		AuthorizationConfigs: []auth.AuthConfigEvaluator{authorizationConfig},
+	}
+
+	indexMock := mock_index.NewMockIndex(mockController)
+	indexMock.EXPECT().Get("myapp.io").Return(authConfig)
+
+	service := &AuthService{Index: indexMock}
+	resp, err := service.Check(context.Background(), &envoy_auth.CheckRequest{
+		Attributes: &envoy_auth.AttributeContext{
+			Request: &envoy_auth.AttributeContext_Request{
+				Http: &envoy_auth.AttributeContext_HttpRequest{Host: "myapp.io", Method: "GET", Path: "/"},
+			},
+		},
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, resp.Status.Code, int32(rpc.PERMISSION_DENIED))
+
+	spans := exporter.GetSpans()
+	val, ok := findSpanAttr(spans, trace.AuthResultAttr)
+	assert.Assert(t, ok)
+	assert.Equal(t, val.AsString(), "DENY")
+
+	val, ok = findSpanAttr(spans, trace.AuthResponseCodeAttr)
+	assert.Assert(t, ok)
+	assert.Equal(t, val.AsString(), "PERMISSION_DENIED")
+
+	_, ok = findSpanAttr(spans, trace.AuthDenialReasonAttr)
+	assert.Assert(t, ok, "denial reason should be set on denied request")
+
+	val, ok = findSpanAttr(spans, trace.AuthConfigNameAttr)
+	assert.Assert(t, ok)
+	assert.Equal(t, val.AsString(), "protected-api")
+}
+
+func TestCheckSpanAttributes_ServiceNotFound(t *testing.T) {
+	exporter := setupTestTracer(t)
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	indexMock := mock_index.NewMockIndex(mockController)
+	indexMock.EXPECT().Get("unknown.io").Return(nil)
+
+	service := &AuthService{Index: indexMock}
+	resp, err := service.Check(context.Background(), &envoy_auth.CheckRequest{
+		Attributes: &envoy_auth.AttributeContext{
+			Request: &envoy_auth.AttributeContext_Request{
+				Http: &envoy_auth.AttributeContext_HttpRequest{Host: "unknown.io", Method: "GET", Path: "/"},
+			},
+		},
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, resp.Status.Code, int32(rpc.NOT_FOUND))
+
+	spans := exporter.GetSpans()
+	val, ok := findSpanAttr(spans, trace.AuthResultAttr)
+	assert.Assert(t, ok)
+	assert.Equal(t, val.AsString(), "DENY")
+
+	val, ok = findSpanAttr(spans, trace.AuthDenialReasonAttr)
+	assert.Assert(t, ok)
+	assert.Equal(t, val.AsString(), "Service not found")
+
+	_, ok = findSpanAttr(spans, trace.AuthConfigNameAttr)
+	assert.Assert(t, !ok, "auth_config.name should not be set when service not found")
+}
+
+func TestCheckSpanAttributes_InvalidRequest(t *testing.T) {
+	exporter := setupTestTracer(t)
+
+	service := &AuthService{Index: index.NewIndex()}
+	resp, err := service.Check(context.Background(), &envoy_auth.CheckRequest{})
+	assert.NilError(t, err)
+	assert.Equal(t, resp.Status.Code, int32(rpc.INVALID_ARGUMENT))
+
+	spans := exporter.GetSpans()
+	val, ok := findSpanAttr(spans, trace.AuthResultAttr)
+	assert.Assert(t, ok)
+	assert.Equal(t, val.AsString(), "DENY")
+
+	val, ok = findSpanAttr(spans, trace.AuthResponseCodeAttr)
+	assert.Assert(t, ok)
+	assert.Equal(t, val.AsString(), "INVALID_ARGUMENT")
 }
 
 func mockAnonymousAccessAuthConfig() *evaluators.AuthConfig {

--- a/pkg/service/auth_test.go
+++ b/pkg/service/auth_test.go
@@ -389,7 +389,9 @@ func setupTestTracer(t *testing.T) *tracetest.InMemoryExporter {
 	otel.SetTracerProvider(tp)
 	t.Cleanup(func() {
 		otel.SetTracerProvider(prev)
-		tp.Shutdown(context.Background())
+		if err := tp.Shutdown(context.Background()); err != nil {
+			t.Errorf("failed to shutdown TracerProvider: %v", err)
+		}
 	})
 	return exporter
 }
@@ -447,6 +449,10 @@ func TestCheckSpanAttributes_AllowedRequest(t *testing.T) {
 	assert.Assert(t, ok)
 	assert.Equal(t, val.AsString(), "anonymous")
 
+	val, ok = findSpanAttr(spans, trace.IdentityTypeAttr)
+	assert.Assert(t, ok)
+	assert.Equal(t, val.AsString(), "IDENTITY_NOOP")
+
 	_, ok = findSpanAttr(spans, trace.AuthDenialReasonAttr)
 	assert.Assert(t, !ok, "denial reason should not be set on allowed request")
 }
@@ -495,6 +501,10 @@ func TestCheckSpanAttributes_DeniedRequest(t *testing.T) {
 	val, ok = findSpanAttr(spans, trace.AuthConfigNameAttr)
 	assert.Assert(t, ok)
 	assert.Equal(t, val.AsString(), "protected-api")
+
+	val, ok = findSpanAttr(spans, trace.AuthConfigNamespaceAttr)
+	assert.Assert(t, ok)
+	assert.Equal(t, val.AsString(), "prod")
 }
 
 func TestCheckSpanAttributes_ServiceNotFound(t *testing.T) {
@@ -521,6 +531,10 @@ func TestCheckSpanAttributes_ServiceNotFound(t *testing.T) {
 	assert.Assert(t, ok)
 	assert.Equal(t, val.AsString(), "DENY")
 
+	val, ok = findSpanAttr(spans, trace.AuthResponseCodeAttr)
+	assert.Assert(t, ok)
+	assert.Equal(t, val.AsString(), "NOT_FOUND")
+
 	val, ok = findSpanAttr(spans, trace.AuthDenialReasonAttr)
 	assert.Assert(t, ok)
 	assert.Equal(t, val.AsString(), "Service not found")
@@ -545,6 +559,10 @@ func TestCheckSpanAttributes_InvalidRequest(t *testing.T) {
 	val, ok = findSpanAttr(spans, trace.AuthResponseCodeAttr)
 	assert.Assert(t, ok)
 	assert.Equal(t, val.AsString(), "INVALID_ARGUMENT")
+
+	val, ok = findSpanAttr(spans, trace.AuthDenialReasonAttr)
+	assert.Assert(t, ok)
+	assert.Equal(t, val.AsString(), "Invalid request")
 }
 
 func mockAnonymousAccessAuthConfig() *evaluators.AuthConfig {

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -11,6 +11,14 @@ import (
 const (
 	AuthorinoRequestIdAttr   = "authorino.request_id"
 	PropagationRequestIdAttr = "guid:x-request-id"
+
+	AuthResultAttr          = "authorino.auth.result"
+	AuthResponseCodeAttr    = "authorino.auth.response_code"
+	AuthDenialReasonAttr    = "authorino.auth.denial_reason"
+	AuthConfigNameAttr      = "authorino.auth_config.name"
+	AuthConfigNamespaceAttr = "authorino.auth_config.namespace"
+	IdentitySourceAttr      = "authorino.identity.source"
+	IdentityTypeAttr        = "authorino.identity.type"
 )
 
 func NewSpan(parentContext context.Context, tracerName, spanName string, options ...otel_trace.SpanStartOption) (context.Context, otel_trace.Span) {


### PR DESCRIPTION
## Summary

Enrich the existing `Check` span with domain-specific auth decision attributes so traces carry actionable metadata for debugging auth flows in production.

**Before:** Check span only had `authorino.request_id` and `guid:x-request-id`.
**After:** Check span includes auth result, denial reason, AuthConfig name/namespace, and resolved identity source/type.

### New span attributes

| Attribute | Type | When set |
|-----------|------|----------|
| `authorino.auth.result` | `ALLOW` / `DENY` | Always |
| `authorino.auth.response_code` | gRPC code name | Always |
| `authorino.auth.denial_reason` | Denial message | On deny only |
| `authorino.auth_config.name` | AuthConfig CR name | When AuthConfig found |
| `authorino.auth_config.namespace` | AuthConfig CR namespace | When AuthConfig found |
| `authorino.identity.source` | Identity evaluator name | When identity resolved |
| `authorino.identity.type` | Identity evaluator type | When identity resolved |

Uses the `authorino.*` namespace, consistent with existing `authorino.request_id`. OTel has no general-purpose auth semantic conventions (only framework-specific `aspnetcore.*`), so a custom namespace avoids future collisions.

Attributes are set at every exit path in `Check()` (invalid request, service not found, context timeout, pipeline result) so spans always carry the decision.

## Changes

- `pkg/trace/trace.go`: Add 7 attribute name constants
- `pkg/service/auth.go`: Set span attributes at each return path in `Check()`; add `setAuthResultSpanAttrs` helper
- `pkg/service/auth_test.go`: 4 new tests verifying span attributes for allowed, denied, not-found, and invalid request scenarios

## Related

- Closes #669
- Follows precedent set by #574 (control-plane tracing)
- Part of RHOAI Observability Standards work (downstream)

## Test plan

- [x] All 4 new span attribute tests pass (`TestCheckSpanAttributes_*`)
- [x] All 43 existing service tests pass unchanged
- [x] `go build ./pkg/service/` compiles cleanly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Authentication and authorisation tracing now records whether requests were allowed or denied.
  - Trace data includes response codes, denial reasons, authentication configuration details, and resolved identity source and type.
  - Invalid requests, missing configuration, context errors, and evaluated results now provide consistent diagnostic attributes for improved observability.
  - Authentication outcomes can be investigated more consistently across successful, denied, invalid, and unavailable-service requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->