### PR TITLE
docs: fixing privilege escalation bug

### DIFF
--- a/docs/user-guides.md
+++ b/docs/user-guides.md
@@ -86,3 +86,6 @@ Cache auth objects resolved at runtime for any configuration bit of an AuthConfi
 
 - **[Observability](./user-guides/observability.md)**<br/>
 Prometheus metrics exported by Authorino, readiness probe, logging, tracing, etc.
+
+- **[Preventing namespace to cluster privilege escalation (AuthConfigs)](./user-guides/preventing-privilege-escalation.md)**<br/>
+Restrict the `apiKey.allNamespaces` and `x509.allNamespaces` fields — which trigger cluster-wide secret lookups — to authorized subjects using a ValidatingAdmissionPolicy.

--- a/docs/user-guides/preventing-privilege-escalation.md
+++ b/docs/user-guides/preventing-privilege-escalation.md
@@ -3,7 +3,7 @@
 Two fields on `AuthConfig` resources reach beyond the namespace they live in: `spec.authentication.*.apiKey.allNamespaces` and `spec.authentication.*.x509.allNamespaces`. When either is set to `true`, cluster-wide Authorino instances will look up the API-key / trusted-certificate `Secret`s across **every** namespace in the cluster, so anyone allowed to create `AuthConfig`s in a single namespace can use Authorino's elevated privileges to quietly reach secrets at cluster scope.
 This issue does not affect namespaced Authorino instances, but it can be a problem in multi-tenant, shared Authorino instances (aka: cluster-wide deployments).
 
-The [ValidatingAdmissionPolicy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) below closes that gap. It blocks those fields unless the user has been given a special permission for them, and you hand that permission only to the subjects that need it to do their job.
+The [ValidatingAdmissionPolicy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) below closes that gap. It blocks *enabling* those fields unless the user has been given a special permission for them, and you hand that permission only to the subjects that need it to do their job.
 
 The policy:
 
@@ -117,12 +117,20 @@ spec:
       expression: "has(object.spec.authentication) && object.spec.authentication.exists(k, has(object.spec.authentication[k].apiKey) && has(object.spec.authentication[k].apiKey.allNamespaces) && object.spec.authentication[k].apiKey.allNamespaces)"
     - name: wantsX509AllNamespaces
       expression: "has(object.spec.authentication) && object.spec.authentication.exists(k, has(object.spec.authentication[k].x509) && has(object.spec.authentication[k].x509.allNamespaces) && object.spec.authentication[k].x509.allNamespaces)"
+    # hadApiKeyAllNamespaces / hadX509AllNamespaces capture whether the field was already
+    # enabled before this request (oldObject is null on CREATE). They let the policy
+    # restrict only newly enabling allNamespaces, so a subject without the permission can
+    # still edit unrelated fields of an object that already has it enabled.
+    - name: hadApiKeyAllNamespaces
+      expression: "oldObject != null && has(oldObject.spec.authentication) && oldObject.spec.authentication.exists(k, has(oldObject.spec.authentication[k].apiKey) && has(oldObject.spec.authentication[k].apiKey.allNamespaces) && oldObject.spec.authentication[k].apiKey.allNamespaces)"
+    - name: hadX509AllNamespaces
+      expression: "oldObject != null && has(oldObject.spec.authentication) && oldObject.spec.authentication.exists(k, has(oldObject.spec.authentication[k].x509) && has(oldObject.spec.authentication[k].x509.allNamespaces) && oldObject.spec.authentication[k].x509.allNamespaces)"
   validations:
-    - expression: "!variables.wantsApiKeyAllNamespaces || variables.isExemptApiKey"
-      message: "apiKey allNamespaces: true (cluster-wide secret lookup) can only be set by a subject granted the 'set-apikey-all-namespaces' permission on authconfigs"
+    - expression: "!variables.wantsApiKeyAllNamespaces || variables.hadApiKeyAllNamespaces || variables.isExemptApiKey"
+      message: "apiKey allNamespaces: true (cluster-wide secret lookup) can only be enabled by a subject granted the 'set-apikey-all-namespaces' permission on authconfigs"
       reason: Forbidden
-    - expression: "!variables.wantsX509AllNamespaces || variables.isExemptX509"
-      message: "x509 allNamespaces: true (cluster-wide secret lookup) can only be set by a subject granted the 'set-x509-all-namespaces' permission on authconfigs"
+    - expression: "!variables.wantsX509AllNamespaces || variables.hadX509AllNamespaces || variables.isExemptX509"
+      message: "x509 allNamespaces: true (cluster-wide secret lookup) can only be enabled by a subject granted the 'set-x509-all-namespaces' permission on authconfigs"
       reason: Forbidden
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -136,7 +144,7 @@ EOF
 ```
 
 > [!WARNING]
-> Enforcement is strict, there is no grandfathering. On **every** create and update, any resource that enables a restricted field (`apiKey.allNamespaces: true` or `x509.allNamespaces: true`) is **rejected** unless the requesting subject holds the matching permission. This includes updates to resources that already exist: once the policy is active, a subject without the permission cannot update such a resource, or even change unrelated fields, until it either **drops the restricted field** (removes it or sets the boolean to `false`) or is **granted the corresponding ClusterRole** (steps 1–2). To avoid breaking existing workloads, grant the required Roles and RoleBindings **before** applying the policy.
+> The policy restricts **newly enabling** a restricted field, not merely having it enabled. On **create**, any resource that sets a restricted field (`apiKey.allNamespaces: true` or `x509.allNamespaces: true`) is **rejected** unless the requesting subject holds the matching permission. On **update**, only the transition from unset/`false` to `true` is blocked: a subject without the permission can still edit **unrelated** fields of — and can **disable** the field on — a resource that already has it enabled. Resources that already enable a restricted field when the policy is applied are therefore **not** retroactively broken. Newly enabling the field always requires the permission, so grant the required Roles and RoleBindings (steps 1–2) to the subjects that need it.
 
 ## 4. Verifying the VAP
 
@@ -192,7 +200,7 @@ EOF
 You should get an error like this instead of the resource being created:
 
 ```text
-... is forbidden: ValidatingAdmissionPolicy 'authconfig-restrict-all-namespaces' ... denied request: apiKey allNamespaces: true (cluster-wide secret lookup) can only be set by a subject granted the 'set-apikey-all-namespaces' permission on authconfigs
+... is forbidden: ValidatingAdmissionPolicy 'authconfig-restrict-all-namespaces' ... denied request: apiKey allNamespaces: true (cluster-wide secret lookup) can only be enabled by a subject granted the 'set-apikey-all-namespaces' permission on authconfigs
 ```
 
 ### A permitted subject is allowed
@@ -268,7 +276,7 @@ EOF
 
 ### Updates are re-checked, not just creates
 
-Because the policy matches `UPDATE` as well as `CREATE`, it re-evaluates on every change. A subject without the permission can still edit **unrelated** fields of a compliant resource, but is blocked the moment it tries to switch a restricted field on. Using the namespaced AuthConfig created above:
+Because the policy matches `UPDATE` as well as `CREATE`, it re-evaluates on every change — but it only restricts *newly enabling* a restricted field. A subject without the permission can edit **unrelated** fields of a resource whether or not the field is already enabled, and can **disable** it; it is blocked only when it tries to switch the field from off to on. Using the namespaced AuthConfig created above:
 
 ```sh
 # Change an unrelated field (the apiKey selector) on the namespaced AuthConfig — should be ALLOWED
@@ -309,6 +317,29 @@ spec:
         selector:
           matchLabels:
             group: family
+EOF
+```
+
+An object that **already** has a restricted field enabled can likewise be updated by a subject without the permission, as long as the field stays enabled. Using `policy-all-namespaces-2` (created by the authorized subject above, with `apiKey.allNamespaces: true`):
+
+```sh
+# Edit an unrelated field (the host) while leaving apiKey allNamespaces: true unchanged — should be ALLOWED
+kubectl apply --as=<unauthorized-subject> -f - <<'EOF'
+apiVersion: authorino.kuadrant.io/v1beta3
+kind: AuthConfig
+metadata:
+  name: policy-all-namespaces-2
+  namespace: <namespace>
+spec:
+  hosts:
+    - test-allowed-updated.example.com
+  authentication:
+    api-key-users:
+      apiKey:
+        allNamespaces: true
+        selector:
+          matchLabels:
+            group: friends
 EOF
 ```
 

--- a/docs/user-guides/preventing-privilege-escalation.md
+++ b/docs/user-guides/preventing-privilege-escalation.md
@@ -1,0 +1,359 @@
+# User guide: Preventing namespace-to-cluster privilege escalation (AuthConfigs)
+
+Two fields on `AuthConfig` resources reach beyond the namespace they live in: `spec.authentication.*.apiKey.allNamespaces` and `spec.authentication.*.x509.allNamespaces`. When either is set to `true`, cluster-wide Authorino instances will look up the API-key / trusted-certificate `Secret`s across **every** namespace in the cluster, so anyone allowed to create `AuthConfig`s in a single namespace can use Authorino's elevated privileges to quietly reach secrets at cluster scope.
+This issue does not affect namespaced Authorino instances, but it can be a problem in multi-tenant, shared Authorino instances (aka: cluster-wide deployments).
+
+The [ValidatingAdmissionPolicy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) below closes that gap. It blocks those fields unless the user has been given a special permission for them, and you hand that permission only to the subjects that need it to do their job.
+
+The policy:
+
+<table>
+  <thead>
+    <tr>
+      <th>Policy</th>
+      <th>Resource</th>
+      <th>Denies</th>
+      <th>ClusterRole required to allow</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="2"><code>authconfig-restrict-all-namespaces</code></td>
+      <td rowspan="2"><code>authconfigs</code></td>
+      <td><code>spec.authentication.*.apiKey.allNamespaces: true</code></td>
+      <td><code>set-apikey-all-namespaces</code> on <code>authconfigs</code></td>
+    </tr>
+    <tr>
+      <td><code>spec.authentication.*.x509.allNamespaces: true</code></td>
+      <td><code>set-x509-all-namespaces</code> on <code>authconfigs</code></td>
+    </tr>
+  </tbody>
+</table>
+
+Follow the steps below: create the Roles that grant those permissions, bind the roles to specific SAs and Users, then apply the policy.
+
+## 1. Create the Roles
+
+```sh
+kubectl apply -f - <<'EOF'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-set-apikey-all-namespaces
+rules:
+  - apiGroups: ["authorino.kuadrant.io"]
+    resources: ["authconfigs"]
+    verbs: ["set-apikey-all-namespaces"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-set-x509-all-namespaces
+rules:
+  - apiGroups: ["authorino.kuadrant.io"]
+    resources: ["authconfigs"]
+    verbs: ["set-x509-all-namespaces"]
+EOF
+```
+
+## 2. Grant the access to the restricted fields
+
+Grant access to your own ServiceAccounts and Users. Use the RoleBindings below as a template. Replace the placeholders (`<sa-name>`, `<namespace-of-sa>`, `<authconfig-namespace>`) with the appropriate values.
+
+```sh
+kubectl apply -f - <<'EOF'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rb-set-apikey-all-namespaces
+  namespace: <authconfig-namespace>
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: authorino-set-apikey-all-namespaces
+subjects:
+  - kind: ServiceAccount
+    name: <sa-name>
+    namespace: <namespace-of-sa>
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rb-set-x509-all-namespaces
+  namespace: <authconfig-namespace>
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: authorino-set-x509-all-namespaces
+subjects:
+  - kind: ServiceAccount
+    name: <sa-name>
+    namespace: <namespace-of-sa>
+EOF
+```
+
+## 3. Create the ValidatingAdmissionPolicy (VAP)
+
+```sh
+kubectl apply -f - <<'EOF'
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: authconfig-restrict-all-namespaces
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["authorino.kuadrant.io"]
+        apiVersions: ["v1beta3"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["authconfigs"]
+  variables:
+    - name: isExemptApiKey
+      expression: "authorizer.requestResource.check('set-apikey-all-namespaces').allowed()"
+    - name: isExemptX509
+      expression: "authorizer.requestResource.check('set-x509-all-namespaces').allowed()"
+    - name: wantsApiKeyAllNamespaces
+      expression: "has(object.spec.authentication) && object.spec.authentication.exists(k, has(object.spec.authentication[k].apiKey) && has(object.spec.authentication[k].apiKey.allNamespaces) && object.spec.authentication[k].apiKey.allNamespaces)"
+    - name: wantsX509AllNamespaces
+      expression: "has(object.spec.authentication) && object.spec.authentication.exists(k, has(object.spec.authentication[k].x509) && has(object.spec.authentication[k].x509.allNamespaces) && object.spec.authentication[k].x509.allNamespaces)"
+  validations:
+    - expression: "!variables.wantsApiKeyAllNamespaces || variables.isExemptApiKey"
+      message: "apiKey allNamespaces: true (cluster-wide secret lookup) can only be set by a subject granted the 'set-apikey-all-namespaces' permission on authconfigs"
+      reason: Forbidden
+    - expression: "!variables.wantsX509AllNamespaces || variables.isExemptX509"
+      message: "x509 allNamespaces: true (cluster-wide secret lookup) can only be set by a subject granted the 'set-x509-all-namespaces' permission on authconfigs"
+      reason: Forbidden
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: authconfig-restrict-all-namespaces-binding
+spec:
+  policyName: authconfig-restrict-all-namespaces
+  validationActions: ["Deny"]
+EOF
+```
+
+> [!WARNING]
+> Enforcement is strict, there is no grandfathering. On **every** create and update, any resource that enables a restricted field (`apiKey.allNamespaces: true` or `x509.allNamespaces: true`) is **rejected** unless the requesting subject holds the matching permission. This includes updates to resources that already exist: once the policy is active, a subject without the permission cannot update such a resource, or even change unrelated fields, until it either **drops the restricted field** (removes it or sets the boolean to `false`) or is **granted the corresponding ClusterRole** (steps 1–2). To avoid breaking existing workloads, grant the required Roles and RoleBindings **before** applying the policy.
+
+## 4. Verifying the VAP
+
+### A normal user is blocked
+
+Try to create resources that break the rules. Run these as a regular user (one *without* the permissions) and both should be **rejected**:
+
+> [!NOTE]
+> Do not run these as a cluster administrator. Anything with wildcard access (`verbs: ["*"]`) — which cluster admins have — satisfies the `set-apikey-all-namespaces` / `set-x509-all-namespaces` checks and is treated as exempt, so the request would be **allowed** and a real cluster-wide secret lookup enabled. Use an ordinary user (or `--as=<unauthorized-subject>`) to see the policy block.
+
+```sh
+# AuthConfig with apiKey allNamespaces: true — should be DENIED
+kubectl apply --as=<unauthorized-subject> -f - <<'EOF'
+apiVersion: authorino.kuadrant.io/v1beta3
+kind: AuthConfig
+metadata:
+  name: policy-all-namespaces-1
+  namespace: <namespace>
+spec:
+  hosts:
+    - test-denied.example.com
+  authentication:
+    api-key-users:
+      apiKey:
+        allNamespaces: true
+        selector:
+          matchLabels:
+            group: friends
+EOF
+```
+
+```sh
+# AuthConfig with x509 allNamespaces: true — should be DENIED
+kubectl apply --as=<unauthorized-subject> -f - <<'EOF'
+apiVersion: authorino.kuadrant.io/v1beta3
+kind: AuthConfig
+metadata:
+  name: policy-x509-1
+  namespace: <namespace>
+spec:
+  hosts:
+    - test-x509-denied.example.com
+  authentication:
+    mtls-clients:
+      x509:
+        allNamespaces: true
+        selector:
+          matchLabels:
+            group: friends
+EOF
+```
+
+You should get an error like this instead of the resource being created:
+
+```text
+... is forbidden: ValidatingAdmissionPolicy 'authconfig-restrict-all-namespaces' ... denied request: apiKey allNamespaces: true (cluster-wide secret lookup) can only be set by a subject granted the 'set-apikey-all-namespaces' permission on authconfigs
+```
+
+### A permitted subject is allowed
+
+Now run the same requests as a subject that holds the matching permission (granted in steps 1–2). Both should be **admitted**. Replace `<authorized-subject>` with the subject you granted the permission to (for example, `system:serviceaccount:<namespace>:<sa>`):
+
+```sh
+# AuthConfig with apiKey allNamespaces: true, as a subject granted 'set-apikey-all-namespaces' — should be ALLOWED
+kubectl apply --as=<authorized-subject> -f - <<'EOF'
+apiVersion: authorino.kuadrant.io/v1beta3
+kind: AuthConfig
+metadata:
+  name: policy-all-namespaces-2
+  namespace: <namespace>
+spec:
+  hosts:
+    - test-allowed.example.com
+  authentication:
+    api-key-users:
+      apiKey:
+        allNamespaces: true
+        selector:
+          matchLabels:
+            group: friends
+EOF
+```
+
+```sh
+# AuthConfig with x509 allNamespaces: true, as a subject granted 'set-x509-all-namespaces' — should be ALLOWED
+kubectl apply --as=<authorized-subject> -f - <<'EOF'
+apiVersion: authorino.kuadrant.io/v1beta3
+kind: AuthConfig
+metadata:
+  name: policy-x509-2
+  namespace: <namespace>
+spec:
+  hosts:
+    - test-x509-allowed.example.com
+  authentication:
+    mtls-clients:
+      x509:
+        allNamespaces: true
+        selector:
+          matchLabels:
+            group: friends
+EOF
+```
+
+### Resources without the restricted fields are always allowed
+
+The policy only looks at the restricted fields. A resource that leaves them unset (or `false`) is admitted for **any** subject, whether or not it holds a permission:
+
+```sh
+# AuthConfig with apiKey allNamespaces: false — should be ALLOWED even for an unauthorized subject
+kubectl apply --as=<unauthorized-subject> -f - <<'EOF'
+apiVersion: authorino.kuadrant.io/v1beta3
+kind: AuthConfig
+metadata:
+  name: policy-namespaced-1
+  namespace: <namespace>
+spec:
+  hosts:
+    - test-namespaced.example.com
+  authentication:
+    api-key-users:
+      apiKey:
+        allNamespaces: false
+        selector:
+          matchLabels:
+            group: friends
+EOF
+```
+
+### Updates are re-checked, not just creates
+
+Because the policy matches `UPDATE` as well as `CREATE`, it re-evaluates on every change. A subject without the permission can still edit **unrelated** fields of a compliant resource, but is blocked the moment it tries to switch a restricted field on. Using the namespaced AuthConfig created above:
+
+```sh
+# Change an unrelated field (the apiKey selector) on the namespaced AuthConfig — should be ALLOWED
+kubectl apply --as=<unauthorized-subject> -f - <<'EOF'
+apiVersion: authorino.kuadrant.io/v1beta3
+kind: AuthConfig
+metadata:
+  name: policy-namespaced-1
+  namespace: <namespace>
+spec:
+  hosts:
+    - test-namespaced.example.com
+  authentication:
+    api-key-users:
+      apiKey:
+        allNamespaces: false
+        selector:
+          matchLabels:
+            group: family
+EOF
+```
+
+```sh
+# Flip the same AuthConfig to apiKey allNamespaces: true — should be DENIED
+kubectl apply --as=<unauthorized-subject> -f - <<'EOF'
+apiVersion: authorino.kuadrant.io/v1beta3
+kind: AuthConfig
+metadata:
+  name: policy-namespaced-1
+  namespace: <namespace>
+spec:
+  hosts:
+    - test-namespaced.example.com
+  authentication:
+    api-key-users:
+      apiKey:
+        allNamespaces: true
+        selector:
+          matchLabels:
+            group: family
+EOF
+```
+
+### Permissions bound with a RoleBinding are namespace-scoped
+
+The exemption check runs against the namespace of the resource being admitted. If you grant the permission with a `RoleBinding` (rather than a `ClusterRoleBinding`), the subject is exempt only in that namespace.
+
+```sh
+# Subject granted 'set-apikey-all-namespaces' via a RoleBinding in <namespace-a> — should be ALLOWED
+kubectl apply --as=<authorized-subject> -f - <<'EOF'
+apiVersion: authorino.kuadrant.io/v1beta3
+kind: AuthConfig
+metadata:
+  name: policy-all-namespaces-3
+  namespace: <namespace-a>
+spec:
+  hosts:
+    - test-rb-a.example.com
+  authentication:
+    api-key-users:
+      apiKey:
+        allNamespaces: true
+        selector:
+          matchLabels:
+            group: friends
+EOF
+```
+
+```sh
+# Same subject, same request, in <namespace-b> where it has no binding — should be DENIED
+kubectl apply --as=<authorized-subject> -f - <<'EOF'
+apiVersion: authorino.kuadrant.io/v1beta3
+kind: AuthConfig
+metadata:
+  name: policy-all-namespaces-3
+  namespace: <namespace-b>
+spec:
+  hosts:
+    - test-rb-b.example.com
+  authentication:
+    api-key-users:
+      apiKey:
+        allNamespaces: true
+        selector:
+          matchLabels:
+            group: friends
+EOF
+```

--- a/docs/user-guides/preventing-privilege-escalation.md
+++ b/docs/user-guides/preventing-privilege-escalation.md
@@ -3,7 +3,7 @@
 Two fields on `AuthConfig` resources reach beyond the namespace they live in: `spec.authentication.*.apiKey.allNamespaces` and `spec.authentication.*.x509.allNamespaces`. When either is set to `true`, cluster-wide Authorino instances will look up the API-key / trusted-certificate `Secret`s across **every** namespace in the cluster, so anyone allowed to create `AuthConfig`s in a single namespace can use Authorino's elevated privileges to quietly reach secrets at cluster scope.
 This issue does not affect namespaced Authorino instances, but it can be a problem in multi-tenant, shared Authorino instances (aka: cluster-wide deployments).
 
-The [ValidatingAdmissionPolicy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) below closes that gap. It blocks *enabling* those fields unless the user has been given a special permission for them, and you hand that permission only to the subjects that need it to do their job.
+The [ValidatingAdmissionPolicy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) below closes that gap. It blocks every create and update of an `AuthConfig` that has one of those fields enabled, unless the user has been given a special permission for it, and you hand that permission only to the subjects that need it to do their job.
 
 The policy:
 
@@ -117,20 +117,12 @@ spec:
       expression: "has(object.spec.authentication) && object.spec.authentication.exists(k, has(object.spec.authentication[k].apiKey) && has(object.spec.authentication[k].apiKey.allNamespaces) && object.spec.authentication[k].apiKey.allNamespaces)"
     - name: wantsX509AllNamespaces
       expression: "has(object.spec.authentication) && object.spec.authentication.exists(k, has(object.spec.authentication[k].x509) && has(object.spec.authentication[k].x509.allNamespaces) && object.spec.authentication[k].x509.allNamespaces)"
-    # hadApiKeyAllNamespaces / hadX509AllNamespaces capture whether the field was already
-    # enabled before this request (oldObject is null on CREATE). They let the policy
-    # restrict only newly enabling allNamespaces, so a subject without the permission can
-    # still edit unrelated fields of an object that already has it enabled.
-    - name: hadApiKeyAllNamespaces
-      expression: "oldObject != null && has(oldObject.spec.authentication) && oldObject.spec.authentication.exists(k, has(oldObject.spec.authentication[k].apiKey) && has(oldObject.spec.authentication[k].apiKey.allNamespaces) && oldObject.spec.authentication[k].apiKey.allNamespaces)"
-    - name: hadX509AllNamespaces
-      expression: "oldObject != null && has(oldObject.spec.authentication) && oldObject.spec.authentication.exists(k, has(oldObject.spec.authentication[k].x509) && has(oldObject.spec.authentication[k].x509.allNamespaces) && oldObject.spec.authentication[k].x509.allNamespaces)"
   validations:
-    - expression: "!variables.wantsApiKeyAllNamespaces || variables.hadApiKeyAllNamespaces || variables.isExemptApiKey"
-      message: "apiKey allNamespaces: true (cluster-wide secret lookup) can only be enabled by a subject granted the 'set-apikey-all-namespaces' permission on authconfigs"
+    - expression: "!variables.wantsApiKeyAllNamespaces || variables.isExemptApiKey"
+      message: "apiKey allNamespaces: true (cluster-wide secret lookup) requires the 'set-apikey-all-namespaces' permission on authconfigs; a subject without it can neither create nor modify an AuthConfig that has the field enabled"
       reason: Forbidden
-    - expression: "!variables.wantsX509AllNamespaces || variables.hadX509AllNamespaces || variables.isExemptX509"
-      message: "x509 allNamespaces: true (cluster-wide secret lookup) can only be enabled by a subject granted the 'set-x509-all-namespaces' permission on authconfigs"
+    - expression: "!variables.wantsX509AllNamespaces || variables.isExemptX509"
+      message: "x509 allNamespaces: true (cluster-wide secret lookup) requires the 'set-x509-all-namespaces' permission on authconfigs; a subject without it can neither create nor modify an AuthConfig that has the field enabled"
       reason: Forbidden
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -144,7 +136,23 @@ EOF
 ```
 
 > [!WARNING]
-> The policy restricts **newly enabling** a restricted field, not merely having it enabled. On **create**, any resource that sets a restricted field (`apiKey.allNamespaces: true` or `x509.allNamespaces: true`) is **rejected** unless the requesting subject holds the matching permission. On **update**, only the transition from unset/`false` to `true` is blocked: a subject without the permission can still edit **unrelated** fields of — and can **disable** the field on — a resource that already has it enabled. Resources that already enable a restricted field when the policy is applied are therefore **not** retroactively broken. Newly enabling the field always requires the permission, so grant the required Roles and RoleBindings (steps 1–2) to the subjects that need it.
+> The policy restricts **having** a restricted field enabled, not merely the act of enabling it. Any request — **create** or **update** — whose resulting resource sets `apiKey.allNamespaces: true` or `x509.allNamespaces: true` is **rejected** unless the requesting subject holds the matching permission. In practice this makes an `AuthConfig` that enables a restricted field **read-only** for every subject that lacks the permission: they cannot edit even unrelated fields such as `hosts` or `authorization`. They *can* still submit an update that **disables** the field, and resources that leave the restricted fields unset or `false` are unaffected. Grant the Roles and RoleBindings from steps 1–2 to every subject that has to write these resources, **including controllers and GitOps agents** that reconcile them.
+>
+> The policy deliberately does not grandfather resources that already enable a restricted field. Editing the *rest* of the spec is enough to abuse the cluster-wide lookup: the resolved identity of an `apiKey` authentication is the matched `Secret` itself, data included, and `spec.callbacks` and `spec.response` can read `auth.identity`. A subject able to edit an already cluster-wide `AuthConfig` could therefore attach a callback to a destination it controls and have every successful request forward the caller's `Secret`, from any namespace in the cluster, without ever touching `allNamespaces` or its `selector`.
+>
+> Existing resources are not deleted or rewritten when you apply the policy, and Authorino keeps enforcing them. Only subsequent writes to them are gated.
+
+Before rolling the policy out on a live cluster, list the resources that will become restricted, so you know which subjects need the permission from steps 1–2:
+
+```sh
+kubectl get authconfigs -A -o json | jq -r '
+  .items[]
+  | select(
+      [.spec.authentication[]? | (.apiKey.allNamespaces // false) or (.x509.allNamespaces // false)]
+      | any
+    )
+  | "\(.metadata.namespace)/\(.metadata.name)"'
+```
 
 ## 4. Verifying the VAP
 
@@ -200,7 +208,7 @@ EOF
 You should get an error like this instead of the resource being created:
 
 ```text
-... is forbidden: ValidatingAdmissionPolicy 'authconfig-restrict-all-namespaces' ... denied request: apiKey allNamespaces: true (cluster-wide secret lookup) can only be enabled by a subject granted the 'set-apikey-all-namespaces' permission on authconfigs
+... is forbidden: ValidatingAdmissionPolicy 'authconfig-restrict-all-namespaces' ... denied request: apiKey allNamespaces: true (cluster-wide secret lookup) requires the 'set-apikey-all-namespaces' permission on authconfigs; a subject without it can neither create nor modify an AuthConfig that has the field enabled
 ```
 
 ### A permitted subject is allowed
@@ -276,7 +284,7 @@ EOF
 
 ### Updates are re-checked, not just creates
 
-Because the policy matches `UPDATE` as well as `CREATE`, it re-evaluates on every change — but it only restricts *newly enabling* a restricted field. A subject without the permission can edit **unrelated** fields of a resource whether or not the field is already enabled, and can **disable** it; it is blocked only when it tries to switch the field from off to on. Using the namespaced AuthConfig created above:
+Because the policy matches `UPDATE` as well as `CREATE`, it re-evaluates on every change, against the resource as it would be **after** the update. A subject without the permission can freely edit a resource that leaves the restricted fields off, but cannot submit any update whose result has one of them on. Using the namespaced AuthConfig created above:
 
 ```sh
 # Change an unrelated field (the apiKey selector) on the namespaced AuthConfig — should be ALLOWED
@@ -320,10 +328,10 @@ spec:
 EOF
 ```
 
-An object that **already** has a restricted field enabled can likewise be updated by a subject without the permission, as long as the field stays enabled. Using `policy-all-namespaces-2` (created by the authorized subject above, with `apiKey.allNamespaces: true`):
+An object that **already** has a restricted field enabled is closed to subjects without the permission, even for edits that do not touch the field. Using `policy-all-namespaces-2` (created by the authorized subject above, with `apiKey.allNamespaces: true`):
 
 ```sh
-# Edit an unrelated field (the host) while leaving apiKey allNamespaces: true unchanged — should be ALLOWED
+# Edit an unrelated field (the host) while leaving apiKey allNamespaces: true unchanged — should be DENIED
 kubectl apply --as=<unauthorized-subject> -f - <<'EOF'
 apiVersion: authorino.kuadrant.io/v1beta3
 kind: AuthConfig
@@ -337,6 +345,29 @@ spec:
     api-key-users:
       apiKey:
         allNamespaces: true
+        selector:
+          matchLabels:
+            group: friends
+EOF
+```
+
+The one update such a subject can still make is one that turns the restricted field **off**, since the resulting resource no longer enables the cluster-wide lookup:
+
+```sh
+# Disable apiKey allNamespaces on the same resource — should be ALLOWED
+kubectl apply --as=<unauthorized-subject> -f - <<'EOF'
+apiVersion: authorino.kuadrant.io/v1beta3
+kind: AuthConfig
+metadata:
+  name: policy-all-namespaces-2
+  namespace: <namespace>
+spec:
+  hosts:
+    - test-allowed.example.com
+  authentication:
+    api-key-users:
+      apiKey:
+        allNamespaces: false
         selector:
           matchLabels:
             group: friends


### PR DESCRIPTION
### Summary

Adds a new user guide documenting how to prevent a namespace-to-cluster privilege escalation vector in Authorino `AuthConfig` resources.

Two fields — `spec.authentication.*.apiKey.allNamespaces` and `spec.authentication.*.x509.allNamespaces` trigger cluster-wide `Secret` lookups when set to `true`. This means any subject able to create an `AuthConfig` in a single namespace can reach API-key / trusted-certificate secrets across **every** namespace in the cluster. 

### Changes

- **`docs/user-guides/preventing-privilege-escalation.md`** (new) — Step-by-step guide covering:
  1. Creating `ClusterRole`s that expose custom verbs (`set-apikey-all-namespaces`, `set-x509-all-namespaces`) on `authconfigs`.
  2. Granting those permissions — starting with the Authorino instance's own ServiceAccount (so it isn't locked out), then to specific SAs/Users via `RoleBinding`s.
  3. Applying a `ValidatingAdmissionPolicy` + binding that rejects `allNamespaces: true` unless the requesting subject holds the matching permission (checked via `authorizer.requestResource.check(...)`).
  4. Verifying behavior: unauthorized subjects are blocked, permitted subjects are allowed, unrestricted resources always pass, updates are re-checked (not just creates), and `RoleBinding`-granted permissions stay namespace-scoped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide explaining how to prevent namespace-to-cluster privilege escalation in Authorino `AuthConfig` resources.
  * Documented how to restrict cluster-wide API key and certificate secret lookups using a ValidatingAdmissionPolicy.
  * Included setup instructions, permission configuration, and verification scenarios for allowed and denied access.
  * Clarified that the guidance applies to cluster-wide Authorino instances and includes checks for resource updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->